### PR TITLE
TINKERPOP3-779: RFC for coalesce retain path

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
@@ -60,7 +60,7 @@ public final class CoalesceStep<S, E> extends FlatMapStep<S, E> implements Trave
     }
 
     @Override
-    public List<Traversal.Admin<S, E>> getLocalChildren() {
+    public List<Traversal.Admin<S, E>> getGlobalChildren() {
         return Collections.unmodifiableList(this.coalesceTraversals);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ComputerAwareStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
@@ -30,7 +31,7 @@ import java.util.*;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class CoalesceStep<S, E> extends FlatMapStep<S, E> implements TraversalParent {
+public final class CoalesceStep<S, E> extends ComputerAwareStep<S, E> implements TraversalParent {
 
     private List<Traversal.Admin<S, E>> coalesceTraversals;
 
@@ -39,19 +40,35 @@ public final class CoalesceStep<S, E> extends FlatMapStep<S, E> implements Trave
         super(traversal);
         this.coalesceTraversals = Arrays.asList(coalesceTraversals);
         for (final Traversal.Admin<S, ?> conjunctionTraversal : this.coalesceTraversals) {
+            conjunctionTraversal.addStep(new EndStep(conjunctionTraversal));
             this.integrateChild(conjunctionTraversal);
         }
     }
 
     @Override
-    protected Iterator<E> flatMap(final Traverser.Admin<S> traverser) {
+    protected Iterator<Traverser<E>> standardAlgorithm() {
+        final Traverser.Admin<S> start = this.starts.next();
         for (final Traversal.Admin<S, E> coalesceTraversal : this.coalesceTraversals) {
             coalesceTraversal.reset();
-            coalesceTraversal.addStart(traverser.asAdmin().split());
-            if (coalesceTraversal.hasNext())
-                return coalesceTraversal;
+            coalesceTraversal.addStart(start.split());
+            if (coalesceTraversal.getEndStep().hasNext())
+                return coalesceTraversal.getEndStep();
         }
         return EmptyIterator.instance();
+    }
+
+    @Override
+    protected Iterator<Traverser<E>> computerAlgorithm() {
+        // TODO: How to stop after the first successful option?
+        final List<Traverser<E>> ends = new ArrayList<>();
+        final Traverser.Admin<S> start = this.starts.next();
+        this.coalesceTraversals.forEach(
+            coalesceTraversal -> {
+                final Traverser.Admin<E> split = (Traverser.Admin<E>) start.split();
+                split.setStepId(coalesceTraversal.getStartStep().getId());
+                ends.add(split);
+            });
+        return ends.iterator();
     }
 
     @Override

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCoalesceTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCoalesceTest.groovy
@@ -55,5 +55,10 @@ public abstract class GroovyCoalesceTest {
         Traversal<Vertex, Path> get_g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX() {
             TraversalScriptHelper.compute("g.V.coalesce(outE('knows'), outE('created')).otherV.path.by('name').by(T.label)", g)
         }
+
+        @Override
+        Traversal<Vertex, Path> get_g_V_coalesceXout_outX_path() {
+            TraversalScriptHelper.compute("g.V.coalesce(out.out).path", g);
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CoalesceTest.java
@@ -55,6 +55,8 @@ public abstract class CoalesceTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Path> get_g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX();
 
+    public abstract Traversal<Vertex, Path> get_g_V_coalesceXout_outX_path();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_coalesceXoutXfooX_outXbarXX() {
@@ -89,7 +91,7 @@ public abstract class CoalesceTest extends AbstractGremlinProcessTest {
         assertTrue(traversal.hasNext());
         final Map<String, Long> result = traversal.next();
         assertEquals(4, result.size());
-        assertTrue(result.containsKey("josh") && result.containsKey("lop") && result.containsKey("ripple") && result.containsKey("vadas"));
+        assertTrue(result.keySet().toString(), result.containsKey("josh") && result.containsKey("lop") && result.containsKey("ripple") && result.containsKey("vadas"));
         assertEquals(1L, (long) result.get("josh"));
         assertEquals(2L, (long) result.get("lop"));
         assertEquals(1L, (long) result.get("ripple"));
@@ -111,7 +113,8 @@ public abstract class CoalesceTest extends AbstractGremlinProcessTest {
             first.compute(path.<String>get(0), (k, v) -> v != null ? v + 1 : 1);
             last.compute(path.<String>get(2), (k, v) -> v != null ? v + 1 : 1);
             assertEquals(3, path.size());
-            assertTrue((path.<String>get(0).equals("marko") && path.<String>get(1).equals("knows") && path.<String>get(2).equals("vadas"))
+            assertTrue(path.toString(),
+                       (path.<String>get(0).equals("marko") && path.<String>get(1).equals("knows") && path.<String>get(2).equals("vadas"))
                     || (path.<String>get(0).equals("marko") && path.<String>get(1).equals("knows") && path.<String>get(2).equals("josh"))
                     || (path.<String>get(0).equals("josh") && path.<String>get(1).equals("created") && path.<String>get(2).equals("lop"))
                     || (path.<String>get(0).equals("josh") && path.<String>get(1).equals("created") && path.<String>get(2).equals("ripple"))
@@ -126,6 +129,20 @@ public abstract class CoalesceTest extends AbstractGremlinProcessTest {
         assertEquals(2, (int) last.get("lop"));
         assertEquals(1, (int) last.get("ripple"));
         assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_coalesceXout_outX_path() {
+        final Traversal<Vertex, Path> traversal = get_g_V_coalesceXout_outX_path();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            ++counter;
+            final Path path = traversal.next();
+            assertEquals(3, path.size());
+        }
+        assertEquals(2, counter);
     }
 
     public static class Traversals extends CoalesceTest {
@@ -152,6 +169,11 @@ public abstract class CoalesceTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Path> get_g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX() {
             return g.V().coalesce(outE("knows"), outE("created")).otherV().path().by("name").by(T.label);
+        }
+
+        @Override
+        public Traversal<Vertex, Path> get_g_V_coalesceXout_outX_path() {
+            return g.V().coalesce(out().out()).path();
         }
     }
 }


### PR DESCRIPTION
I tried to make some progress on this.  First, I added unit test to reproduce the bug.

I then changed the child traversals from local to global, based on the fact that BranchStep shows its branch traversals as global.  I'm not entirely sure what this does, and it had no effect on the test.

Next, I tried to reimplement CoalesceStep using ComputerAwareStep (instead of FlatMapStep).  This seems necessary, since the child traversals can do whatever they want.  My test now passes in "standard" mode, but fails in "computer" mode.

In "computer" mode, I'm not sure how to implement the sequential "first successful child" logic.  What's in there now is "follow all paths" logic.  If it appears that I am on the right track, I can work more on this.
