### PR TITLE
Use FastNoSuchElementException on TraverserSet.remove()

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/TraverserSet.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/TraverserSet.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.traverser.util;
 
+import org.apache.tinkerpop.gremlin.process.traversal.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 
 import java.io.Serializable;
@@ -95,7 +96,13 @@ public class TraverserSet<S> extends AbstractSet<Traverser.Admin<S>> implements 
 
     @Override
     public Traverser.Admin<S> remove() {  // pop, exception if empty
-        return this.map.remove(this.map.values().iterator().next());
+        final Iterator<Traverser.Admin<S>> iterator = this.map.values().iterator();
+        if (!iterator.hasNext()) {
+            throw FastNoSuchElementException.instance();
+        }
+        Traverser.Admin<S> next = iterator.next();
+        iterator.remove();
+        return next;
     }
 
     @Override


### PR DESCRIPTION
A JMH microbenchmark on a TP3 traversal that hit thousands of vertices showed the use of exceptions for flow control in `TraverserSet` as a hotspot.  Using `FastNoSuchElementException` dramatically improved the performance of the benchmark.

Thanks to @danielthomas for identifying the root issue and providing an initial patch.