### PR TITLE
TINKERPOP3-639 selectList

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
@@ -62,7 +62,7 @@ public interface Path extends Cloneable {
      *
      * @param label the label of the path
      * @param <A>   the type of the object associated with the label
-     * @return the object associated with the label of the path
+     * @return the object (<A>) or list of objects (List<A>) associated with the label of the path
      * @throws IllegalArgumentException if the path does not contain the label
      */
     public default <A> A get(final String label) throws IllegalArgumentException {
@@ -86,6 +86,47 @@ public interface Path extends Cloneable {
         if (null == object)
             throw Path.Exceptions.stepWithProvidedLabelDoesNotExist(label);
         return (A) object;
+    }
+
+    /**
+     * Get the object most recently associated with the particular label of the path.
+     *
+     * @param label the label of the path
+     * @param <A>   the type of the object associated with the label
+     * @return the object associated with the label of the path
+     * @throws IllegalArgumentException if the path does not contain the label
+     */
+    public default <A> A getLast(final String label) throws IllegalArgumentException {
+        final List<Object> objects = this.objects();
+        final List<Set<String>> labels = this.labels();
+        for (int i = 0; i < labels.size(); i++) {
+            int index = labels.size() - i - 1;
+            if (labels.get(index).contains(label))
+                return (A) objects.get(index);
+        }
+        throw Path.Exceptions.stepWithProvidedLabelDoesNotExist(label);
+    }
+
+    /**
+     * Get the list of objects associated with the particular label of the path.
+     *
+     * @param label the label of the path
+     * @param <A>   the type of the object associated with the label
+     * @return the list of objects (List<A>) associated with the label of the path
+     * @throws IllegalArgumentException if the path does not contain the label
+     */
+    public default <A> List<A> getList(final String label) throws IllegalArgumentException {
+        final List<Object> objects = this.objects();
+        final List<Set<String>> labels = this.labels();
+        final List<A> list = new ArrayList();
+        for (int i = 0; i < labels.size(); i++) {
+            if (labels.get(i).contains(label)) {
+                list.add((A) objects.get(i));
+            }
+        }
+        if (list.isEmpty())
+            throw Path.Exceptions.stepWithProvidedLabelDoesNotExist(label);
+        return list;
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -90,6 +90,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertyValueStep
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.RangeLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SackStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SampleLocalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectListOneStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectListStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectOneStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumGlobalStep;
@@ -302,6 +304,14 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default <E2> GraphTraversal<S, E2> select(final String stepLabel) {
         return this.asAdmin().addStep(new SelectOneStep<S, E2>(this.asAdmin(), stepLabel));
+    }
+
+    public default <E2> GraphTraversal<S, Map<String, List<E2>>> selectList(final String... stepLabels) {
+        return this.asAdmin().addStep(new SelectListStep<S, E2>(this.asAdmin(), stepLabels));
+    }
+
+    public default <E2> GraphTraversal<S, List<E2>> selectList(final String stepLabel) {
+        return this.asAdmin().addStep(new SelectListOneStep<S, E2>(this.asAdmin(), stepLabel));
     }
 
     public default <E2> GraphTraversal<S, E2> unfold() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -297,11 +297,11 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     public default <E2> GraphTraversal<S, Map<String, E2>> select(final String... stepLabels) {
-        return this.asAdmin().addStep(new SelectStep<>(this.asAdmin(), stepLabels));
+        return this.asAdmin().addStep(new SelectStep<S, E2>(this.asAdmin(), stepLabels));
     }
 
     public default <E2> GraphTraversal<S, E2> select(final String stepLabel) {
-        return this.asAdmin().addStep(new SelectOneStep(this.asAdmin(), stepLabel));
+        return this.asAdmin().addStep(new SelectOneStep<S, E2>(this.asAdmin(), stepLabel));
     }
 
     public default <E2> GraphTraversal<S, E2> unfold() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectListOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectListOneStep.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.CollectingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class SelectListOneStep<S, E> extends MapStep<S, List<E>> implements TraversalParent {
+
+    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(
+            TraverserRequirement.PATH,
+            TraverserRequirement.PATH_ACCESS,
+            TraverserRequirement.OBJECT
+    );
+
+    private final String selectLabel;
+    private Traversal.Admin<Object, Object> selectTraversal = new IdentityTraversal<>();
+    private boolean requiresPaths = false;
+
+    public SelectListOneStep(final Traversal.Admin traversal, final String selectLabel) {
+        super(traversal);
+        this.selectLabel = selectLabel;
+    }
+
+    @Override
+    protected List<E> map(final Traverser.Admin<S> traverser) {
+        final S start = traverser.get();
+        return (List<E>) TraversalUtil.applyEach(traverser.path().getList(this.selectLabel), this.selectTraversal);
+    }
+
+    @Override
+    public String toString() {
+        return TraversalHelper.makeStepString(this, this.selectLabel, this.selectTraversal);
+    }
+
+    @Override
+    public SelectListOneStep<S, E> clone() {
+        final SelectListOneStep<S, E> clone = (SelectListOneStep<S, E>) super.clone();
+        clone.selectTraversal = this.selectTraversal.clone();
+        return clone;
+    }
+
+    @Override
+    public List<Traversal.Admin<Object, Object>> getLocalChildren() {
+        return Collections.singletonList(this.selectTraversal);
+    }
+
+    @Override
+    public void addLocalChild(final Traversal.Admin<?, ?> selectTraversal) {
+        this.selectTraversal = this.integrateChild(selectTraversal);
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return REQUIREMENTS;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectListStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectListStep.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.CollectingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.EngineDependent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class SelectListStep<S, E> extends MapStep<S, Map<String, List<E>>> implements TraversalParent {
+
+    private static final Set<TraverserRequirement> REQUIREMENTS = EnumSet.of(
+            TraverserRequirement.PATH,
+            TraverserRequirement.PATH_ACCESS,
+            TraverserRequirement.OBJECT
+    );
+
+    protected TraversalRing<Object, Object> traversalRing = new TraversalRing<>();
+    private final List<String> selectLabels;
+    private boolean requiresPaths = false;
+
+    public SelectListStep(final Traversal.Admin traversal, final String... selectLabels) {
+        super(traversal);
+        this.selectLabels = selectLabels.length == 0 ? TraversalHelper.getLabelsUpTo(this, this.traversal) : Arrays.asList(selectLabels);
+    }
+
+    @Override
+    protected Map<String, List<E>> map(final Traverser.Admin<S> traverser) {
+        final S start = traverser.get();
+        final Map<String, List<E>> bindings = new LinkedHashMap<>();
+
+        ////// PROCESS STEP BINDINGS
+        final Path path = traverser.path();
+        this.selectLabels.forEach(label -> {
+            if (path.hasLabel(label))
+                bindings.put(label, (List<E>) TraversalUtil.applyEach(path.getList(label), this.traversalRing.next()));
+            else {
+                // TODO: throw NoSuchElementException? TINKERPOP3-619
+            }
+        });
+
+        this.traversalRing.reset();
+        return bindings;
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.traversalRing.reset();
+    }
+
+    @Override
+    public String toString() {
+        return TraversalHelper.makeStepString(this, this.selectLabels, this.traversalRing);
+    }
+
+    @Override
+    public SelectListStep<S, E> clone() {
+        final SelectListStep<S, E> clone = (SelectListStep<S, E>) super.clone();
+        clone.traversalRing = new TraversalRing<>();
+        for (final Traversal.Admin<Object, Object> traversal : this.traversalRing.getTraversals()) {
+            clone.traversalRing.addTraversal(clone.integrateChild(traversal.clone()));
+        }
+        return clone;
+    }
+
+    @Override
+    public List<Traversal.Admin<Object, Object>> getLocalChildren() {
+        return this.traversalRing.getTraversals();
+    }
+
+    @Override
+    public void addLocalChild(final Traversal.Admin<?, ?> selectTraversal) {
+        this.traversalRing.addTraversal(this.integrateChild(selectTraversal));
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return REQUIREMENTS;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
@@ -54,7 +54,7 @@ public final class SelectOneStep<S, E> extends MapStep<S, E> implements Traversa
         if (start instanceof Map && ((Map) start).containsKey(this.selectLabel))
             return (E) TraversalUtil.apply(((Map) start).get(this.selectLabel), this.selectTraversal);
         else
-            return (E) TraversalUtil.apply(traverser.path().<Object>get(this.selectLabel), this.selectTraversal);
+            return (E) TraversalUtil.apply(traverser.path().<Object>getLast(this.selectLabel), this.selectTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -59,7 +59,7 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
         final Path path = traverser.path();
         this.selectLabels.forEach(label -> {
             if (path.hasLabel(label))
-                bindings.put(label, (E) TraversalUtil.apply(path.<Object>get(label), this.traversalRing.next()));
+                bindings.put(label, (E) TraversalUtil.apply(path.<Object>getLast(label), this.traversalRing.next()));
         });
 
         ////// PROCESS MAP BINDINGS

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/SparsePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/SparsePath.java
@@ -70,12 +70,23 @@ public class SparsePath implements Path, Serializable {
         return Collections.unmodifiableList(labels);
     }
 
-
+    @Override
     public <A> A get(final String label) throws IllegalArgumentException {
         final Object object = this.map.get(label);
         if (null == object)
             throw Path.Exceptions.stepWithProvidedLabelDoesNotExist(label);
         return (A) object;
+    }
+
+    @Override
+    public <A> A getLast(final String label) throws IllegalArgumentException {
+        // SparsePath is only capable of returning the last value at a step.
+        return get(label);
+    }
+
+    @Override
+    public <A> List<A> getList(final String label) throws IllegalArgumentException {
+        throw new IllegalArgumentException("SparsePath.getList is nonsensical");
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
@@ -21,7 +21,9 @@ package org.apache.tinkerpop.gremlin.process.traversal.util;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -67,6 +69,10 @@ public final class TraversalUtil {
         } catch (final NoSuchElementException e) {
             throw new IllegalArgumentException("The provided start does not map to a value: " + start + "->" + traversal);
         }
+    }
+
+    public static final <S, E> List<E> applyEach(final List<S> startList, final Traversal.Admin<S, E> traversal) {
+        return startList.stream().map(start -> apply(start, traversal)).collect(Collectors.toList());
     }
 
     public static final <S, E> E applyNullable(final S start, final Traversal.Admin<S, E> traversal) {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectListTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectListTest.groovy
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map
+
+import org.apache.tinkerpop.gremlin.process.computer.ComputerTestHelper
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine
+import org.apache.tinkerpop.gremlin.process.UseEngine
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
+import org.apache.tinkerpop.gremlin.structure.Edge
+import org.apache.tinkerpop.gremlin.structure.Order
+import org.apache.tinkerpop.gremlin.structure.Vertex
+import org.junit.Test
+
+import static __.values
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class GroovySelectListTest {
+
+    @UseEngine(TraversalEngine.Type.STANDARD)
+    public static class StandardTraversals extends SelectListTest {
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Vertex>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList(final Object v1Id) {
+            g.V(v1Id).as('a').out('knows').as('b').selectList()
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX(
+                final Object v1Id) {
+            g.V(v1Id).as('a').out('knows').as('b').selectList.by('name')
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX(final Object v1Id) {
+            g.V(v1Id).as('a').out('knows').as('b').selectList('a')
+        }
+
+        @Override
+        public Traversal<Vertex, List<String>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX(
+                final Object v1Id) {
+            g.V(v1Id).as('a').out('knows').as('b').selectList('a').by('name')
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_asXbX_selectList_byXnameX() {
+            g.V.as('a').out.as('b').selectList.by('name')
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_aggregateXxX_asXbX_selectList_byXnameX() {
+            g.V.as('a').out.aggregate('x').as('b').selectList.by('name')
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_name_order_asXbX_selectList_byXnameX_by_XitX() {
+            g.V().as('a').name.order().as('b').selectList.by('name').by
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX() {
+            g.V.has('name', 'gremlin').inE('uses').order.by('skill', Order.incr).as('a').outV.as('b').selectList.by('skill').by('name')
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_isXmarkoXX_asXaX_selectList() {
+            return g.V.has(values('name').is('marko')).as('a').selectList
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Map<String, Long>>>> get_g_V_label_groupCount_asXxX_selectList() {
+            return g.V().label().groupCount().as('x').selectList()
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by() {
+            return g.V().hasLabel('person').as('person').local(__.bothE().label().groupCount()).as('relations').selectList().by('name').by()
+        }
+
+        // WIP
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX() {
+            return g.V().as("a").out().as("a").out().as("a").selectList("a");
+        }
+
+        @Override
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX_byXnameX() {
+            return g.V().as("a").out().as("a").out().as("a").<String>selectList("a").by("name");
+        }
+
+        //
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX1X_asXhereX_out_selectListXhereX(final Object v1Id) {
+            g.V(v1Id).as('here').out.selectList('here')
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX(final Object v4Id) {
+            g.V(v4Id).out.as('here').has('lang', 'java').selectList('here')
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX_unfold_name(
+                final Object v4Id) {
+            g.V(v4Id).out.as('here').has('lang', 'java').selectList('here').unfold().name
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectListXhereX(final Object v1Id) {
+            g.V(v1Id).outE.as('here').inV.has('name', 'vadas').selectList('here')
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectListXhereX(
+                final Object v1Id) {
+            g.V(v1Id).outE('knows').has('weight', 1.0d).as('here').inV.has('name', 'josh').selectList('here')
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_inV_hasXname_joshX_selectListXhereX(
+                final Object v1Id) {
+            g.V(v1Id).outE('knows').as('here').has('weight', 1.0d).inV.has('name', 'josh').selectList('here')
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_asXfakeX_inV_hasXname_joshX_selectListXhereX(
+                final Object v1Id) {
+            g.V(v1Id).outE("knows").as('here').has('weight', 1.0d).as('fake').inV.has("name", 'josh').selectList('here')
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_asXhereXout_name_selectListXhereX() {
+            g.V().as("here").out.name.selectList("here");
+        }
+
+
+        @Override
+        public Traversal<Vertex, Map<List<String>, Long>> get_g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectListXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectListXprojectXX_groupCount_byXnameX() {
+            g.V.out('created')
+                    .union(__.as('project').in('created').has('name', 'marko').selectList('project'),
+                    __.as('project').in('created').in('knows').has('name', 'marko').selectList('project')).groupCount().by('name');
+        }
+    }
+
+    @UseEngine(TraversalEngine.Type.COMPUTER)
+    public static class ComputerTraversals extends SelectListTest {
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Vertex>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList(final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).as('a').out('knows').as('b').selectList()", g);
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        public void g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX() {
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX(final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).as('a').out('knows').as('b').selectList('a')", g);
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        public void g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX() {
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        public void g_V_asXaX_out_asXbX_selectList_byXnameX() {
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        public void g_V_asXaX_name_order_asXbX_selectList_byXnameX_byXitX() {
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        public void g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX() {
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_isXmarkoXX_asXaX_selectList() {
+            ComputerTestHelper.compute("g.V.has(values('name').is('marko')).as('a').selectList", g)
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        public void g_V_label_groupCount_asXxX_selectList() {
+        }
+
+        @Override
+        @Test
+        @org.junit.Ignore("Traversal not supported by ComputerTraversalEngine.computer")
+        void g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by() {
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<String>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX(Object v1Id) {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, List<String>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX(Object v1Id) {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_asXbX_selectList_byXnameX() {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_aggregateXxX_asXbX_selectList_byXnameX() {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_name_order_asXbX_selectList_byXnameX_by_XitX() {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX() {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<Map<String, Long>>>> get_g_V_label_groupCount_asXxX_selectList() {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        @Override
+        Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by() {
+            // override with nothing until the test itself is supported
+            return null
+        }
+
+        // WIP
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX() {
+            ComputerTestHelper.compute("g.V().as('a').out().as('a').out().as('a').selectList('a')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX_byXnameX() {
+            ComputerTestHelper.compute("g.V().as('a').out().as('a').out().as('a').selectList('a').by('name')", g);
+        }
+
+        //
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX1X_asXhereX_out_selectListXhereX(final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).as('here').out.selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX(final Object v4Id) {
+            ComputerTestHelper.compute("g.V(${v4Id}).out.as('here').has('lang', 'java').selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX_unfold_name(
+                final Object v4Id) {
+            ComputerTestHelper.compute("g.V(${v4Id}).out.as('here').has('lang', 'java').selectList('here').unfold().name", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectListXhereX(final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).outE.as('here').inV.has('name', 'vadas').selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectListXhereX(
+                final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).outE('knows').has('weight', 1.0d).as('here').inV.has('name', 'josh').selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_inV_hasXname_joshX_selectListXhereX(
+                final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).outE('knows').as('here').has('weight', 1.0d).inV.has('name','josh').selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_asXfakeX_inV_hasXname_joshX_selectListXhereX(
+                final Object v1Id) {
+            ComputerTestHelper.compute("g.V(${v1Id}).outE('knows').as('here').has('weight', 1.0d).as('fake').inV.has('name','josh').selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_asXhereXout_name_selectListXhereX() {
+            ComputerTestHelper.compute("g.V().as('here').out.name.selectList('here')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, Map<List<String>, Long>> get_g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectListXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectListXprojectXX_groupCount_byXnameX() {
+            ComputerTestHelper.compute("""
+            g.V.out('created')
+                    .union(__.as('project').in('created').has('name', 'marko').selectList('project'),
+                    __.as('project').in('created').in('knows').has('name', 'marko').selectList('project')).groupCount().by('name');
+            """, g)
+        }
+    }
+}

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectTest.groovy
@@ -95,6 +95,16 @@ public abstract class GroovySelectTest {
             return g.V().hasLabel('person').as('person').local(__.bothE().label().groupCount()).as('relations').select().by('name').by()
         }
 
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX() {
+            return g.V().as("a").out().as("a").out().as("a").select("a");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXnameX() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by("name");
+        }
+
         //
 
         @Override
@@ -256,6 +266,16 @@ public abstract class GroovySelectTest {
         Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_select_byXnameX_by() {
             // override with nothing until the test itself is supported
             return null
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX() {
+            ComputerTestHelper.compute("g.V().as('a').out().as('a').out().as('a').select('a')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXnameX() {
+            ComputerTestHelper.compute("g.V().as('a').out().as('a').out().as('a').select('a').by('name')", g);
         }
 
         //

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -52,6 +52,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyMinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyOrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPropertiesTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySelectListTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySumTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyUnfoldTest;
@@ -126,6 +127,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
             GroovyOrderTest.ComputerTraversals.class,
             GroovyPathTest.ComputerTraversals.class,
             GroovyPropertiesTest.ComputerTraversals.class,
+            GroovySelectListTest.ComputerTraversals.class,
             GroovySelectTest.ComputerTraversals.class,
             GroovySumTest.ComputerTraversals.class,
             GroovyUnfoldTest.ComputerTraversals.class,

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessStandardSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessStandardSuite.java
@@ -58,6 +58,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyMinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyOrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPropertiesTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySelectListTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySumTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyUnfoldTest;
@@ -132,6 +133,7 @@ public class GroovyProcessStandardSuite extends ProcessStandardSuite {
             GroovyOrderTest.StandardTraversals.class,
             GroovyPathTest.StandardTraversals.class,
             GroovyPropertiesTest.StandardTraversals.class,
+            GroovySelectListTest.StandardTraversals.class,
             GroovySelectTest.StandardTraversals.class,
             GroovySumTest.StandardTraversals.class,
             GroovyUnfoldTest.StandardTraversals.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
@@ -55,6 +55,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectListTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest;
@@ -138,6 +139,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             OrderTest.Traversals.class,
             PathTest.Traversals.class,
             PropertiesTest.Traversals.class,
+            SelectListTest.Traversals.class,
             SelectTest.Traversals.class,
             UnfoldTest.Traversals.class,
             ValueMapTest.Traversals.class,
@@ -212,6 +214,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             OrderTest.class,
             PathTest.class,
             PropertiesTest.class,
+            SelectListTest.class,
             SelectTest.class,
             UnfoldTest.class,
             ValueMapTest.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
@@ -73,6 +73,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StoreTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SubgraphTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.PathTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.SparsePathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategyProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategyProcessTest;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategyProcessTest;
@@ -166,6 +167,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             // compliance
             CoreTraversalTest.class,
             PathTest.class,
+            SparsePathTest.class,
 
             // strategy
             TraversalVerificationStrategyTest.StandardTraversals.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
@@ -56,6 +56,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectListTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest;
@@ -142,6 +143,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             OrderTest.Traversals.class,
             org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest.Traversals.class,
             PropertiesTest.Traversals.class,
+            SelectListTest.Traversals.class,
             SelectTest.Traversals.class,
             VertexTest.Traversals.class,
             UnfoldTest.Traversals.class,
@@ -227,6 +229,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             OrderTest.class,
             org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest.class,   // note that there are two PathTest in this suite - only one is enforce
             PropertiesTest.class,
+            SelectListTest.class,
             SelectTest.class,
             VertexTest.class,
             UnfoldTest.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectListTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectListTest.java
@@ -1,0 +1,575 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.IgnoreEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.UseEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Order;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.values;
+import static org.junit.Assert.*;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public abstract class SelectListTest extends AbstractGremlinProcessTest {
+
+    public abstract Traversal<Vertex, Map<String, List<Vertex>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList(final Object v1Id);
+
+    public abstract Traversal<Vertex, Map<String, List<String>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<String>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX(final Object v1Id);
+
+    public abstract Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_asXbX_selectList_byXnameX();
+
+    public abstract Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_aggregateXxX_asXbX_selectList_byXnameX();
+
+    public abstract Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_name_order_asXbX_selectList_byXnameX_by_XitX();
+
+    public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX();
+
+    public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_isXmarkoXX_asXaX_selectList();
+
+    public abstract Traversal<Vertex, Map<String, List<Map<String, Long>>>> get_g_V_label_groupCount_asXxX_selectList();
+
+    public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by();
+
+    // WIP
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX();
+
+    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX_byXnameX();
+
+    // below we original back()-tests
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_VX1X_asXhereX_out_selectListXhereX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX(final Object v4Id);
+
+    public abstract Traversal<Vertex, String> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX_unfold_name(final Object v4Id);
+
+    public abstract Traversal<Vertex, List<Edge>> get_g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectListXhereX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectListXhereX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_inV_hasXname_joshX_selectListXhereX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_asXfakeX_inV_hasXname_joshX_selectListXhereX(final Object v1Id);
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_V_asXhereXout_name_selectListXhereX();
+
+    public abstract Traversal<Vertex, Map<List<String>, Long>> get_g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectListXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectListXprojectXX_groupCount_byXnameX();
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX1X_asXaX_outXknowsX_asXbX_selectList() {
+        final Traversal<Vertex, Map<String, List<Vertex>>> traversal = get_g_VX1X_asXaX_outXknowsX_asXbX_selectList(convertToVertexId("marko"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            Map<String, List<Vertex>> bindings = traversal.next();
+            assertEquals(2, bindings.size());
+            List<Vertex> a = bindings.get("a");
+            assertEquals(1, a.size());
+            assertEquals(convertToVertexId("marko"), a.get(0).id());
+            List<Vertex> b = bindings.get("b");
+            assertEquals(1, b.size());
+            Vertex b0 = b.get(0);
+            assertTrue(b0.id().equals(convertToVertexId("vadas")) || b0.id().equals(convertToVertexId("josh")));
+        }
+        assertEquals(2, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    // @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX() {
+        final Traversal<Vertex, Map<String, List<String>>> traversal = get_g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX(convertToVertexId("marko"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            Map<String, List<String>> bindings = traversal.next();
+            assertEquals(2, bindings.size());
+            List<String> a = bindings.get("a");
+            assertEquals(1, a.size());
+            assertEquals("marko", a.get(0));
+            List<String> b = bindings.get("b");
+            assertEquals(1, b.size());
+            String b0 = b.get(0);
+            assertTrue(b0.equals("josh") || b0.equals("vadas"));
+        }
+        assertEquals(2, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX() {
+        final Traversal<Vertex, List<Vertex>> traversal = get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX(convertToVertexId("marko"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            List<Vertex> list = traversal.next();
+            assertEquals(1, list.size());
+            Vertex vertex = list.get(0);
+            assertEquals(convertToVertexId("marko"), vertex.id());
+        }
+        assertEquals(2, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    //@IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX() {
+        final Traversal<Vertex, List<String>> traversal = get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX(convertToVertexId("marko"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            List<String> list = traversal.next();
+            assertEquals(1, list.size());
+            assertEquals("marko", list.get(0));
+        }
+        assertEquals(2, counter);
+    }
+
+    private final static <X> List<X> L(final X...elements) { return Arrays.asList(elements); }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_V_asXaX_out_asXbX_selectList_byXnameX() {
+        Arrays.asList(
+                get_g_V_asXaX_out_asXbX_selectList_byXnameX(),
+                get_g_V_asXaX_out_aggregateXxX_asXbX_selectList_byXnameX()).forEach(traversal -> {
+            printTraversalForm(traversal);
+            final List<Map<String, List<String>>> expected = makeMapList(2,
+                    "a", L("marko"), "b", L("lop"),
+                    "a", L("marko"), "b", L("vadas"),
+                    "a", L("marko"), "b", L("josh"),
+                    "a", L("josh"), "b", L("ripple"),
+                    "a", L("josh"), "b", L("lop"),
+                    "a", L("peter"), "b", L("lop"));
+            checkResults(expected, traversal);
+        });
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_V_asXaX_name_order_asXbX_selectList_byXnameX_byXitX() {
+        Arrays.asList(
+                get_g_V_asXaX_name_order_asXbX_selectList_byXnameX_by_XitX()).forEach(traversal -> {
+            printTraversalForm(traversal);
+            final List<Map<String, List<String>>> expected = makeMapList(2,
+                    "a", L("marko"), "b", L("marko"),
+                    "a", L("vadas"), "b", L("vadas"),
+                    "a", L("josh"), "b", L("josh"),
+                    "a", L("ripple"), "b", L("ripple"),
+                    "a", L("lop"), "b", L("lop"),
+                    "a", L("peter"), "b", L("peter"));
+            checkResults(expected, traversal);
+        });
+    }
+
+    @Test
+    @LoadGraphWith(CREW)
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX() {
+        final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX();
+        printTraversalForm(traversal);
+        final List<Map<String, List<Object>>> expected = makeMapList(2,
+                   "a", L(3), "b", L("matthias"),
+                   "a", L(4), "b", L("marko"),
+                   "a", L(5), "b", L("stephen"),
+                   "a", L(5), "b", L("daniel"));
+        checkResults(expected, traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasXname_isXmarkoXX_asXaX_selectList() {
+        final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_hasXname_isXmarkoXX_asXaX_selectList();
+        printTraversalForm(traversal);
+        final List<Map<String, List<Object>>> expected = makeMapList(1, "a", L(g.V(convertToVertexId("marko")).next()));
+        checkResults(expected, traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_V_label_groupCount_asXxX_selectList() {
+        final Traversal<Vertex, Map<String, List<Map<String, Long>>>> traversal = get_g_V_label_groupCount_asXxX_selectList();
+        printTraversalForm(traversal);
+        assertTrue(traversal.hasNext());
+        final Map<String, List<Map<String, Long>>> map1 = traversal.next();
+        assertEquals(1, map1.size());
+        assertTrue(map1.containsKey("x"));
+        final List<Map<String, Long>> list = (List<Map<String, Long>>) map1.get("x");
+        final Map<String, Long> map2 = list.get(0);
+        assertEquals(2, map2.size());
+        assertTrue(map2.containsKey("person"));
+        assertTrue(map2.containsKey("software"));
+        assertEquals(2, map2.get("software").longValue());
+        assertEquals(4, map2.get("person").longValue());
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @Ignore("Even though the reduce is local, you cannot select across that barrier step")
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by() {
+        final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by();
+        printTraversalForm(traversal);
+        final Set<String> persons = new HashSet<>();
+        for (int i = 0; i < 4; i++) {
+            assertTrue(traversal.hasNext());
+            final Map<String, List<Object>> map = traversal.next();
+            assertEquals(2, map.size());
+            assertTrue(map.containsKey("person"));
+            assertTrue(map.containsKey("relations"));
+            final List<String> personList = (List<String>)(List) map.get("person");
+            assertEquals(1, personList.size());
+            final String person = personList.get(0);
+            assertTrue(persons.add(person));
+            final List<Map<String, Long>> relationsList = (List<Map<String, Long>>)(List) map.get("relations");
+            assertEquals(1, relationsList.size());
+            final Map<String, Long> relations = relationsList.get(0);
+            switch (person) {
+                case "marko":
+                    assertEquals(2, relations.size());
+                    assertEquals(1, relations.get("created").longValue());
+                    assertEquals(2, relations.get("knows").longValue());
+                    break;
+                case "vadas":
+                    assertEquals(1, relations.size());
+                    assertEquals(1, relations.get("knows").longValue());
+                    break;
+                case "josh":
+                    assertEquals(2, relations.size());
+                    assertEquals(2, relations.get("created").longValue());
+                    assertEquals(1, relations.get("knows").longValue());
+                    break;
+                case "peter":
+                    assertEquals(1, relations.size());
+                    assertEquals(1, relations.get("created").longValue());
+                    break;
+                default:
+                    assertTrue(false);
+                    break;
+            }
+        }
+        assertFalse(traversal.hasNext());
+        assertEquals(4, persons.size());
+    }
+
+    // WIP
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectListXaX() {
+        final Traversal<Vertex, List<Vertex>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            List<Vertex> vertices = traversal.next();
+            assertEquals(3, vertices.size());
+            assertEquals("marko", vertices.get(0).value("name"));
+            assertEquals("josh", vertices.get(1).value("name"));
+            Vertex last = vertices.get(2);
+            assertTrue(last.value("name").equals("ripple") || last.value("name").equals("lop"));
+        }
+        assertEquals(2, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectListXaX_byXnameX() {
+        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX_byXnameX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            List<String> names = traversal.next();
+            assertEquals(3, names.size());
+            assertEquals("marko", names.get(0));
+            assertEquals("josh", names.get(1));
+            String last = names.get(2);
+            assertTrue(last.equals("ripple") || last.equals("lop"));
+        }
+        assertEquals(2, counter);
+    }
+
+    //
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX1X_asXhereX_out_selectListXhereX() {
+        final Traversal<Vertex, List<Vertex>> traversal = get_g_VX1X_asXhereX_out_selectListXhereX(convertToVertexId("marko"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            final List<Vertex> list = traversal.next();
+            assertEquals(1, list.size());
+            assertEquals("marko", list.get(0).value("name"));
+        }
+        assertEquals(3, counter);
+    }
+
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX() {
+        final Traversal<Vertex, List<Vertex>> traversal = get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX(convertToVertexId("josh"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            final List<Vertex> list = traversal.next();
+            assertEquals(1, list.size());
+            final Vertex vertex = list.get(0);
+            assertEquals("java", vertex.<String>value("lang"));
+            assertTrue(vertex.value("name").equals("ripple") || vertex.value("name").equals("lop"));
+        }
+        assertEquals(2, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectListXhereX() {
+        final Traversal<Vertex, List<Edge>> traversal = get_g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectListXhereX(convertToVertexId("marko"));
+        printTraversalForm(traversal);
+        final List<Edge> list = traversal.next();
+        assertEquals(1, list.size());
+        final Edge edge = list.get(0);
+        assertEquals("knows", edge.label());
+        assertEquals(convertToVertexId("vadas"), edge.inVertex().id());
+        assertEquals(convertToVertexId("marko"), edge.outVertex().id());
+        assertEquals(0.5d, edge.<Double>value("weight"), 0.0001d);
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX_unfold_name() {
+        final Traversal<Vertex, String> traversal = get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX_unfold_name(convertToVertexId("josh"));
+        printTraversalForm(traversal);
+        int counter = 0;
+        final Set<String> names = new HashSet<>();
+        while (traversal.hasNext()) {
+            counter++;
+            names.add(traversal.next());
+        }
+        assertEquals(2, counter);
+        assertEquals(2, names.size());
+        assertTrue(names.contains("ripple"));
+        assertTrue(names.contains("lop"));
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectListXhereX() {
+        final List<Traversal<Vertex, List<Edge>>> traversals = Arrays.asList(
+                get_g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectListXhereX(convertToVertexId("marko")),
+                get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_inV_hasXname_joshX_selectListXhereX(convertToVertexId("marko")),
+                get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_asXfakeX_inV_hasXname_joshX_selectListXhereX(convertToVertexId("marko")));
+        traversals.forEach(traversal -> {
+            printTraversalForm(traversal);
+            assertTrue(traversal.hasNext());
+            assertTrue(traversal.hasNext());
+            final List<Edge> list = traversal.next();
+            assertEquals(1, list.size());
+            final Edge edge = list.get(0);
+            assertEquals("knows", edge.label());
+            assertEquals(1.0d, edge.<Double>value("weight"), 0.00001d);
+            assertFalse(traversal.hasNext());
+            assertFalse(traversal.hasNext());
+        });
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXhereXout_name_selectListXhereX() {
+        Traversal<Vertex, List<Vertex>> traversal = get_g_V_asXhereXout_name_selectListXhereX();
+        printTraversalForm(traversal);
+        super.checkResults(new HashMap<List<Vertex>, Long>() {{
+            put(L(convertToVertex(graph, "marko")), 3l);
+            put(L(convertToVertex(graph, "josh")), 2l);
+            put(L(convertToVertex(graph, "peter")), 1l);
+        }}, traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    @Ignore("groupCount needs to be able to apply 'by' traversals to a List")
+    public void g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectListXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectListXprojectXX_groupCount_byXnameX() {
+        List<Traversal<Vertex, Map<List<String>, Long>>> traversals = Arrays.asList(get_g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectListXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectListXprojectXX_groupCount_byXnameX());
+        traversals.forEach(traversal -> {
+            printTraversalForm(traversal);
+            assertTrue(traversal.hasNext());
+            final Map<List<String>, Long> map = traversal.next();
+            assertFalse(traversal.hasNext());
+            assertEquals(2, map.size());
+            assertEquals(1l, map.get(L("ripple")).longValue());
+            assertEquals(6l, map.get(L("lop")).longValue());
+        });
+    }
+
+    @UseEngine(TraversalEngine.Type.STANDARD)
+    @UseEngine(TraversalEngine.Type.COMPUTER)
+    public static class Traversals extends SelectListTest {
+        @Override
+        public Traversal<Vertex, Map<String, List<Vertex>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList(final Object v1Id) {
+            return g.V(v1Id).as("a").out("knows").as("b").<Vertex>selectList();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectList_byXnameX(final Object v1Id) {
+            return g.V(v1Id).as("a").out("knows").as("b").<String>selectList().by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX(final Object v1Id) {
+            return g.V(v1Id).as("a").out("knows").as("b").<Vertex>selectList("a");
+        }
+
+        @Override
+        public Traversal<Vertex, List<String>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectListXaX_byXnameX(final Object v1Id) {
+            return g.V(v1Id).as("a").out("knows").as("b").<String>selectList("a").by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_asXbX_selectList_byXnameX() {
+            return g.V().as("a").out().as("b").<String>selectList().by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_out_aggregateXxX_asXbX_selectList_byXnameX() {
+            return g.V().as("a").out().aggregate("x").as("b").<String>selectList().by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<String>>> get_g_V_asXaX_name_order_asXbX_selectList_byXnameX_by_XitX() {
+            return g.V().as("a").values("name").order().as("b").<String>selectList().by("name").by();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectList_byXskillX_byXnameX() {
+            return g.V().has("name", "gremlin").inE("uses").order().by("skill", Order.incr).as("a").outV().as("b").selectList().by("skill").by("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasXname_isXmarkoXX_asXaX_selectList() {
+            return g.V().has(values("name").is("marko")).as("a").selectList();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Map<String, Long>>>> get_g_V_label_groupCount_asXxX_selectList() {
+            return g.V().label().groupCount().as("x").<Map<String, Long>>selectList();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_selectList_byXnameX_by() {
+            return g.V().hasLabel("person").as("person").local(__.bothE().label().groupCount()).as("relations").selectList().by("name").by();
+        }
+
+        // WIP
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX() {
+            return g.V().as("a").out().as("a").out().as("a").<Vertex>selectList("a");
+        }
+
+        @Override
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectListXaX_byXnameX() {
+            return g.V().as("a").out().as("a").out().as("a").<String>selectList("a").by("name");
+        }
+
+        //
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX1X_asXhereX_out_selectListXhereX(final Object v1Id) {
+            return g.V(v1Id).as("here").out().<Vertex>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX(final Object v4Id) {
+            return g.V(v4Id).out().as("here").has("lang", "java").<Vertex>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectListXhereX_unfold_name(final Object v4Id) {
+            return g.V(v4Id).out().as("here").has("lang", "java").<Vertex>selectList("here").unfold().values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectListXhereX(final Object v1Id) {
+            return g.V(v1Id).outE().as("here").inV().has("name", "vadas").<Edge>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectListXhereX(final Object v1Id) {
+            return g.V(v1Id).outE("knows").has("weight", 1.0d).as("here").inV().has("name", "josh").<Edge>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_inV_hasXname_joshX_selectListXhereX(final Object v1Id) {
+            return g.V(v1Id).outE("knows").as("here").has("weight", 1.0d).inV().has("name", "josh").<Edge>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Edge>> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_asXfakeX_inV_hasXname_joshX_selectListXhereX(final Object v1Id) {
+            return g.V(v1Id).outE("knows").as("here").has("weight", 1.0d).as("fake").inV().has("name", "josh").<Edge>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_asXhereXout_name_selectListXhereX() {
+            return g.V().as("here").out().values("name").<Vertex>selectList("here");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<List<String>, Long>> get_g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectListXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectListXprojectXX_groupCount_byXnameX() {
+            return (Traversal) g.V().out("created")
+                .union(as("project").in("created").has("name", "marko").<Vertex>selectList("project"),
+                       as("project").in("created").in("knows").has("name", "marko").<Vertex>selectList("project"))
+                .<String>groupCount().by("name");
+        }
+    }
+}

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -67,6 +67,10 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_select_byXnameX_by();
 
+    public abstract Traversal<Vertex, Vertex> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX();
+
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXnameX();
+
     // below we original back()-tests
 
     public abstract Traversal<Vertex, Vertex> get_g_VX1X_asXhereX_out_selectXhereX(final Object v1Id);
@@ -271,6 +275,34 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         assertEquals(4, persons.size());
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            Vertex vertex = traversal.next();
+            assertTrue(vertex.value("name").equals("ripple") || vertex.value("name").equals("lop"));
+        }
+        assertEquals(2, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXnameX() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXnameX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            counter++;
+            String name = traversal.next();
+            assertTrue(name.equals("ripple") || name.equals("lop"));
+        }
+        assertEquals(2, counter);
+    }
+
     //
 
     @Test
@@ -435,6 +467,16 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_select_byXnameX_by() {
             return g.V().hasLabel("person").as("person").local(__.bothE().label().groupCount()).as("relations").select().by("name").by();
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX() {
+            return g.V().as("a").out().as("a").out().as("a").select("a");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXnameX() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by("name");
         }
 
         //

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectTest.java
@@ -233,7 +233,7 @@ public abstract class SelectTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    @Ignore("There is a HashMap to Element cast problem happening here for some reason in both OLTP and OLAP")  // TODO: dkuppitz this has been ignored for some time now -- don't know if the test is bad or the code is bad.
+    @Ignore("Even though the reduce is local, you cannot select across that barrier step")
     @IgnoreEngine(TraversalEngine.Type.COMPUTER)
     public void g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_select_byXnameX_by() {
         final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_hasLabelXpersonX_asXpersonX_localXbothE_label_groupCountX_asXrelationsX_select_byXnameX_by();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/PathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/PathTest.java
@@ -50,12 +50,26 @@ public class PathTest extends AbstractGremlinProcessTest {
             assertEquals(Integer.valueOf(1), path.get("a"));
             assertEquals(Integer.valueOf(2), path.get("b"));
             assertEquals(Integer.valueOf(3), path.get("c"));
+            assertEquals(Integer.valueOf(1), path.getLast("a"));
+            assertEquals(Integer.valueOf(2), path.getLast("b"));
+            assertEquals(Integer.valueOf(3), path.getLast("c"));
+            assertEquals(Arrays.asList(Integer.valueOf(1)), path.getList("a"));
+            assertEquals(Arrays.asList(Integer.valueOf(2)), path.getList("b"));
+            assertEquals(Arrays.asList(Integer.valueOf(3)), path.getList("c"));
             path.addLabel("d");
             assertEquals(3, path.size());
             assertEquals(Integer.valueOf(1), path.get("a"));
             assertEquals(Integer.valueOf(2), path.get("b"));
             assertEquals(Integer.valueOf(3), path.get("c"));
             assertEquals(Integer.valueOf(3), path.get("d"));
+            assertEquals(Integer.valueOf(1), path.getLast("a"));
+            assertEquals(Integer.valueOf(2), path.getLast("b"));
+            assertEquals(Integer.valueOf(3), path.getLast("c"));
+            assertEquals(Integer.valueOf(3), path.getLast("d"));
+            assertEquals(Arrays.asList(Integer.valueOf(1)), path.getList("a"));
+            assertEquals(Arrays.asList(Integer.valueOf(2)), path.getList("b"));
+            assertEquals(Arrays.asList(Integer.valueOf(3)), path.getList("c"));
+            assertEquals(Arrays.asList(Integer.valueOf(3)), path.getList("d"));
             assertTrue(path.hasLabel("a"));
             assertTrue(path.hasLabel("b"));
             assertTrue(path.hasLabel("c"));
@@ -89,6 +103,10 @@ public class PathTest extends AbstractGremlinProcessTest {
             assertEquals(2, path.<List<String>>get("a").size());
             assertTrue(path.<List<String>>get("a").contains("marko"));
             assertTrue(path.<List<String>>get("a").contains("matthias"));
+            // getLast should return the most recent value.
+            assertEquals("matthias", path.getLast("a"));
+            // getList should return a list of values in path order.
+            assertEquals(Arrays.asList("marko", "matthias"), path.getList("a"));
         });
 
         final Path path = g.V().as("x").repeat(out().as("y")).times(2).path().by("name").next();
@@ -98,8 +116,17 @@ public class PathTest extends AbstractGremlinProcessTest {
         assertTrue(path.get("x") instanceof String);
         assertTrue(path.get("y") instanceof List);
         assertEquals(2, path.<List<String>>get("y").size());
+        // get should return the list of both values, which, because of nondeterminism in the order in which paths are
+        // traversed, will be one of two possible values.
         assertTrue(path.<List<String>>get("y").contains("josh"));
-        assertTrue(path.<List<String>>get("y").contains("ripple") || path.<List<String>>get("y").contains("lop"));
+        assertTrue(path.<List<String>>get("y").contains("ripple") ||
+                   path.<List<String>>get("y").contains("lop"));
+        // getLast should return the most recent value (with the same nondeterminism caveat)
+        assertTrue(path.getLast("y").equals("ripple") ||
+                   path.getLast("y").equals("lop"));
+        // getList should return both values (with the same nondeterminism caveat)
+        assertTrue(path.getList("y").equals(Arrays.asList("josh", "ripple")) ||
+                   path.getList("y").equals(Arrays.asList("josh", "lop")));
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/SparsePathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/SparsePathTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.util;
+
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.IgnoreEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.UseEngine;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.junit.Assert.*;
+
+/**
+ * SparsePath implements Path, but with different semantics, so PathTest does not apply.
+ *
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+@UseEngine(TraversalEngine.Type.STANDARD)
+public class SparsePathTest extends AbstractGremlinProcessTest {
+
+    @Test
+    public void shouldHaveStandardSemanticsImplementedCorrectly() {
+        Arrays.<Path>asList(SparsePath.make()).forEach(path -> {
+            assertTrue(path.isSimple());
+            assertEquals(0, path.size());
+            path = path.extend(1, "a");
+            path = path.extend(2, "b");
+            path = path.extend(3, "c");
+            assertEquals(3, path.size());
+            assertEquals(Integer.valueOf(1), path.get("a"));
+            assertEquals(Integer.valueOf(2), path.get("b"));
+            assertEquals(Integer.valueOf(3), path.get("c"));
+            assertEquals(Integer.valueOf(1), path.getLast("a"));
+            assertEquals(Integer.valueOf(2), path.getLast("b"));
+            assertEquals(Integer.valueOf(3), path.getLast("c"));
+            // In other paths, getList should work, but SparsePath.getList throws.
+            try {
+                assertEquals(Arrays.asList(Integer.valueOf(1)), path.getList("a"));
+                fail("SparsePath.getList should throw");
+            }
+            catch (IllegalArgumentException exc) {
+                // OK
+            }
+            path.addLabel("d");
+            assertEquals(4, path.size());  // 3 in other Paths
+            assertEquals(Integer.valueOf(1), path.get("a"));
+            assertEquals(Integer.valueOf(2), path.get("b"));
+            assertEquals(Integer.valueOf(3), path.get("c"));
+            assertEquals(Integer.valueOf(3), path.get("d"));
+            assertEquals(Integer.valueOf(1), path.getLast("a"));
+            assertEquals(Integer.valueOf(2), path.getLast("b"));
+            assertEquals(Integer.valueOf(3), path.getLast("c"));
+            assertEquals(Integer.valueOf(3), path.getLast("d"));
+            assertTrue(path.hasLabel("a"));
+            assertTrue(path.hasLabel("b"));
+            assertTrue(path.hasLabel("c"));
+            assertTrue(path.hasLabel("d"));
+            assertFalse(path.hasLabel("e"));
+            assertFalse(path.isSimple());  // true in other Paths
+            path = path.extend(3, "e");
+            assertFalse(path.isSimple());
+            assertTrue(path.hasLabel("e"));
+            assertEquals(5, path.size());  // 4 in other Paths
+            assertEquals(Integer.valueOf(1), path.get(0));
+            assertEquals(Integer.valueOf(2), path.get(1));
+            assertEquals(Integer.valueOf(3), path.get(2));
+            assertEquals(Integer.valueOf(3), path.get(3));
+        });
+    }
+
+    @Test
+    @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER)
+    public void shouldHandleMultiLabelPaths() {
+        Arrays.<Path>asList(SparsePath.make()).forEach(path -> {
+            path = path.extend("marko", "a");
+            path = path.extend("stephen", "b");
+            path = path.extend("matthias", "a");
+            assertEquals(2, path.size());  // 3 in other Paths
+            assertEquals(2, path.objects().size());  // 3 in other Paths
+            assertEquals(2, path.labels().size());  // 3 in other Paths
+            assertEquals(2, new HashSet<>(path.labels()).size());
+            assertTrue(path.get("a") instanceof String);  // List in other Paths
+            assertTrue(path.get("b") instanceof String);
+            assertEquals("matthias", path.get("a"));  // List containing "marko" and "matthias" in other Paths
+            // getLast should return the most recent value.
+            assertEquals("matthias", path.getLast("a"));
+        });
+
+        // As long as we avoid a PATH requirement, we will get a SparsePath.  This should use SparsePath in
+        // TinkerGraph, but may not always do so due to implementation variations.
+        final Traversal<Vertex, Map<String, String>> t =
+            g.V().as("x").out().out().as("y").<String>select().by("name");
+
+        assertTrue(t.hasNext());
+        final Map<String, String> map = t.next();
+        assertEquals(2, map.size());
+        assertTrue(map.get("x") instanceof String);
+        assertTrue(map.get("y") instanceof String);
+        // Both of the paths start with marko
+        assertEquals("marko", map.get("x"));
+        // get should return the list of both values, which, because of nondeterminism in the order in which paths are
+        // traversed, will be one of two possible values.
+        assertTrue(map.get("y").equals("ripple") ||
+                   map.get("y").equals("lop"));
+    }
+
+    @Test
+    public void shouldExcludeUnlabeledLabelsFromPath() {
+        Arrays.<Path>asList(SparsePath.make()).forEach(path -> {
+            path = path.extend("marko", "a");
+            path = path.extend("stephen", "b");
+            path = path.extend("matthias", "c", "d");
+            assertEquals(4, path.size());  // 3 in other Paths
+            assertEquals(4, path.objects().size());  // 3 in other Paths
+            assertEquals(4, path.labels().size());  // 3 in other Paths
+            assertEquals(1, path.labels().get(0).size());
+            assertEquals(1, path.labels().get(1).size());
+            assertEquals("b", path.labels().get(1).iterator().next());
+            assertEquals(1, path.labels().get(2).size());  // 2 in other Paths
+            assertTrue(path.labels().get(2).contains("c"));
+            assertTrue(path.labels().get(3).contains("d"));  // get(2) in other Paths
+        });
+    }
+}


### PR DESCRIPTION
This PR includes #54 and puts those changes in context.  In particular, the new `Path` API (`getLast` and `getList`) are used to implement `select` and `selectList`.

I'm still open to renaming `selectList` to `selectPath`.

The unit tests in `SelectListTest` are based on the ones in `SelectTest`.

I added a couple of tests to `SelectTest` because there weren't any tests that demonstrated the list result.