### PR TITLE
TINKERPOP-714 - remove jsr305 from standalone and job jar

### DIFF
--- a/hadoop-gremlin/src/assembly/hadoop-job.xml
+++ b/hadoop-gremlin/src/assembly/hadoop-job.xml
@@ -27,6 +27,7 @@ limitations under the License.
             <outputDirectory>lib</outputDirectory>
             <excludes>
                 <exclude>${groupId}:${artifactId}</exclude>
+                <exclude>com.google.code.findbugs:jsr305</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>

--- a/hadoop-gremlin/src/assembly/standalone.xml
+++ b/hadoop-gremlin/src/assembly/standalone.xml
@@ -38,6 +38,9 @@ limitations under the License.
             <outputDirectory>/lib</outputDirectory>
             <unpack>false</unpack>
             <scope>compile</scope>
+            <excludes>
+               <exclude>com.google.code.findbugs:jsr305</exclude>
+            </excludes>
         </dependencySet>
         <dependencySet>
             <outputDirectory>/lib</outputDirectory>


### PR DESCRIPTION
excluding jsr305 from packaging and standalone because it has a creative commons license in it.
Plus, as a static analysis jar, this should not be needed for run times.

Here are the results from the mvn clean install (with test cases):
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Apache TinkerPop ................................... SUCCESS [  2.920 s]
[INFO] Apache TinkerPop :: Gremlin Shaded ................. SUCCESS [  1.032 s]
[INFO] Apache TinkerPop :: Gremlin Core ................... SUCCESS [ 25.428 s]
[INFO] Apache TinkerPop :: Gremlin Test ................... SUCCESS [ 10.694 s]
[INFO] Apache TinkerPop :: Gremlin Groovy ................. SUCCESS [ 23.034 s]
[INFO] Apache TinkerPop :: Gremlin Groovy Test ............ SUCCESS [  4.931 s]
[INFO] Apache TinkerPop :: TinkerGraph Gremlin ............ SUCCESS [ 41.566 s]
[INFO] Apache TinkerPop :: Hadoop Gremlin ................. SUCCESS [02:23 min]
[INFO] Apache TinkerPop :: Neo4j Gremlin .................. SUCCESS [  2.809 s]
[INFO] Apache TinkerPop :: Gremlin Driver ................. SUCCESS [  4.425 s]
[INFO] Apache TinkerPop :: Gremlin Server ................. SUCCESS [  4.417 s]
[INFO] Apache TinkerPop :: Gremlin Console ................ SUCCESS [ 15.072 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
