### PR TITLE
TINKERPOP3-670 tail step (v2)

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -53,6 +53,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.OrStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.SampleGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.SimplePathStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TimeLimitStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeByPathStep;
@@ -91,6 +92,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectOneStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumLocalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.TailLocalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.TreeStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
@@ -558,6 +560,16 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
 
     public default GraphTraversal<S, E> limit(final Scope scope, final long limit) {
         return this.range(scope, 0, limit);
+    }
+
+    public default GraphTraversal<S, E> tail(final long limit) {
+        return this.tail(Scope.global, limit);
+    }
+
+    public default GraphTraversal<S, E> tail(final Scope scope, final long limit) {
+        return this.asAdmin().addStep(scope.equals(Scope.global)
+                ? new TailGlobalStep<>(this.asAdmin(), limit)
+                : new TailLocalStep<>(this.asAdmin(), limit));
     }
 
     public default GraphTraversal<S, E> simplePath() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -562,8 +562,16 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         return this.range(scope, 0, limit);
     }
 
+    public default GraphTraversal<S, E> tail() {
+        return this.tail(1);
+    }
+
     public default GraphTraversal<S, E> tail(final long limit) {
         return this.tail(Scope.global, limit);
+    }
+
+    public default GraphTraversal<S, E> tail(final Scope scope) {
+        return this.tail(scope, 1);
     }
 
     public default GraphTraversal<S, E> tail(final Scope scope, final long limit) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -410,6 +410,22 @@ public class __ {
         return __.<A>start().limit(scope, limit);
     }
 
+    public static <A> GraphTraversal<A, A> tail() {
+        return __.<A>start().tail();
+    }
+
+    public static <A> GraphTraversal<A, A> tail(final long limit) {
+        return __.<A>start().tail(limit);
+    }
+
+    public static <A> GraphTraversal<A, A> tail(final Scope scope) {
+        return __.<A>start().tail(scope);
+    }
+
+    public static <A> GraphTraversal<A, A> tail(final Scope scope, final long limit) {
+        return __.<A>start().tail(scope, limit);
+    }
+
     public static <A> GraphTraversal<A, A> simplePath() {
         return __.<A>start().simplePath();
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStep.java
@@ -65,7 +65,7 @@ public final class TailGlobalStep<S> extends AbstractStep<S, S> {
     @Override
     public TailGlobalStep<S> clone() {
         final TailGlobalStep<S> clone = (TailGlobalStep<S>) super.clone();
-        clone.tail = new ArrayDeque<Traverser.Admin<S>>(this.tail);
+        clone.tail = new ArrayDeque<Traverser.Admin<S>>((int)this.limit);
         return clone;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailGlobalStep.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
+
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Set;
+
+/**
+ * @author Matt Frantz (http://github.com/mhfrantz)
+ */
+public final class TailGlobalStep<S> extends AbstractStep<S, S> {
+
+    private final long limit;
+    private Deque<Traverser.Admin<S>> tail;
+
+    public TailGlobalStep(final Traversal.Admin traversal, final long limit) {
+        super(traversal);
+        this.limit = limit;
+        this.tail = new ArrayDeque<Traverser.Admin<S>>((int)limit);
+    }
+
+    @Override
+    public Traverser<S> processNextStart() {
+        if (this.starts.hasNext()) {
+            this.starts.forEachRemaining(this::addTail);
+        }
+        return this.tail.pop();
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.tail.clear();
+    }
+
+    @Override
+    public String toString() {
+        return TraversalHelper.makeStepString(this, this.limit);
+    }
+
+    @Override
+    public TailGlobalStep<S> clone() {
+        final TailGlobalStep<S> clone = (TailGlobalStep<S>) super.clone();
+        clone.tail = new ArrayDeque<Traverser.Admin<S>>(this.tail);
+        return clone;
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return Collections.singleton(TraverserRequirement.BULK);
+    }
+
+    private void addTail(Traverser.Admin<S> start) {
+        if (this.tail.size() >= this.limit)
+            this.tail.pop();
+        this.tail.add(start);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
@@ -46,15 +46,34 @@ public final class RangeLocalStep<S> extends MapStep<S, S> {
     @Override
     protected S map(final Traverser.Admin<S> traverser) {
         final S start = traverser.get();
+        return applyRange(start, this.low, this.high);
+    }
+
+    /**
+     * Extracts the specified range of elements from a collection.
+     * Return type depends on dynamic type of start.
+     * <ul>
+     * <li>
+     * Map becomes Map (order-preserving)
+     * </li>
+     * <li>
+     * Set becomes Set (order-preserving)
+     * </li>
+     * <li>
+     * Other Collection types become List
+     * </li>
+     * </ul>
+     */
+    static <S> S applyRange(S start, long low, long high) {
         if (start instanceof Map) {
             final Map map = (Map) start;
-            final long capacity = (this.high != -1 ? this.high : map.size()) - this.low;
+            final long capacity = (high != -1 ? high : map.size()) - low;
             final Map result = new LinkedHashMap((int) Math.min(capacity, map.size()));
             long c = 0L;
             for (final Object obj : map.entrySet()) {
                 final Map.Entry entry = (Map.Entry) obj;
-                if (c >= this.low) {
-                    if (c < this.high || this.high == -1) {
+                if (c >= low) {
+                    if (c < high || high == -1) {
                         result.put(entry.getKey(), entry.getValue());
                     } else break;
                 }
@@ -66,8 +85,8 @@ public final class RangeLocalStep<S> extends MapStep<S, S> {
             final Collection result = (collection instanceof Set) ? new LinkedHashSet() : new LinkedList();
             long c = 0L;
             for (final Object item : collection) {
-                if (c >= this.low) {
-                    if (c < this.high || this.high == -1) {
+                if (c >= low) {
+                    if (c < high || high == -1) {
                         result.add(item);
                     } else break;
                 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/RangeLocalStep.java
@@ -22,6 +22,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 
 import java.util.*;
 
@@ -75,6 +76,11 @@ public final class RangeLocalStep<S> extends MapStep<S, S> {
             return (S) result;
         }
         return start;
+    }
+
+    @Override
+    public String toString() {
+        return TraversalHelper.makeStepString(this, this.low, this.high);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TailLocalStep.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Matt Frantz (http://github.com/mhfrantz)
+ */
+public final class TailLocalStep<S> extends MapStep<S, S> {
+
+    private final long limit;
+
+    public TailLocalStep(final Traversal.Admin traversal, final long limit) {
+        super(traversal);
+        this.limit = limit;
+    }
+
+    @Override
+    protected S map(final Traverser.Admin<S> traverser) {
+        // We may consider optimizing the iteration of these containers using subtype-specific interfaces.  For
+        // example, we could use descendingIterator if we have a Deque.  But in general, we cannot reliably iterate a
+        // collection in reverse, so we use the range algorithm with dynamically computed boundaries.
+        final S start = traverser.get();
+        final long high =
+            start instanceof Map ? ((Map)start).size() :
+            start instanceof Collection ? ((Collection)start).size() :
+            this.limit;
+        final long low = high - this.limit;
+        final S result = RangeLocalStep.applyRange(start, low, high);
+
+        // If we are limiting a collection to a single item, then emit only that item.
+        if (1 == this.limit && result instanceof Collection) {
+            final Collection c = (Collection) result;
+            if (c.isEmpty()) {
+                // We have nothing to emit, so stop traversal.
+                throw FastNoSuchElementException.instance();
+            } else {
+                return (S) c.iterator().next();
+            }
+        } else {
+            return result;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return TraversalHelper.makeStepString(this, this.limit);
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategy.java
@@ -25,11 +25,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Bypassing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.match.MatchStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GraphStep;
@@ -84,12 +86,12 @@ public final class ComputerVerificationStrategy extends AbstractTraversalStrateg
                     throw new ComputerVerificationException("A final CollectingBarrierStep can not process an element beyond its id: " + endStep, traversal);
             }
             ///
-            if(endStep instanceof RangeGlobalStep)
-                ((RangeGlobalStep) endStep).setBypass(true);
+            if(endStep instanceof RangeGlobalStep || endStep instanceof TailGlobalStep)
+                ((Bypassing) endStep).setBypass(true);
         }
 
         for (final Step<?, ?> step : traversal.getSteps()) {
-            if ((step instanceof ReducingBarrierStep || step instanceof SupplyingBarrierStep || step instanceof OrderGlobalStep || step instanceof RangeGlobalStep) && (step != endStep || !(traversal.getParent() instanceof EmptyStep)))
+            if ((step instanceof ReducingBarrierStep || step instanceof SupplyingBarrierStep || step instanceof OrderGlobalStep || step instanceof RangeGlobalStep || step instanceof TailGlobalStep) && (step != endStep || !(traversal.getParent() instanceof EmptyStep)))
                 throw new ComputerVerificationException("Global traversals on GraphComputer may not contain mid-traversal barriers: " + step, traversal);
 
             if (step instanceof TraversalParent) {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.structure.T
+import org.apache.tinkerpop.gremlin.structure.Vertex
+
+import java.util.List
+import java.util.Map
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local
+
+/**
+ * @author Matt Frantz (http://github.com/mhfrantz)
+ */
+public abstract class GroovyTailTest {
+
+    public static class Traversals extends TailTest {
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_id_order_tailXglobal_2X() {
+            g.V.id.order.tail(global, 2)
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_id_order_tailX2X() {
+            g.V.id.order.tail(2)
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_id_order_tailX7X() {
+            g.V.id.order.tail(7)
+        }
+
+        @Override
+        public Traversal<Vertex, List<Object>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X() {
+            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().id.fold).tail(local, 2)
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X() {
+            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().id.fold).tail(local, 1)
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
+            g.V.as('a').out.as('a').out.as('a').select('a').by(limit(local, 0)).tail(local, 1)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X() {
+            g.V.as('a').out.as('b').out.as('c').select.by(T.id).tail(local, 2)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X() {
+            g.V.as('a').out.as('b').out.as('c').select.by(T.id).tail(local, 1)
+        }
+    }
+}

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -38,42 +38,42 @@ public abstract class GroovyTailTest {
     public static class Traversals extends TailTest {
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_id_order_tailXglobal_2X() {
-            g.V.id.order.tail(global, 2)
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailXglobal_2X() {
+            g.V.values('name').order.tail(global, 2)
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_id_order_tailX2X() {
-            g.V.id.order.tail(2)
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX2X() {
+            g.V.values('name').order.tail(2)
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_id_order_tailX7X() {
-            g.V.id.order.tail(7)
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
+            g.V.values('name').order.tail(7)
         }
 
         @Override
-        public Traversal<Vertex, List<Object>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X() {
-            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().id.fold).tail(local, 2)
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
+            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 2)
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X() {
-            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().id.fold).tail(local, 1)
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
+            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 1)
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
             g.V.as('a').out.as('a').out.as('a').select('a').by(limit(local, 0)).tail(local, 1)
         }
 
         @Override
-        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X() {
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_2X() {
             g.V.as('a').out.as('b').out.as('c').select.by(T.id).tail(local, 2)
         }
 
         @Override
-        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X() {
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_1X() {
             g.V.as('a').out.as('b').out.as('c').select.by(T.id).tail(local, 1)
         }
     }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex
 import java.util.List
 import java.util.Map
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold
 import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global
@@ -49,12 +50,17 @@ public abstract class GroovyTailTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tail() {
-            g.V.values('name')order.tail
+            g.V.values('name').order.tail
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
             g.V.values('name').order.tail(7)
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_tailX7X() {
+            g.V.repeat(both()).times(3).tail(7)
         }
 
         @Override

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -48,6 +48,11 @@ public abstract class GroovyTailTest {
         }
 
         @Override
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tail() {
+            g.V.values('name')order.tail
+        }
+
+        @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
             g.V.values('name').order.tail(7)
         }
@@ -60,6 +65,11 @@ public abstract class GroovyTailTest {
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
             g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 1)
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
+            g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local)
         }
 
         @Override

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -72,6 +72,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
             GroovyRangeTest.Traversals.class,
             GroovySampleTest.Traversals.class,
             GroovySimplePathTest.Traversals.class,
+            GroovyTailTest.Traversals.class,
             GroovyWhereTest.Traversals.class,
 
             // map

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessStandardSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessStandardSuite.java
@@ -42,6 +42,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.GroovyOrTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.GroovyRangeTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.GroovySampleTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.GroovySimplePathTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.GroovyTailTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.GroovyWhereTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyAddEdgeTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyAddVertexTest;
@@ -113,6 +114,7 @@ public class GroovyProcessStandardSuite extends ProcessStandardSuite {
             GroovyRangeTest.Traversals.class,
             GroovySampleTest.Traversals.class,
             GroovySimplePathTest.Traversals.class,
+            GroovyTailTest.Traversals.class,
             GroovyWhereTest.Traversals.class,
             // map
             GroovyAddEdgeTest.Traversals.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
@@ -76,6 +76,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             RangeTest.Traversals.class,
             SampleTest.Traversals.class,
             SimplePathTest.Traversals.class,
+            TailTest.Traversals.class,
             WhereTest.Traversals.class,
 
             // map
@@ -145,6 +146,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             RangeTest.class,
             SampleTest.class,
             SimplePathTest.class,
+            TailTest.class,
             WhereTest.class,
 
             // map

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessStandardSuite.java
@@ -41,6 +41,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.OrTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.SampleTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.SimplePathTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexTest;
@@ -119,6 +120,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             RangeTest.Traversals.class,
             SampleTest.Traversals.class,
             SimplePathTest.Traversals.class,
+            TailTest.Traversals.class,
             WhereTest.Traversals.class,
 
             // map
@@ -200,6 +202,7 @@ public class ProcessStandardSuite extends AbstractGremlinSuite {
             RangeTest.class,
             SampleTest.class,
             SimplePathTest.class,
+            TailTest.class,
             WhereTest.class,
 
             // map

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
+
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global;
+import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Original spec: https://issues.apache.org/jira/browse/TINKERPOP3-670
+ *
+ * @author Matt Frantz (http://github.com/mhfrantz)
+ */
+@RunWith(GremlinProcessRunner.class)
+public abstract class TailTest extends AbstractGremlinProcessTest {
+
+    public abstract Traversal<Vertex, Object> get_g_V_id_order_tailXglobal_2X();
+
+    public abstract Traversal<Vertex, Object> get_g_V_id_order_tailX2X();
+
+    public abstract Traversal<Vertex, Object> get_g_V_id_order_tailX7X();
+
+    public abstract Traversal<Vertex, List<Object>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X();
+
+    public abstract Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X();
+
+    public abstract Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
+
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X();
+
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X();
+
+    /** Scenario: Global scope */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_id_order_tailXglobal_2X() {
+        final Traversal<Vertex, Object> traversal = get_g_V_id_order_tailXglobal_2X();
+        printTraversalForm(traversal);
+        assertEquals(Arrays.asList(5, 6), traversal.toList());
+    }
+
+    /** Scenario: Default scope is global */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_id_order_tailX2X() {
+        final Traversal<Vertex, Object> traversal = get_g_V_id_order_tailX2X();
+        printTraversalForm(traversal);
+        assertEquals(Arrays.asList(5, 6), traversal.toList());
+    }
+
+    /** Scenario: Global scope, not enough elements */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_id_order_tailX7X() {
+        final Traversal<Vertex, Object> traversal = get_g_V_id_order_tailX7X();
+        printTraversalForm(traversal);
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6), traversal.toList());
+    }
+
+    /** Scenario: Local scope, List input, N>1 */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X() {
+        final Traversal<Vertex, List<Object>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X();
+        printTraversalForm(traversal);
+        final Set<List<Object>> expected =
+            new HashSet(Arrays.asList(
+                            Arrays.asList(4, 5),
+                            Arrays.asList(4, 3)));
+        final Set<List<Object>> actual = new HashSet(traversal.toList());
+        assertEquals(expected, actual);
+    }
+
+    /** Scenario: Local scope, List input, N=1 */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X() {
+        final Traversal<Vertex, Object> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X();
+        printTraversalForm(traversal);
+        final Set<Object> expected = new HashSet(Arrays.asList(5, 3));
+        final Set<Object> actual = new HashSet(traversal.toList());
+        assertEquals(expected, actual);
+    }
+
+    /** Scenario: Local scope, List input, N=1, empty input */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
+        final Traversal<Vertex, Object> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
+        printTraversalForm(traversal);
+        final Set<Object> expected = new HashSet();
+        final Set<Object> actual = new HashSet(traversal.toList());
+        assertEquals(expected, actual);
+    }
+
+    /** Scenario: Local scope, Map input, N>1 */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X();
+        printTraversalForm(traversal);
+        final Set<Map<String, Object>> expected = new HashSet(makeMapList(2,
+                 "b", 4, "c", 5,
+                 "b", 4, "c", 3));
+        final Set<Map<String, Object>> actual = new HashSet(traversal.toList());
+        assertEquals(expected, actual);
+    }
+
+    /** Scenario: Local scope, Map input, N=1 */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X();
+        printTraversalForm(traversal);
+        final Set<Map<String, Object>> expected = new HashSet(makeMapList(1,
+                 "c", 5,
+                 "c", 3));
+        final Set<Map<String, Object>> actual = new HashSet(traversal.toList());
+        assertEquals(expected, actual);
+    }
+
+    public static class Traversals extends TailTest {
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_id_order_tailXglobal_2X() {
+            return g.V().id().order().tail(global, 2);
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_id_order_tailX2X() {
+            return g.V().id().order().tail(2);
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_id_order_tailX7X() {
+            return g.V().id().order().tail(7);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Object>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X() {
+            return g.V().as("a").out().as("a").out().as("a").<List<Object>>select("a").by(unfold().id().fold()).tail(local, 2);
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X() {
+            return g.V().as("a").out().as("a").out().as("a").<Object>select("a").by(unfold().id().fold()).tail(local, 1);
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
+            return g.V().as("a").out().as("a").out().as("a").<Object>select("a").by(limit(local, 0)).tail(local, 1);
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X() {
+            return g.V().as("a").out().as("b").out().as("c").<Object>select().by(T.id).tail(local, 2);
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X() {
+            return g.V().as("a").out().as("b").out().as("c").<Object>select().by(T.id).tail(local, 1);
+        }
+    }
+}

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
@@ -48,71 +48,71 @@ import java.util.Set;
 @RunWith(GremlinProcessRunner.class)
 public abstract class TailTest extends AbstractGremlinProcessTest {
 
-    public abstract Traversal<Vertex, Object> get_g_V_id_order_tailXglobal_2X();
+    public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailXglobal_2X();
 
-    public abstract Traversal<Vertex, Object> get_g_V_id_order_tailX2X();
+    public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX2X();
 
-    public abstract Traversal<Vertex, Object> get_g_V_id_order_tailX7X();
+    public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X();
 
-    public abstract Traversal<Vertex, List<Object>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X();
+    public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
 
-    public abstract Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
 
-    public abstract Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
 
-    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X();
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_2X();
 
-    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X();
+    public abstract Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_1X();
 
     /** Scenario: Global scope */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_id_order_tailXglobal_2X() {
-        final Traversal<Vertex, Object> traversal = get_g_V_id_order_tailXglobal_2X();
+    public void g_V_valuesXnameX_order_tailXglobal_2X() {
+        final Traversal<Vertex, String> traversal = get_g_V_valuesXnameX_order_tailXglobal_2X();
         printTraversalForm(traversal);
-        assertEquals(Arrays.asList(5, 6), traversal.toList());
+        assertEquals(Arrays.asList("ripple", "vadas"), traversal.toList());
     }
 
     /** Scenario: Default scope is global */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_id_order_tailX2X() {
-        final Traversal<Vertex, Object> traversal = get_g_V_id_order_tailX2X();
+    public void g_V_valuesXnameX_order_tailX2X() {
+        final Traversal<Vertex, String> traversal = get_g_V_valuesXnameX_order_tailX2X();
         printTraversalForm(traversal);
-        assertEquals(Arrays.asList(5, 6), traversal.toList());
+        assertEquals(Arrays.asList("ripple", "vadas"), traversal.toList());
     }
 
     /** Scenario: Global scope, not enough elements */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_id_order_tailX7X() {
-        final Traversal<Vertex, Object> traversal = get_g_V_id_order_tailX7X();
+    public void g_V_valuesXnameX_order_tailX7X() {
+        final Traversal<Vertex, String> traversal = get_g_V_valuesXnameX_order_tailX7X();
         printTraversalForm(traversal);
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6), traversal.toList());
+        assertEquals(Arrays.asList("josh", "lop", "marko", "peter", "ripple", "vadas"), traversal.toList());
     }
 
     /** Scenario: Local scope, List input, N>1 */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X() {
-        final Traversal<Vertex, List<Object>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
+        final Traversal<Vertex, List<String>> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
         printTraversalForm(traversal);
-        final Set<List<Object>> expected =
+        final Set<List<String>> expected =
             new HashSet(Arrays.asList(
-                            Arrays.asList(4, 5),
-                            Arrays.asList(4, 3)));
-        final Set<List<Object>> actual = new HashSet(traversal.toList());
+                            Arrays.asList("josh", "ripple"),
+                            Arrays.asList("josh", "lop")));
+        final Set<List<String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
     /** Scenario: Local scope, List input, N=1 */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X() {
-        final Traversal<Vertex, Object> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X();
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
         printTraversalForm(traversal);
-        final Set<Object> expected = new HashSet(Arrays.asList(5, 3));
-        final Set<Object> actual = new HashSet(traversal.toList());
+        final Set<String> expected = new HashSet(Arrays.asList("ripple", "lop"));
+        final Set<String> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
@@ -120,79 +120,79 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
-        final Traversal<Vertex, Object> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
         printTraversalForm(traversal);
-        final Set<Object> expected = new HashSet();
-        final Set<Object> actual = new HashSet(traversal.toList());
+        final Set<String> expected = new HashSet();
+        final Set<String> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
     /** Scenario: Local scope, Map input, N>1 */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X() {
-        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X();
+    public void g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_2X() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_2X();
         printTraversalForm(traversal);
-        final Set<Map<String, Object>> expected = new HashSet(makeMapList(2,
-                 "b", 4, "c", 5,
-                 "b", 4, "c", 3));
-        final Set<Map<String, Object>> actual = new HashSet(traversal.toList());
+        final Set<Map<String, String>> expected = new HashSet(makeMapList(2,
+                 "b", "josh", "c", "ripple",
+                 "b", "josh", "c", "lop"));
+        final Set<Map<String, String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
     /** Scenario: Local scope, Map input, N=1 */
     @Test
     @LoadGraphWith(MODERN)
-    public void g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X() {
-        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X();
+    public void g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_1X() {
+        final Traversal<Vertex, Map<String, String>> traversal = get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_1X();
         printTraversalForm(traversal);
-        final Set<Map<String, Object>> expected = new HashSet(makeMapList(1,
-                 "c", 5,
-                 "c", 3));
-        final Set<Map<String, Object>> actual = new HashSet(traversal.toList());
+        final Set<Map<String, String>> expected = new HashSet(makeMapList(1,
+                 "c", "ripple",
+                 "c", "lop"));
+        final Set<Map<String, String>> actual = new HashSet(traversal.toList());
         assertEquals(expected, actual);
     }
 
     public static class Traversals extends TailTest {
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_id_order_tailXglobal_2X() {
-            return g.V().id().order().tail(global, 2);
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailXglobal_2X() {
+            return g.V().<String>values("name").order().tail(global, 2);
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_id_order_tailX2X() {
-            return g.V().id().order().tail(2);
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX2X() {
+            return g.V().<String>values("name").order().tail(2);
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_id_order_tailX7X() {
-            return g.V().id().order().tail(7);
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
+            return g.V().<String>values("name").order().tail(7);
         }
 
         @Override
-        public Traversal<Vertex, List<Object>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_2X() {
-            return g.V().as("a").out().as("a").out().as("a").<List<Object>>select("a").by(unfold().id().fold()).tail(local, 2);
+        public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
+            return g.V().as("a").out().as("a").out().as("a").<List<String>>select("a").by(unfold().values("name").fold()).tail(local, 2);
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_id_foldX_tailXlocal_1X() {
-            return g.V().as("a").out().as("a").out().as("a").<Object>select("a").by(unfold().id().fold()).tail(local, 1);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(unfold().values("name").fold()).tail(local, 1);
         }
 
         @Override
-        public Traversal<Vertex, Object> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
-            return g.V().as("a").out().as("a").out().as("a").<Object>select("a").by(limit(local, 0)).tail(local, 1);
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(limit(local, 0)).tail(local, 1);
         }
 
         @Override
-        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_2X() {
-            return g.V().as("a").out().as("b").out().as("c").<Object>select().by(T.id).tail(local, 2);
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_2X() {
+            return g.V().as("a").out().as("b").out().as("c").<String>select().by("name").tail(local, 2);
         }
 
         @Override
-        public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXT_idX_tailXlocal_1X() {
-            return g.V().as("a").out().as("b").out().as("c").<Object>select().by(T.id).tail(local, 1);
+        public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_select_byXnameX_tailXlocal_1X() {
+            return g.V().as("a").out().as("b").out().as("c").<String>select().by("name").tail(local, 1);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
@@ -52,11 +52,15 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX2X();
 
+    public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tail();
+
     public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X();
 
     public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
 
     public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
+
+    public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX();
 
     public abstract Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X();
 
@@ -80,6 +84,15 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         final Traversal<Vertex, String> traversal = get_g_V_valuesXnameX_order_tailX2X();
         printTraversalForm(traversal);
         assertEquals(Arrays.asList("ripple", "vadas"), traversal.toList());
+    }
+
+    /** Scenario: Default is global, N=1 */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_valuesXnameX_order_tail() {
+        final Traversal<Vertex, String> traversal = get_g_V_valuesXnameX_order_tail();
+        printTraversalForm(traversal);
+        assertEquals(Arrays.asList("vadas"), traversal.toList());
     }
 
     /** Scenario: Global scope, not enough elements */
@@ -110,6 +123,17 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
     @LoadGraphWith(MODERN)
     public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
         final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X();
+        printTraversalForm(traversal);
+        final Set<String> expected = new HashSet(Arrays.asList("ripple", "lop"));
+        final Set<String> actual = new HashSet(traversal.toList());
+        assertEquals(expected, actual);
+    }
+
+    /** Scenario: Local scope, List input, default N=1 */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
+        final Traversal<Vertex, String> traversal = get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX();
         printTraversalForm(traversal);
         final Set<String> expected = new HashSet(Arrays.asList("ripple", "lop"));
         final Set<String> actual = new HashSet(traversal.toList());
@@ -166,6 +190,11 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         }
 
         @Override
+        public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tail() {
+            return g.V().<String>values("name").order().tail();
+        }
+
+        @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
             return g.V().<String>values("name").order().tail(7);
         }
@@ -178,6 +207,11 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
             return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(unfold().values("name").fold()).tail(local, 1);
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
+            return g.V().as("a").out().as("a").out().as("a").<String>select("a").by(unfold().values("name").fold()).tail(local);
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/TailTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold;
 import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global;
@@ -55,6 +56,8 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tail();
 
     public abstract Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X();
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_tailX7X();
 
     public abstract Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X();
 
@@ -102,6 +105,20 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         final Traversal<Vertex, String> traversal = get_g_V_valuesXnameX_order_tailX7X();
         printTraversalForm(traversal);
         assertEquals(Arrays.asList("josh", "lop", "marko", "peter", "ripple", "vadas"), traversal.toList());
+    }
+
+    /** Scenario: Global scope, using repeat (BULK) */
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_repeatXbothX_timesX3X_tailX7X() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_repeatXbothX_timesX3X_tailX7X();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            traversal.next();
+            counter++;
+        }
+        assertEquals(7, counter);
     }
 
     /** Scenario: Local scope, List input, N>1 */
@@ -197,6 +214,11 @@ public abstract class TailTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
             return g.V().<String>values("name").order().tail(7);
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_tailX7X() {
+            return g.V().repeat(both()).times(3).tail(7);
         }
 
         @Override


### PR DESCRIPTION
Replaces PR #60 

Based on feedback on the initial PR:
* correctly (I hope) tested and implemented "bulk" support
* `ComputerVerificationStrategy` balks at mid-traversal global tail steps
* `__` (anonymous traversals) include `tail` methods
* deferred execution during MR (using `Bypassing`)

The hadoop-gremlin tests pass for me.