### PR TITLE
TINKERPOP3-700 Path getSingle/getList improvements

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
@@ -119,7 +119,7 @@ public interface Path extends Cloneable {
     /**
      * Get the object most/least recently associated with the particular label of the path.
      *
-     * @param pop   head for most recent, tail for least recent
+     * @param pop   head for least recent, tail for most recent
      * @param label the label of the path
      * @param <A>   the type of the object associated with the label
      * @return the object associated with the label of the path
@@ -128,7 +128,7 @@ public interface Path extends Cloneable {
     public default <A> A getSingle(final Pop pop, final String label) throws IllegalArgumentException {
         final Object object = this.get(label);
         if (object instanceof List) {
-            return Pop.head == pop ? ((List<A>) object).get(((List) object).size() - 1) : ((List<A>) object).get(0);
+            return Pop.tail == pop ? ((List<A>) object).get(((List) object).size() - 1) : ((List<A>) object).get(0);
         } else
             return (A) object;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Path.java
@@ -97,6 +97,13 @@ public interface Path extends Cloneable {
         return (A) object;
     }
 
+    /**
+     * Get the list of objects associated with the particular label of the path.
+     *
+     * @param label the label of the path
+     * @param <A>   the type of the object associated with the label
+     * @return the list of objects (List<A>) associated with the label of the path, or empty list if label is not found
+     */
     public default <A> List<A> getList(final String label) throws IllegalArgumentException {
         if (this.hasLabel(label)) {
             final Object object = this.get(label);
@@ -109,6 +116,15 @@ public interface Path extends Cloneable {
         }
     }
 
+    /**
+     * Get the object most/least recently associated with the particular label of the path.
+     *
+     * @param pop   head for most recent, tail for least recent
+     * @param label the label of the path
+     * @param <A>   the type of the object associated with the label
+     * @return the object associated with the label of the path
+     * @throws IllegalArgumentException if the path does not contain the label
+     */
     public default <A> A getSingle(final Pop pop, final String label) throws IllegalArgumentException {
         final Object object = this.get(label);
         if (object instanceof List) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePathImpl.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ImmutablePathImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.process.traversal.step.util;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+
+/**
+ * Internal interface used by ImmutablePath to provide more efficient implementation.
+ *
+ * @author Matt Frantz (http://github.com/mhfrantz)
+ */
+interface ImmutablePathImpl extends Path {
+
+    @Override
+    public default <A> A getSingle(final Pop pop, final String label) {
+        // Delegate to the non-throwing, optimized head/tail calculations.
+        final A single = Pop.tail == pop ? this.getSingleTail(label) : this.getSingleHead(label);
+        // Throw if we didn't find the label.
+        if (null == single)
+            throw Path.Exceptions.stepWithProvidedLabelDoesNotExist(label);
+        return single;
+    }
+
+    /**
+     * Get the object least recently associated with the particular label of the path.
+     *
+     * @param label the label of the path
+     * @param <A>   the type of the object associated with the label
+     * @return the object associated with the label of the path or null if the path does not contain the label
+     */
+    public <A> A getSingleHead(String label);
+
+    /**
+     * Get the object most recently associated with the particular label of the path.
+     *
+     * @param label the label of the path
+     * @param <A>   the type of the object associated with the label
+     * @return the object associated with the label of the path or null if the path does not contain the label
+     */
+    public <A> A getSingleTail(String label);
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/MutablePath.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -78,6 +79,23 @@ public class MutablePath implements Path, Serializable {
     @Override
     public <A> A get(int index) {
         return (A) this.objects.get(index);
+    }
+
+    @Override
+    public <A> A getSingle(final Pop pop, final String label) {
+        // Override default to avoid building temporary list, and to stop looking when we find the label.
+        if (Pop.tail == pop) {
+            for (int i = this.labels.size() - 1; i >= 0; i--) {
+                if (labels.get(i).contains(label))
+                    return (A) objects.get(i);
+            }
+        } else {
+            for (int i = 0; i != this.labels.size(); i++) {
+                if (labels.get(i).contains(label))
+                    return (A) objects.get(i);
+            }
+        }
+        throw Path.Exceptions.stepWithProvidedLabelDoesNotExist(label);
     }
 
     @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/PathTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/PathTest.java
@@ -175,15 +175,15 @@ public class PathTest extends AbstractGremlinProcessTest {
             path = path.extend("stephen", "a", "c");
             path = path.extend("matthias", "c", "d");
             assertEquals(3, path.size());
-            assertEquals("marko", path.getSingle(Pop.tail, "a"));
-            assertEquals("marko", path.getSingle(Pop.tail, "b"));
-            assertEquals("stephen", path.getSingle(Pop.tail, "c"));
-            assertEquals("matthias", path.getSingle(Pop.tail, "d"));
-            ///
+            assertEquals("marko", path.getSingle(Pop.head, "a"));
             assertEquals("marko", path.getSingle(Pop.head, "b"));
-            assertEquals("stephen", path.getSingle(Pop.head, "a"));
-            assertEquals("matthias", path.getSingle(Pop.head, "c"));
+            assertEquals("stephen", path.getSingle(Pop.head, "c"));
             assertEquals("matthias", path.getSingle(Pop.head, "d"));
+            ///
+            assertEquals("marko", path.getSingle(Pop.tail, "b"));
+            assertEquals("stephen", path.getSingle(Pop.tail, "a"));
+            assertEquals("matthias", path.getSingle(Pop.tail, "c"));
+            assertEquals("matthias", path.getSingle(Pop.tail, "d"));
         });
     }
 


### PR DESCRIPTION
As requested in the comments of TINKERPOP3-700.  I also reversed the sense of `Pop` to align with `tail(local)`.  Thus `Pop.tail` now means the most recent value.