### PR TITLE
trivial patch to add extra feature requirement on EdgeTest.shouldGetPropertyKeysOnEdge()

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
@@ -215,6 +215,7 @@ public class EdgeTest {
 
         @Test
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
+        @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_REMOVE_PROPERTY)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = Graph.Features.EdgePropertyFeatures.class, feature = FEATURE_STRING_VALUES)
         public void shouldGetPropertyKeysOnEdge() {


### PR DESCRIPTION
I'm not supporting property deletes yet in my TP implementation, and this test requires that feature. Thus, indicate it with the FeatureRequirement annotation.