### PR TITLE
TinkerPop-713: use specific groovy dependencies, remove cc license on…

### DIFF
--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -41,7 +41,19 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-sql</artifactId>
             <version>${groovy.version}</version>
             <classifier>indy</classifier>
         </dependency>

--- a/gremlin-groovy/pom.xml
+++ b/gremlin-groovy/pom.xml
@@ -38,14 +38,27 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
             <classifier>indy</classifier>
         </dependency>
         <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-            <version>2.11</version>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-groovysh</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>${groovy.version}</version>
+            <classifier>indy</classifier>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Remove the groovy-all dependency and use specific groovy dependencies.
This eliminates the creative commons icons contained in the groovy-console
jar from the project, and makes dependencies more explicitly.


Results from build and tests:
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Apache TinkerPop ................................... SUCCESS [  3.210 s]
[INFO] Apache TinkerPop :: Gremlin Shaded ................. SUCCESS [  1.111 s]
[INFO] Apache TinkerPop :: Gremlin Core ................... SUCCESS [ 25.459 s]
[INFO] Apache TinkerPop :: Gremlin Test ................... SUCCESS [  9.672 s]
[INFO] Apache TinkerPop :: Gremlin Groovy ................. SUCCESS [ 23.639 s]
[INFO] Apache TinkerPop :: Gremlin Groovy Test ............ SUCCESS [  5.137 s]
[INFO] Apache TinkerPop :: TinkerGraph Gremlin ............ SUCCESS [ 45.772 s]
[INFO] Apache TinkerPop :: Hadoop Gremlin ................. SUCCESS [02:35 min]
[INFO] Apache TinkerPop :: Neo4j Gremlin .................. SUCCESS [  2.612 s]
[INFO] Apache TinkerPop :: Gremlin Driver ................. SUCCESS [  4.630 s]
[INFO] Apache TinkerPop :: Gremlin Server ................. SUCCESS [  4.236 s]
[INFO] Apache TinkerPop :: Gremlin Console ................ SUCCESS [ 15.279 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
