### PR TITLE
TINKERPOP-714

### DIFF
--- a/hadoop-gremlin/pom.xml
+++ b/hadoop-gremlin/pom.xml
@@ -168,6 +168,10 @@ limitations under the License.
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>findbugs</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- consistent dependencies -->


### PR DESCRIPTION
removing jsr305 from hadoop-gremlin standalone and distribution in the pom.xml rather than the assembly because marko's a nice guy...plus he won't accept the fix in the assembly files  :-) 