### PR TITLE
Fix empty buffer return upon buffer capacity exceeded

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GryoMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GryoMessageSerializerV1d0.java
@@ -225,7 +225,7 @@ public final class GryoMessageSerializerV1d0 implements MessageSerializer {
         ByteBuf encodedMessage = null;
         try {
             final Kryo kryo = kryoThreadLocal.get();
-            try (final OutputStream baos = new ByteArrayOutputStream()) {
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                 final Output output = new Output(baos, bufferSize);
 
                 // request id - if present
@@ -244,9 +244,9 @@ public final class GryoMessageSerializerV1d0 implements MessageSerializer {
                 if (size > Integer.MAX_VALUE)
                     throw new SerializationException(String.format("Message size of %s exceeds allocatable space", size));
 
+                output.flush();
                 encodedMessage = allocator.buffer((int) size);
-                if (size > bufferSize) output.flush();
-                encodedMessage.writeBytes(output.toBytes());
+                encodedMessage.writeBytes(baos.toByteArray());
             }
 
             return encodedMessage;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GryoMessageSerializerV1d0.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ser/GryoMessageSerializerV1d0.java
@@ -35,16 +35,9 @@ import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -290,7 +283,7 @@ public final class GryoMessageSerializerV1d0 implements MessageSerializer {
         ByteBuf encodedMessage = null;
         try {
             final Kryo kryo = kryoThreadLocal.get();
-            try (final OutputStream baos = new ByteArrayOutputStream()) {
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                 final Output output = new Output(baos, bufferSize);
                 final String mimeType = serializeToString ? MIME_TYPE_STRINGD : MIME_TYPE;
                 output.writeByte(mimeType.length());
@@ -305,9 +298,9 @@ public final class GryoMessageSerializerV1d0 implements MessageSerializer {
                 if (size > Integer.MAX_VALUE)
                     throw new SerializationException(String.format("Message size of %s exceeds allocatable space", size));
 
+                output.flush();
                 encodedMessage = allocator.buffer((int) size);
-                if (size > bufferSize) output.flush();
-                encodedMessage.writeBytes(output.toBytes());
+                encodedMessage.writeBytes(baos.toByteArray());
             }
 
             return encodedMessage;


### PR DESCRIPTION
Discussion: https://groups.google.com/forum/#!topic/gremlin-users/zWGAn-oS5PQ

Return the underlying byte array output stream which will always contain the full serialized object.