### PR TITLE
TINKERPOP3-895: Use "as BinaryOperator" and remove GBinaryOperator

### DIFF
--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/loaders/StepLoader.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/loaders/StepLoader.groovy
@@ -18,10 +18,14 @@
  */
 package org.apache.tinkerpop.gremlin.groovy.loaders
 
-import org.apache.tinkerpop.gremlin.groovy.function.*
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
 import org.apache.tinkerpop.gremlin.util.function.ConstantSupplier
+
+import java.util.function.BinaryOperator
+import java.util.function.Function
+import java.util.function.Supplier
+import java.util.function.UnaryOperator
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -31,45 +35,45 @@ class StepLoader {
     public static void load() {
 
         GraphTraversal.metaClass.by = { final Closure closure ->
-            return ((GraphTraversal) delegate).by(1 == closure.getMaximumNumberOfParameters() ? new GFunction(closure) : new GComparator(closure));
+            return ((GraphTraversal) delegate).by(1 == closure.getMaximumNumberOfParameters() ? closure as Function : closure as Comparator);
         }
 
         GraphTraversalSource.metaClass.withSideEffect = { final String key, final Object object ->
-            return ((GraphTraversalSource) delegate).withSideEffect(key, object instanceof Closure ? new GSupplier((Closure) object) : new ConstantSupplier<>(object));
+            return ((GraphTraversalSource) delegate).withSideEffect(key, object instanceof Closure ? ((Closure) object) as Supplier : new ConstantSupplier<>(object));
         }
 
         GraphTraversalSource.metaClass.withSack = { final Closure closure ->
-            return ((GraphTraversalSource) delegate).withSack(new GSupplier(closure));
+            return ((GraphTraversalSource) delegate).withSack(closure as Supplier);
         }
 
         GraphTraversalSource.metaClass.withSack = { final Closure closure, final Closure splitOrMergeOperator ->
-            return ((GraphTraversalSource) delegate).withSack(new GSupplier(closure), splitOrMergeOperator.getMaximumNumberOfParameters() == 1 ? new GUnaryOperator(splitOrMergeOperator) : new GBinaryOperator(splitOrMergeOperator));
+            return ((GraphTraversalSource) delegate).withSack(closure as Supplier, splitOrMergeOperator.getMaximumNumberOfParameters() == 1 ? splitOrMergeOperator as UnaryOperator : splitOrMergeOperator as BinaryOperator);
         }
 
         GraphTraversalSource.metaClass.withSack = {
             final Closure closure, final Closure splitOperator, final Closure mergeOperator ->
-                return ((GraphTraversalSource) delegate).withSack(new GSupplier(closure), new GUnaryOperator(splitOperator), new GBinaryOperator(mergeOperator));
+                return ((GraphTraversalSource) delegate).withSack(closure as Supplier, splitOperator as UnaryOperator, mergeOperator as BinaryOperator);
         }
 
         ///////////////////
 
         GraphTraversalSource.GraphTraversalSourceStub.metaClass.withSideEffect = {
             final String key, final Object object ->
-                return (((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSideEffect(key, object instanceof Closure ? new GSupplier((Closure) object) : new ConstantSupplier<>(object)));
+                return (((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSideEffect(key, object instanceof Closure ? ((Closure) object) as Supplier : new ConstantSupplier<>(object)));
         }
 
         GraphTraversalSource.GraphTraversalSourceStub.metaClass.withSack = { final Closure closure ->
-            return ((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSack(new GSupplier(closure));
+            return ((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSack(closure as Supplier);
         }
 
         GraphTraversalSource.GraphTraversalSourceStub.metaClass.withSack = {
             final Closure closure, final Closure splitOrMergeOperator ->
-                return ((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSack(new GSupplier(closure), splitOrMergeOperator.getMaximumNumberOfParameters() == 1 ? new GUnaryOperator(splitOrMergeOperator) : new GBinaryOperator(splitOrMergeOperator));
+                return ((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSack(closure as Supplier, splitOrMergeOperator.getMaximumNumberOfParameters() == 1 ? splitOrMergeOperator as UnaryOperator : splitOrMergeOperator as BinaryOperator);
         }
 
         GraphTraversalSource.GraphTraversalSourceStub.metaClass.withSack = {
             final Closure closure, final Closure splitOperator, Closure mergeOperator ->
-                return ((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSack(new GSupplier(closure), new GUnaryOperator(splitOperator), new GBinaryOperator(mergeOperator));
+                return ((GraphTraversalSource.GraphTraversalSourceStub) delegate).withSack(closure as Supplier, splitOperator as UnaryOperator, mergeOperator as BinaryOperator);
         }
     }
 }

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GBinaryOperator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GBinaryOperator.java
@@ -25,8 +25,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import java.util.function.BinaryOperator;
 
 /**
+ * @deprecated  As of release 3.1.0, use {@code as BinaryOperator} in Groovy.
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@Deprecated
 public final class GBinaryOperator<A> implements BinaryOperator<A>, LambdaHolder {
 
     private final Closure closure;

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GComparator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GComparator.java
@@ -24,8 +24,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import java.util.Comparator;
 
 /**
+ * @deprecated As of release 3.1.0, use {@code as Comparator} in Groovy.
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@Deprecated
 public final class GComparator<A> implements Comparator<A>, LambdaHolder {
 
     private final Closure closure;

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GFunction.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GFunction.java
@@ -24,8 +24,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import java.util.function.Function;
 
 /**
+ * @deprecated As of release 3.1.0, use {@code as Function} in Groovy.
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@Deprecated
 public final class GFunction<A, B> implements Function<A, B>, LambdaHolder {
 
     private final Closure closure;

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GSupplier.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GSupplier.java
@@ -24,8 +24,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import java.util.function.Supplier;
 
 /**
+ * @deprecated As of release 3.1.0, use {@code as Supplier} in Groovy.
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@Deprecated
 public final class GSupplier<A> implements Supplier<A>, LambdaHolder {
 
     private final Closure closure;

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GUnaryOperator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/function/GUnaryOperator.java
@@ -24,8 +24,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import java.util.function.UnaryOperator;
 
 /**
+ * @deprecated As of release 3.1.0, use {@code as UnaryOperator} in Groovy.
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
+@Deprecated
 public final class GUnaryOperator<A> implements UnaryOperator<A>, LambdaHolder {
 
     private final Closure closure;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-895

The full test suite has passed. Integration tests not required as this does not effect the semantics of a traversal beyond `GraphTraversalSource` construction in Gremlin-Groovy.

Respective lambda wrappers deprecated.

No AsciiDoc documentation updates required. Will update CHANGELOG on merge to master/.

VOTE: +1