### PR TITLE
TINKERPOP3-714 Exclude jsr305 jar in assemblies to prevent jsr305 cc license from ap…

### DIFF
--- a/hadoop-gremlin/src/assembly/hadoop-job.xml
+++ b/hadoop-gremlin/src/assembly/hadoop-job.xml
@@ -27,6 +27,7 @@ limitations under the License.
             <outputDirectory>lib</outputDirectory>
             <excludes>
                 <exclude>${groupId}:${artifactId}</exclude>
+                <exclude>com.google.code.findbugs:jsr305</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>

--- a/hadoop-gremlin/src/assembly/standalone.xml
+++ b/hadoop-gremlin/src/assembly/standalone.xml
@@ -38,6 +38,9 @@ limitations under the License.
             <outputDirectory>/lib</outputDirectory>
             <unpack>false</unpack>
             <scope>compile</scope>
+            <excludes>
+               <exclude>com.google.code.findbugs:jsr305</exclude>
+            </excludes>
         </dependencySet>
         <dependencySet>
             <outputDirectory>/lib</outputDirectory>


### PR DESCRIPTION
Excludes jsr305 jar from standalone and -job.jar to eliminate distribution of creative commons licensed files.