### PR TITLE
TINKERPOP3-713 Remove dependency on groovy-console which contains creative commons licenses

### DIFF
--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -41,7 +41,19 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-sql</artifactId>
             <version>${groovy.version}</version>
             <classifier>indy</classifier>
         </dependency>

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -38,15 +38,28 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
             <classifier>indy</classifier>
         </dependency>
-        <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-            <version>2.11</version>
-        </dependency>
+       <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-groovysh</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+       </dependency>
+       <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+       </dependency>
+       <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+       </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/hadoop-gremlin/src/assembly/hadoop-job.xml
+++ b/hadoop-gremlin/src/assembly/hadoop-job.xml
@@ -27,6 +27,7 @@ limitations under the License.
             <outputDirectory>lib</outputDirectory>
             <excludes>
                 <exclude>${groupId}:${artifactId}</exclude>
+                <exclude>com.google.code.findbugs:jsr305</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>

--- a/hadoop-gremlin/src/assembly/standalone.xml
+++ b/hadoop-gremlin/src/assembly/standalone.xml
@@ -38,6 +38,9 @@ limitations under the License.
             <outputDirectory>/lib</outputDirectory>
             <unpack>false</unpack>
             <scope>compile</scope>
+            <excludes>
+               <exclude>com.google.code.findbugs:jsr305</exclude>
+            </excludes>
         </dependencySet>
         <dependencySet>
             <outputDirectory>/lib</outputDirectory>


### PR DESCRIPTION
Updates two pom files - for gremlin-groovy and gremlin-driver to remove the groovy-all and use specific groovy files needed.

Also removed jline dependency from gremlin-groovy - not needed and also caused version conflicts.