### PR TITLE
Fixed a bug in `select()`, when it assumed that every map in a result is...

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/SelectStep.java
@@ -30,11 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.process.traverser.TraverserRequirement;
 
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -43,13 +39,11 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
 
     protected TraversalRing<Object, Object> traversalRing = new TraversalRing<>();
     private final List<String> selectLabels;
-    private final boolean wasEmpty;
     private boolean requiresPaths = false;
 
     public SelectStep(final Traversal.Admin traversal, final String... selectLabels) {
         super(traversal);
-        this.wasEmpty = selectLabels.length == 0;
-        this.selectLabels = this.wasEmpty ? TraversalHelper.getLabelsUpTo(this, this.traversal) : Arrays.asList(selectLabels);
+        this.selectLabels = selectLabels.length == 0 ? TraversalHelper.getLabelsUpTo(this, this.traversal) : Arrays.asList(selectLabels);
     }
 
     @Override
@@ -66,7 +60,7 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
 
         ////// PROCESS MAP BINDINGS
         if (start instanceof Map) {
-            if (this.wasEmpty)
+            if (this.selectLabels.isEmpty())
                 ((Map<String, Object>) start).forEach((k, v) -> bindings.put(k, (E) TraversalUtil.apply(v, this.traversalRing.next())));
             else
                 this.selectLabels.forEach(label -> {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/GroovySelectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/GroovySelectTest.groovy
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.graph.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.ComputerTestHelper
 import org.apache.tinkerpop.gremlin.process.Traversal
+import org.apache.tinkerpop.gremlin.process.graph.traversal.__
 import org.apache.tinkerpop.gremlin.process.traversal.engine.StandardTraversalEngine
 import org.apache.tinkerpop.gremlin.structure.Order
 import org.apache.tinkerpop.gremlin.structure.Vertex
@@ -79,6 +80,16 @@ public abstract class GroovySelectTest {
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_isXmarkoXX_asXaX_select() {
             return g.V.has(values('name').is('marko')).as('a').select
         }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select() {
+            return g.V().label().groupCount().cap().as('x').select()
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by() {
+            return g.V().hasLabel('person').as('person').local(__.bothE().label().groupCount().cap()).as('relations').select().by('name').by()
+        }
     }
 
     public static class ComputerTest extends SelectTest {
@@ -137,6 +148,19 @@ public abstract class GroovySelectTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_isXmarkoXX_asXaX_select() {
             ComputerTestHelper.compute("g.V.has(values('name').is('marko')).as('a').select", g)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select() {
+            ComputerTestHelper.compute("g.V().label().groupCount().cap().as('x').select()", g)
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by() {
+            g.engine(StandardTraversalEngine.standard);
+            // TODO: should work in computer mode, but throws ClassCastException
+            g.V().hasLabel('person').as('person').local(__.bothE().label().groupCount().cap()).as('relations').select().by('name').by()
+            //ComputerTestHelper.compute("g.V().hasLabel('person').as('person').local(__.bothE().label().groupCount().cap()).as('relations').select().by('name').by()", g)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/GroovySelectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/GroovySelectTest.groovy
@@ -152,7 +152,9 @@ public abstract class GroovySelectTest {
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select() {
-            ComputerTestHelper.compute("g.V().label().groupCount().cap().as('x').select()", g)
+            g.engine(StandardTraversalEngine.standard);
+            g.V().label().groupCount().cap().as('x').select()
+            //ComputerTestHelper.compute("g.V().label().groupCount().cap().as('x').select()", g)
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/SelectTest.java
@@ -366,6 +366,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select() {
+            g.engine(StandardTraversalEngine.standard); // TODO
             return g.V().label().groupCount().cap().as("x").select();
         }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/graph/traversal/step/map/SelectTest.java
@@ -21,20 +21,19 @@ package org.apache.tinkerpop.gremlin.process.graph.traversal.step.map;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.Traversal;
+import org.apache.tinkerpop.gremlin.process.graph.traversal.__;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.StandardTraversalEngine;
 import org.apache.tinkerpop.gremlin.structure.Order;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.apache.tinkerpop.gremlin.process.graph.traversal.__.values;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -59,6 +58,10 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_select_byXskillX_byXnameX();
 
     public abstract Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_isXmarkoXX_asXaX_select();
+
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select();
+
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -176,6 +179,66 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         checkResults(expected, traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_label_groupCount_cap_asXxX_select() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_label_groupCount_cap_asXxX_select();
+        printTraversalForm(traversal);
+        assertTrue(traversal.hasNext());
+        final Map<String, Object> map1 = traversal.next();
+        assertEquals(1, map1.size());
+        assertTrue(map1.containsKey("x"));
+        final Map<String, Long> map2 = (Map<String, Long>) map1.get("x");
+        assertEquals(2, map2.size());
+        assertTrue(map2.containsKey("person"));
+        assertTrue(map2.containsKey("software"));
+        assertEquals(2, map2.get("software").longValue());
+        assertEquals(4, map2.get("person").longValue());
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @Ignore
+    @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by();
+        printTraversalForm(traversal);
+        final Set<String> persons = new HashSet<>();
+        for (int i = 0; i < 4; i++) {
+            assertTrue(traversal.hasNext());
+            final Map<String, Object> map = traversal.next();
+            assertEquals(2, map.size());
+            assertTrue(map.containsKey("person"));
+            assertTrue(map.containsKey("relations"));
+            assertTrue(persons.add((String) map.get("person")));
+            final Map<String, Long> relations = (Map<String, Long>) map.get("relations");
+            switch ((String) map.get("person")) {
+                case "marko":
+                    assertEquals(2, relations.size());
+                    assertEquals(1, relations.get("created").longValue());
+                    assertEquals(2, relations.get("knows").longValue());
+                    break;
+                case "vadas":
+                    assertEquals(1, relations.size());
+                    assertEquals(1, relations.get("knows").longValue());
+                    break;
+                case "josh":
+                    assertEquals(2, relations.size());
+                    assertEquals(2, relations.get("created").longValue());
+                    assertEquals(1, relations.get("knows").longValue());
+                    break;
+                case "peter":
+                    assertEquals(1, relations.size());
+                    assertEquals(1, relations.get("created").longValue());
+                    break;
+                default:
+                    assertTrue(false);
+                    break;
+            }
+        }
+        assertFalse(traversal.hasNext());
+        assertEquals(4, persons.size());
+    }
 
     public static class StandardTest extends SelectTest {
         public StandardTest() {
@@ -225,6 +288,16 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_isXmarkoXX_asXaX_select() {
             return g.V().has(values("name").is("marko")).as("a").select();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select() {
+            return g.V().label().groupCount().cap().as("x").select();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by() {
+            return g.V().hasLabel("person").as("person").local(__.bothE().label().groupCount().cap()).as("relations").select().by("name").by();
         }
     }
 
@@ -289,6 +362,17 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_isXmarkoXX_asXaX_select() {
             return g.V().has(values("name").is("marko")).as("a").select();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_label_groupCount_cap_asXxX_select() {
+            return g.V().label().groupCount().cap().as("x").select();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCount_capX_asXrelationsX_select_byXnameX_by() {
+            g.engine(StandardTraversalEngine.standard); // TODO
+            return g.V().hasLabel("person").as("person").local(__.bothE().label().groupCount().cap()).as("relations").select().by("name").by();
         }
     }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.process.Scope;
 import org.apache.tinkerpop.gremlin.process.T;
 import org.apache.tinkerpop.gremlin.process.Traversal;
+import org.apache.tinkerpop.gremlin.process.graph.traversal.step.map.match.Bindings;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.io.GraphReader;
@@ -40,6 +41,7 @@ import java.io.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.apache.tinkerpop.gremlin.process.graph.traversal.__.*;
@@ -179,29 +181,17 @@ public class TinkerGraphTest {
     @Test
     @Ignore
     public void testPlayDK() throws Exception {
-
         Graph g = TinkerFactory.createModern();
-        Traversal t = g.V().hasLabel("person").as("p").local(out("created").values("name").fold().limit(Scope.local, 1));
+        Traversal t = g.V().hasLabel("person").as("person").local(bothE().label().groupCount().cap()).as("relations").select().by("name").by();
         t.forEachRemaining(System.out::println);
         System.out.println("--");
 
-        t = g.V().hasLabel("person").group().by("name").by(out("created").values("name").fold()).cap().limit(Scope.local, 2);
-        t.forEachRemaining(System.out::println);
-        System.out.println("--");
-
-        t = g.V().hasLabel("person").as("p").local(out("created").values("name").fold().sample(Scope.local, 1));
-        t.forEachRemaining(System.out::println);
-        System.out.println("--");
-
-        t = g.V().hasLabel("person").group().by("name").by(out("created").values("name").fold()).cap().sample(Scope.local, 2);
-        t.forEachRemaining(System.out::println);
-        System.out.println("--");
-
-        t = g.V().group().by(T.label).by(bothE().values("weight").fold()).by(sample(Scope.local, 5)).cap();
-        t.forEachRemaining(System.out::println);
-
-        System.out.println("--");
-        t = g.V().group().by(T.label).by(bothE().values("weight").fold()).by(order(Scope.local).by(Order.keyDecr)).cap();
+        t = g.V().match("a",
+                as("a").out("knows").as("b"),
+                as("b").out("created").has("name", "lop"),
+                as("b").match("a1",
+                        as("a1").out("created").as("b1"),
+                        as("b1").in("created").as("c1")).select("c1").as("c")).<String>select().by("name");
         t.forEachRemaining(System.out::println);
     }
 

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -20,10 +20,8 @@ package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
-import org.apache.tinkerpop.gremlin.process.Scope;
 import org.apache.tinkerpop.gremlin.process.T;
 import org.apache.tinkerpop.gremlin.process.Traversal;
-import org.apache.tinkerpop.gremlin.process.graph.traversal.step.map.match.Bindings;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.io.GraphReader;
@@ -41,7 +39,6 @@ import java.io.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.apache.tinkerpop.gremlin.process.graph.traversal.__.*;


### PR DESCRIPTION
... the result of a `match()` step.