### PR TITLE
Fixes TINKERPOP3-600: invoke{Function|Method} should be varargs

### DIFF
--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
@@ -334,12 +334,12 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl implements
     }
 
     @Override
-    public Object invokeFunction(final String name, final Object args[]) throws ScriptException, NoSuchMethodException {
+    public Object invokeFunction(final String name, final Object... args) throws ScriptException, NoSuchMethodException {
         return invokeImpl(null, name, args);
     }
 
     @Override
-    public Object invokeMethod(final Object thiz, final String name, final Object args[]) throws ScriptException, NoSuchMethodException {
+    public Object invokeMethod(final Object thiz, final String name, final Object... args) throws ScriptException, NoSuchMethodException {
         if (thiz == null) {
             throw new IllegalArgumentException("Script object can not be null");
         } else {


### PR DESCRIPTION
Fixes [TINKERPOP3-600](https://issues.apache.org/jira/browse/TINKERPOP3-600).
