### PR TITLE
TINKERPOP3-850: Reduce Graph.addVertex overload ambiguity

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/ComputerGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/ComputerGraph.java
@@ -74,7 +74,7 @@ public final class ComputerGraph implements Graph {
     }
 
     @Override
-    public Vertex addVertex(final Object... keyValues) {
+    public Vertex addVertex(final Object[] keyValues) {
         throw new UnsupportedOperationException();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -107,14 +107,40 @@ public interface Graph extends AutoCloseable, Host {
     }
 
     /**
-     * Add a {@link Vertex} to the graph given an optional series of key/value pairs.  These key/values
-     * must be provided in an even number where the odd numbered arguments are {@link String} property keys and the
-     * even numbered arguments are the related property values.
+     * Add a {@link Vertex} to the graph with default label and no properties.
+     * @return The newly created vertex
+     */
+    public default Vertex addVertex() {
+        return this.addVertex(T.label, Vertex.DEFAULT_LABEL);
+    }
+
+    /**
+     * Add a {@link Vertex} to the graph given a series of key/value pairs.  These key/values must be provided in an
+     * even number where the odd numbered arguments are {@link String} property keys or {@link T} tokens and the even
+     * numbered arguments are the related values.
+     *
+     * @param key {@link String} property key or {@link T} token
+     * @param value Value related to key
+     * @param keyValues Additional key/value pairs to turn into vertex properties
+     * @return The newly created vertex
+     */
+    public default Vertex addVertex(final Object key, final Object value, final Object... keyValues) {
+        final Object[] allKeyValues = new Object[2 + keyValues.length];
+        allKeyValues[0] = key;
+        allKeyValues[1] = value;
+        System.arraycopy(keyValues, 0, allKeyValues, 2, keyValues.length);
+        return this.addVertex(allKeyValues);
+    }
+
+    /**
+     * Add a {@link Vertex} to the graph given an optional series of key/value pairs.  These key/values must be
+     * provided in an even number where the odd numbered arguments are {@link String} property keys or {@link T}
+     * tokens and the even numbered arguments are the related values.
      *
      * @param keyValues The key/value pairs to turn into vertex properties
      * @return The newly created vertex
      */
-    public Vertex addVertex(final Object... keyValues);
+    public Vertex addVertex(final Object[] keyValues);
 
     /**
      * Add a {@link Vertex} to the graph with provided vertex label.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/empty/EmptyGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/empty/EmptyGraph.java
@@ -52,7 +52,7 @@ public final class EmptyGraph implements Graph {
     }
 
     @Override
-    public Vertex addVertex(final Object... keyValues) {
+    public Vertex addVertex(final Object[] keyValues) {
         throw Exceptions.vertexAdditionsNotSupported();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -84,7 +84,7 @@ public final class StarGraph implements Graph, Serializable {
     }
 
     @Override
-    public Vertex addVertex(final Object... keyValues) {
+    public Vertex addVertex(final Object[] keyValues) {
         if (null == this.starVertex) {
             ElementHelper.legalPropertyKeyValueArray(keyValues);
             this.starVertex = new StarVertex(ElementHelper.getIdValue(keyValues).orElse(this.nextId()), ElementHelper.getLabelValue(keyValues).orElse(Vertex.DEFAULT_LABEL));

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/GraphFactoryTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/util/GraphFactoryTest.java
@@ -434,7 +434,7 @@ public class GraphFactoryTest {
         }
 
         @Override
-        public Vertex addVertex(Object... keyValues) {
+        public Vertex addVertex(Object[] keyValues) {
             return null;
         }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -649,6 +649,7 @@ public class GraphTest extends AbstractGremlinTest {
 
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_MULTI_PROPERTIES, supported = false)
     public void shouldOverwriteEarlierKeyValuesWithLaterKeyValuesOnAddVertexIfNoMultiProperty() {
         final Vertex v = graph.addVertex("test", "A", "test", "B", "test", "C");
@@ -660,6 +661,7 @@ public class GraphTest extends AbstractGremlinTest {
 
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_MULTI_PROPERTIES)
     public void shouldOverwriteEarlierKeyValuesWithLaterKeyValuesOnAddVertexIfMultiProperty() {
         final Vertex v = graph.addVertex("test", "A", "test", "B", "test", "C");

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -663,7 +663,7 @@ public class GraphTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_MULTI_PROPERTIES)
-    public void shouldOverwriteEarlierKeyValuesWithLaterKeyValuesOnAddVertexIfMultiProperty() {
+    public void shouldAppendKeyValuesWithLaterKeyValuesOnAddVertexIfMultiProperty() {
         final Vertex v = graph.addVertex("test", "A", "test", "B", "test", "C");
         tryCommit(graph, graph -> {
             assertEquals(3, IteratorUtils.count(v.properties("test")));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
@@ -649,11 +650,107 @@ public class GraphTest extends AbstractGremlinTest {
 
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    public void shouldHaveDefaultLabelAndNoPropertiesOnAddVertex() {
+        final Vertex v = graph.addVertex();
+        tryCommit(graph, graph -> {
+            assertEquals(Vertex.DEFAULT_LABEL, v.label());
+            assertEquals(0, IteratorUtils.count(v.properties()));
+        });
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    public void shouldSaveLabelOnAddVertex() {
+        final Vertex v = graph.addVertex("theLabel");
+        tryCommit(graph, graph -> {
+            assertEquals("theLabel", v.label());
+            assertEquals(0, IteratorUtils.count(v.properties()));
+        });
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    public void shouldSaveLabelSpecifiedWithTOnAddVertex() {
+        final Vertex v = graph.addVertex(T.label, "theLabel");
+        tryCommit(graph, graph -> {
+            assertEquals("theLabel", v.label());
+            assertEquals(0, IteratorUtils.count(v.properties()));
+        });
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
+    public void shouldSaveSinglePropertyOnAddVertex() {
+        final Vertex v = graph.addVertex("keyA", "valueA");
+        tryCommit(graph, graph -> {
+            assertEquals(Vertex.DEFAULT_LABEL, v.label());
+            assertEquals(1, IteratorUtils.count(v.properties()));
+            assertTrue(IteratorUtils.stream(v.values("keyA")).allMatch(t -> t.equals("valueA")));
+        });
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
+    public void shouldSaveSeveralPropertiesOnAddVertex() {
+        final Vertex v = graph.addVertex("keyA", "valueA", "keyB", "valueB", "keyC", "valueC");
+        tryCommit(graph, graph -> {
+            assertEquals(Vertex.DEFAULT_LABEL, v.label());
+            assertEquals(3, IteratorUtils.count(v.properties()));
+            assertTrue(IteratorUtils.stream(v.values("keyA")).allMatch(t -> t.equals("valueA")));
+            assertTrue(IteratorUtils.stream(v.values("keyB")).allMatch(t -> t.equals("valueB")));
+            assertTrue(IteratorUtils.stream(v.values("keyC")).allMatch(t -> t.equals("valueC")));
+        });
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
+    public void shouldAllowLabelAfterSeveralPropertiesOnAddVertex() {
+        final Vertex v = graph.addVertex("keyA", "valueA", "keyB", "valueB", T.label, "theLabel");
+        tryCommit(graph, graph -> {
+            assertEquals("theLabel", v.label());
+            assertEquals(2, IteratorUtils.count(v.properties()));
+            assertTrue(IteratorUtils.stream(v.values("keyA")).allMatch(t -> t.equals("valueA")));
+            assertTrue(IteratorUtils.stream(v.values("keyB")).allMatch(t -> t.equals("valueB")));
+        });
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
+    public void shouldRejectOddNumberedArgListOnAddVertex() {
+        try {
+            graph.addVertex("keyA", "valueA", "keyB");
+            fail("IllegalArgumentException expected");
+        } catch (Exception exc) {
+            assertThat(exc, instanceOf(IllegalArgumentException.class));
+            assertThat(exc.toString(), containsString("The provided key/value array length must be a multiple of two"));
+        }
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
+    public void shouldRejectWrongKeyTypeOnAddVertex() {
+        try {
+            graph.addVertex(123, "valueA");
+            fail("IllegalArgumentException expected");
+        } catch (Exception exc) {
+            assertThat(exc, instanceOf(IllegalArgumentException.class));
+            assertThat(exc.toString(), containsString("The provided key/value array must have a String or T on even array indices"));
+        }
+    }
+
+    @Test
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = Graph.Features.DataTypeFeatures.FEATURE_STRING_VALUES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_MULTI_PROPERTIES, supported = false)
     public void shouldOverwriteEarlierKeyValuesWithLaterKeyValuesOnAddVertexIfNoMultiProperty() {
         final Vertex v = graph.addVertex("test", "A", "test", "B", "test", "C");
         tryCommit(graph, graph -> {
+            assertEquals(Vertex.DEFAULT_LABEL, v.label());
             assertEquals(1, IteratorUtils.count(v.properties("test")));
             assertTrue(IteratorUtils.stream(v.values("test")).anyMatch(t -> t.equals("C")));
         });
@@ -666,6 +763,7 @@ public class GraphTest extends AbstractGremlinTest {
     public void shouldAppendKeyValuesWithLaterKeyValuesOnAddVertexIfMultiProperty() {
         final Vertex v = graph.addVertex("test", "A", "test", "B", "test", "C");
         tryCommit(graph, graph -> {
+            assertEquals(Vertex.DEFAULT_LABEL, v.label());
             assertEquals(3, IteratorUtils.count(v.properties("test")));
             assertTrue(IteratorUtils.stream(v.values("test")).anyMatch(t -> t.equals("A")));
             assertTrue(IteratorUtils.stream(v.values("test")).anyMatch(t -> t.equals("B")));

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopGraph.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/HadoopGraph.java
@@ -176,7 +176,7 @@ public final class HadoopGraph implements Graph {
     }
 
     @Override
-    public Vertex addVertex(final Object... keyValues) {
+    public Vertex addVertex(final Object[] keyValues) {
         throw Exceptions.vertexAdditionsNotSupported();
     }
 

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jGraph.java
@@ -161,7 +161,7 @@ public final class Neo4jGraph implements Graph, WrappedGraph<Neo4jGraphAPI> {
     }
 
     @Override
-    public Vertex addVertex(final Object... keyValues) {
+    public Vertex addVertex(final Object[] keyValues) {
         ElementHelper.legalPropertyKeyValueArray(keyValues);
         if (ElementHelper.getIdValue(keyValues).isPresent())
             throw Vertex.Exceptions.userSuppliedIdsNotSupported();

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -158,7 +158,7 @@ public final class TinkerGraph implements Graph {
     ////////////// STRUCTURE API METHODS //////////////////
 
     @Override
-    public Vertex addVertex(final Object... keyValues) {
+    public Vertex addVertex(final Object[] keyValues) {
         ElementHelper.legalPropertyKeyValueArray(keyValues);
         Object idValue = vertexIdManager.convert(ElementHelper.getIdValue(keyValues).orElse(null));
         final String label = ElementHelper.getLabelValue(keyValues).orElse(Vertex.DEFAULT_LABEL);

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
@@ -72,8 +72,10 @@ public class TinkerGraphProvider extends AbstractGraphProvider {
                 put(TinkerGraph.CONFIG_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.name());
             if (requiresPersistence(test, testMethodName)) {
                 put(TinkerGraph.CONFIG_GRAPH_FORMAT, "gryo");
+                final File tempDir = TestHelper.makeTestDataPath(test, "temp");
+                if (!tempDir.exists()) tempDir.mkdirs();
                 put(TinkerGraph.CONFIG_GRAPH_LOCATION,
-                        TestHelper.makeTestDataPath(test, "temp").getAbsolutePath() + File.separator + testMethodName + ".kryo");
+                        tempDir.getAbsolutePath() + File.separator + testMethodName + ".kryo");
             }
         }};
     }


### PR DESCRIPTION
Since this is a breaking change for vendors, do we want to merge this into tp30 or master?

Also, how can we verify that it addresses the initial problem with Scala and overloading?
