### PR TITLE
Use Epoll based netty eventloop when possible

### DIFF
--- a/docs/src/gremlin-applications.asciidoc
+++ b/docs/src/gremlin-applications.asciidoc
@@ -523,6 +523,7 @@ The following table describes the various configuration options that Gremlin Ser
 |graphs |A `Map` of `Graph` configuration files where the key of the `Map` becomes the name to which the `Graph` will be bound and the value is the file name of a `Graph` configuration file. |_none_
 |gremlinPool |The number of "Gremlin" threads available to execute actual scripts in a `ScriptEngine`. This pool represents the workers available to handle blocking operations in Gremlin Server. |8
 |host |The name of the host to bind the server to. |localhost
+|useEpollEventLoop |try to use epoll event loops (works only on Linux os) instead of netty NIO. |false
 |maxAccumulationBufferComponents |Maximum number of request components that can be aggregated for a message. |1024
 |maxChunkSize |The maximum length of the content or each chunk.  If the content length exceeds this value, the transfer encoding of the decoded request will be converted to 'chunked' and the content will be split into multiple `HttpContent` objects.  If the transfer encoding of the HTTP request is 'chunked' already, each chunk will be split into smaller chunks if the length of the chunk exceeds this value. |8192
 |maxContentLength |The maximum length of the aggregated content for a message.  Works in concert with `maxChunkSize` where chunked requests are accumulated back into a single message.  A request exceeding this size will return a `413 - Request Entity Too Large` status code.  A response exceeding this size will raise an internal exception. |65536

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -40,6 +40,11 @@ limitations under the License.
             <version>${netty.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>

--- a/gremlin-driver/pom.xml
+++ b/gremlin-driver/pom.xml
@@ -40,11 +40,6 @@ limitations under the License.
             <version>${netty.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -140,6 +140,7 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -147,6 +148,29 @@ limitations under the License.
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>linux</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <gremlin.server.epoll>true</gremlin.server.epoll>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
         <profile>
             <!--
               This profile will include neo4j for purposes of transactional testing within Gremlin Server.

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -151,9 +151,10 @@ limitations under the License.
         <profile>
             <id>linux</id>
             <activation>
-                <os>
-                    <family>Linux</family>
-                </os>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>EPOLL</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -18,33 +18,28 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
-import org.apache.tinkerpop.gremlin.server.op.OpLoader;
-import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook;
-import org.apache.tinkerpop.gremlin.server.util.MetricManager;
-import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
-import org.apache.tinkerpop.gremlin.server.util.ThreadFactoryUtil;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
+import io.netty.channel.*;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.tinkerpop.gremlin.server.op.OpLoader;
+import org.apache.tinkerpop.gremlin.server.util.LifeCycleHook;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
+import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
+import org.apache.tinkerpop.gremlin.server.util.ThreadFactoryUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /**
  * Start and stop Gremlin Server.
@@ -71,21 +66,33 @@ public class GremlinServer {
     private final EventLoopGroup workerGroup;
     private final ExecutorService gremlinExecutorService;
     private final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor;
+    private final boolean isLinuxOS;
 
     /**
      * Construct a Gremlin Server instance from {@link Settings}.
      */
     public GremlinServer(final Settings settings) {
         this.settings = settings;
+        this.isLinuxOS = settings.useEpollEventLoop && SystemUtils.IS_OS_LINUX;
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> this.stop().join(), SERVER_THREAD_PREFIX + "shutdown"));
 
         final ThreadFactory threadFactoryBoss = ThreadFactoryUtil.create("boss-%d");
-        bossGroup = new NioEventLoopGroup(settings.threadPoolBoss, threadFactoryBoss);
+        // if linux os use epoll else fallback to nio based eventloop
+        // epoll helps in reducing GC and has better  performance
+        // http://netty.io/wiki/native-transports.html
+        if(isLinuxOS){
+            bossGroup = new EpollEventLoopGroup(settings.threadPoolBoss, threadFactoryBoss);
+        } else {
+            bossGroup = new NioEventLoopGroup(settings.threadPoolBoss, threadFactoryBoss);
+        }
 
         final ThreadFactory threadFactoryWorker = ThreadFactoryUtil.create("worker-%d");
-        workerGroup = new NioEventLoopGroup(settings.threadPoolWorker, threadFactoryWorker);
-
+        if(isLinuxOS) {
+            workerGroup = new EpollEventLoopGroup(settings.threadPoolWorker, threadFactoryWorker);
+        }else {
+            workerGroup = new NioEventLoopGroup(settings.threadPoolWorker, threadFactoryWorker);
+        }
         serverGremlinExecutor = new ServerGremlinExecutor<>(settings, null, workerGroup, EventLoopGroup.class);
         gremlinExecutorService = serverGremlinExecutor.getGremlinExecutorService();
     }
@@ -99,11 +106,16 @@ public class GremlinServer {
     public GremlinServer(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
         this.serverGremlinExecutor = serverGremlinExecutor;
         this.settings = serverGremlinExecutor.getSettings();
+        this.isLinuxOS = settings.useEpollEventLoop && SystemUtils.IS_OS_LINUX;
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> this.stop().join(), SERVER_THREAD_PREFIX + "shutdown"));
 
         final ThreadFactory threadFactoryBoss = ThreadFactoryUtil.create("boss-%d");
-        bossGroup = new NioEventLoopGroup(settings.threadPoolBoss, threadFactoryBoss);
+        if(isLinuxOS) {
+            bossGroup = new EpollEventLoopGroup(settings.threadPoolBoss, threadFactoryBoss);
+        } else{
+            bossGroup = new NioEventLoopGroup(settings.threadPoolBoss, threadFactoryBoss);
+        }
         workerGroup = serverGremlinExecutor.getScheduledExecutorService();
         gremlinExecutorService = serverGremlinExecutor.getGremlinExecutorService();
     }
@@ -112,7 +124,7 @@ public class GremlinServer {
      * Start Gremlin Server with {@link Settings} provided to the constructor.
      */
     public synchronized CompletableFuture<ServerGremlinExecutor<EventLoopGroup>> start() throws Exception {
-        if(serverStarted != null) {
+        if (serverStarted != null) {
             // server already started - don't get it rolling again
             return serverStarted;
         }
@@ -143,8 +155,12 @@ public class GremlinServer {
             final Channelizer channelizer = createChannelizer(settings);
             channelizer.init(serverGremlinExecutor);
             b.group(bossGroup, workerGroup)
-                    .channel(NioServerSocketChannel.class)
                     .childHandler(channelizer);
+            if(isLinuxOS){
+                b.channel(NioServerSocketChannel.class);
+            } else{
+                b.channel(EpollServerSocketChannel.class);
+            }
 
             // bind to host/port and wait for channel to be ready
             b.bind(settings.host, settings.port).addListener(new ChannelFutureListener() {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -20,11 +20,7 @@ package org.apache.tinkerpop.gremlin.server;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
+import io.netty.channel.*;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -43,11 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /**
  * Start and stop Gremlin Server.
@@ -165,9 +157,9 @@ public class GremlinServer {
             b.group(bossGroup, workerGroup)
                     .childHandler(channelizer);
             if(isLinuxOS){
-                b.channel(NioServerSocketChannel.class);
-            } else{
                 b.channel(EpollServerSocketChannel.class);
+            } else{
+                b.channel(NioServerSocketChannel.class);
             }
 
             // bind to host/port and wait for channel to be ready

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -20,7 +20,11 @@ package org.apache.tinkerpop.gremlin.server;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -20,7 +20,11 @@ package org.apache.tinkerpop.gremlin.server;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -39,7 +43,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Start and stop Gremlin Server.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -43,7 +43,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Start and stop Gremlin Server.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -81,6 +81,11 @@ public class Settings {
     public int threadPoolWorker = 1;
 
     /**
+     * detect if the OS is linux, then use epoll instead of NIO which causes less GC
+     */
+    public boolean useEpollEventLoop = false;
+
+    /**
      * Size of the Gremlin thread pool. This pool handles Gremlin script execution and other related "long-run"
      * processing.  This setting should be sufficiently large to ensure that requests processed by the non-blocking
      * worker threads are processed with limited queuing.  Defaults to 8.

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assume.assumeThat;
  */
 public abstract class AbstractGremlinServerIntegrationTest {
     private GremlinServer server;
+    private final static String epollOption = "gremlin.server.epoll";
+    private static final boolean GREMLIN_SERVER_EPOLL = "true".equalsIgnoreCase(System.getProperty(epollOption));
 
     @Rule
     public TestName name = new TestName();
@@ -51,12 +53,15 @@ public abstract class AbstractGremlinServerIntegrationTest {
     @Before
     public void setUp() throws Exception {
         System.out.println("* Testing: " + name.getMethodName());
+        System.out.println("* Epoll option enabled:" + GREMLIN_SERVER_EPOLL);
 
         final InputStream stream = getSettingsInputStream();
         final Settings settings = Settings.read(stream);
-
         final Settings overridenSettings = overrideSettings(settings);
         ServerTestHelper.rewritePathsInGremlinServerSettings(overridenSettings);
+        if (GREMLIN_SERVER_EPOLL) {
+            overridenSettings.useEpollEventLoop = true;
+        }
 
         this.server = new GremlinServer(overridenSettings);
 


### PR DESCRIPTION
This patch checks if the the OS is linux and uses netty epoll based event loops which perform better than NIO based event loops.

More details at:
http://netty.io/wiki/native-transports.html

Not sure if you guys have already tried it out. I saw a reduced GC pressure using epoll.