### PR TITLE
shade plugin prototype config for Kryo

### DIFF
--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -43,7 +43,23 @@ limitations under the License.
         <dependency>
             <groupId>com.esotericsoftware.kryo</groupId>
             <artifactId>kryo</artifactId>
+            <!-- Update the shade plugin config whenever you change this version -->
             <version>2.24.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware.minlog</groupId>
+            <artifactId>minlog</artifactId>
+            <!-- Update the shade plugin config whenever you change this version -->
+            <version>1.2</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <!-- Update the shade plugin config whenever you change this version -->
+            <version>2.1</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.carrotsearch</groupId>
@@ -105,6 +121,52 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <id>shade-kryo</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.esotericsoftware.kryo:*</include>
+                                    <include>com.esotericsoftware.minlog:*</include>
+                                    <include>com.esotericsoftware.reflectasm:*</include>
+                                    <include>org.objenesis:*</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.esotericsoftware.reflectasm</pattern>
+                                    <shadedPattern>org.apache.tinkerpop.shaded.kryo_2_24_0_reflectasm</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.esotericsoftware.kryo</pattern>
+                                    <shadedPattern>org.apache.tinkerpop.shaded.kryo_2_24_0</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.objenesis</pattern>
+                                    <shadedPattern>org.apache.tinkerpop.shaded.objenesis_2_1</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.esotericsoftware.minlog</pattern>
+                                    <shadedPattern>org.apache.tinkerpop.shaded.minlog_1_2</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <!-- false below means the shade plugin overwrites the main project artifact (the one with no classifier).
+                                 false does *not* actually detach the main artifact, despite what the option name suggests. -->
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <minimizeJar>false</minimizeJar>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GryoMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GryoMessageSerializerV1d0.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.driver.ser;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.Kryo;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.Serializer;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Input;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Output;
 import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/JsonBuilderGryoSerializer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/JsonBuilderGryoSerializer.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.driver.ser;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.Kryo;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.Serializer;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Input;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Output;
 import groovy.json.JsonBuilder;
 import groovy.json.JsonSlurper;
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.structure;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.Kryo;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Input;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Output;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritable.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritable.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.hadoop.structure.io;
 
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Input;
+import org.apache.tinkerpop.shaded.kryo_2_24_0.io.Output;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.tinkerpop.gremlin.hadoop.process.computer.giraph.GiraphWorkerContext;


### PR DESCRIPTION
This commit modifies gremlin-core to shade Kryo 2.24.0 and its
dependencies under the package prefix org.apache.tinkerpop.shaded.
The shaded Kryo & dep classfiles are packed into the gremlin-core jar.
The shaded gremlin-core jar becomes the main project artifact
(i.e. there is no separate gremlin-core-$VERSION-shaded.jar).

Here's a sample of classfiles from the gremlin-core jar:

...
org/apache/tinkerpop/gremlin/structure/Graph$Helper.class
org/apache/tinkerpop/gremlin/structure/Graph.class
...
org/apache/tinkerpop/shaded/kryo_2_24_0/ClassResolver.class
org/apache/tinkerpop/shaded/kryo_2_24_0/DefaultSerializer.class
...
org/apache/tinkerpop/shaded/objenesis_2_1/Objenesis.class
org/apache/tinkerpop/shaded/objenesis_2_1/ObjenesisBase.class
...
org/apache/tinkerpop/shaded/minlog_1_2/Log$Logger.class
org/apache/tinkerpop/shaded/minlog_1_2/Log.class
...
org/apache/tinkerpop/shaded/kryo_2_24_0_reflectasm/AccessClassLoader.class
org/apache/tinkerpop/shaded/kryo_2_24_0_reflectasm/ConstructorAccess.class
...

I disassembled a couple of Kryo classfiles with `javap -verbose` to
check that the intended references were rewritten, and it seems to be
OK, though I only spent a few minutes in there.

Other modules (gremlin-{driver,test}, hadoop-gremlin) depend on Kryo
2.24.0 types shaded by this commit.  This commit modifies the imports
in those modules' sources to use the shaded package names,
e.g. `import org.apache.tinkerpop.shaded.kryo_2_24_0.Kryo;`.  The
project builds with Maven and the tests run by mvn clean install
-DfeelingLucky pass.  However, IDEA's builtin compiler can't figure
out what's going on.  IDEA's compiler chokes whenever it encounters a
reference to one of the types normally created by the shade plugin.

One way to make IDEA happy would be to hide all direct references to
Kryo types behind a TP interface that lives in -core and which is
implemented in -core.  Modules which currently import Kryo directly
would instead import the interface from -core.  This should make the
effects of shading invisible at the source level and placate IDEA.

One last comment about gremlin-core/pom.xml's new
`<optional>true</optional>` lines.  These are kind of a hack.  The
idea is to let gremlin-core continue depending on Kryo and its
dependencies so that it can compile and shade the classfiles, but to
prevent artifacts that depend on gremlin-core from pulling down the
unshaded Kryo artifact, which would defeat the point.  Optional=true
does this, but it's not really the intended function.  The alternative
is to use the "dependency reduced" POM generation feature of the
maven-shade-plugin, but that has always kind of creeped me out.  It's
worth investigating if you don't like the optional=true hack though.