### PR TITLE
TINKERPOP3-898: Rename ConjuctionP and ConjuctionStep to ConnectiveP and ConnectiveStep

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.0 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Renamed `ConjunctionX` to `ConnectiveX` because "conjunction" is assumed "and" (disjunction "or"), where "connective" is the parent concept.
 * Removed `PathIdentityStep` as it was a hack that is now solved by `Traversal.Admin.addTraverserRequirement()`.
 * Added `Traversal.Admin.addTraverserRequirement()` to allow a traversal strategy or source to add requirements (not only step determined anymore).
 * Added `TraverserRequirement.ONE_BULK` to state the traverser does not handle bulk.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalStrategies.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal;
 
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConjunctionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.EngineDependentStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.AdjacentToIncidentStrategy;
@@ -196,7 +196,7 @@ public interface TraversalStrategies extends Serializable, Cloneable {
         static {
             final TraversalStrategies coreStrategies = new DefaultTraversalStrategies();
             coreStrategies.addStrategies(
-                    ConjunctionStrategy.instance(),
+                    ConnectiveStrategy.instance(),
                     EngineDependentStrategy.instance(),
                     ProfileStrategy.instance(),
                     IncidentToAdjacentStrategy.instance(),

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -45,7 +45,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.UnionStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.CoinStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConjunctionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.CyclicPathStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DropStep;
@@ -521,7 +521,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
      * @return the traversal with an appended {@link MatchStep}.
      */
     public default <E2> GraphTraversal<S, Map<String, E2>> match(final Traversal<?, ?>... matchTraversals) {
-        return this.asAdmin().addStep(new MatchStep<>(this.asAdmin(), ConjunctionStep.Conjunction.AND, matchTraversals));
+        return this.asAdmin().addStep(new MatchStep<>(this.asAdmin(), ConnectiveStep.Connective.AND, matchTraversals));
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/AndStep.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class AndStep<S> extends ConjunctionStep<S> {
+public final class AndStep<S> extends ConnectiveStep<S> {
 
     public AndStep(final Traversal.Admin traversal, final Traversal<S, ?>... traversals) {
         super(traversal, traversals);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ConnectiveStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/ConnectiveStep.java
@@ -33,13 +33,13 @@ import java.util.stream.Stream;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class ConjunctionStep<S> extends AbstractStep<S, S> implements TraversalParent {
+public abstract class ConnectiveStep<S> extends AbstractStep<S, S> implements TraversalParent {
 
-    public enum Conjunction {AND, OR}
+    public enum Connective {AND, OR}
 
     protected List<Traversal.Admin<S, ?>> traversals;
 
-    public ConjunctionStep(final Traversal.Admin traversal, final Traversal<S, ?>... traversals) {
+    public ConnectiveStep(final Traversal.Admin traversal, final Traversal<S, ?>... traversals) {
         super(traversal);
         this.traversals = Stream.of(traversals).map(Traversal::asAdmin).collect(Collectors.toList());
         this.traversals.forEach(this::integrateChild);
@@ -60,8 +60,8 @@ public abstract class ConjunctionStep<S> extends AbstractStep<S, S> implements T
     }
 
     @Override
-    public ConjunctionStep<S> clone() {
-        final ConjunctionStep<S> clone = (ConjunctionStep<S>) super.clone();
+    public ConnectiveStep<S> clone() {
+        final ConnectiveStep<S> clone = (ConnectiveStep<S>) super.clone();
         clone.traversals = new ArrayList<>();
         for (final Traversal.Admin<S, ?> traversal : this.traversals) {
             clone.traversals.add(clone.integrateChild(traversal.clone()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/OrStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/OrStep.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrStep<S> extends ConjunctionStep<S> {
+public final class OrStep<S> extends ConnectiveStep<S> {
 
     public OrStep(final Traversal.Admin traversal, final Traversal<S, ?>... traversals) {
         super(traversal, traversals);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WherePredicateStep.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
-import org.apache.tinkerpop.gremlin.process.traversal.util.ConjunctionP;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
@@ -51,8 +51,8 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
     }
 
     private void configurePredicates(final P<Object> predicate) {
-        if (predicate instanceof ConjunctionP)
-            ((ConjunctionP<Object>) predicate).getPredicates().forEach(this::configurePredicates);
+        if (predicate instanceof ConnectiveP)
+            ((ConnectiveP<Object>) predicate).getPredicates().forEach(this::configurePredicates);
         else {
             final String selectKey = (String) (predicate.getValue() instanceof Collection ? ((Collection) predicate.getValue()).iterator().next() : predicate.getValue()); // hack for within("x"))
             this.selectKeys.add(selectKey);
@@ -61,8 +61,8 @@ public final class WherePredicateStep<S> extends FilterStep<S> implements Scopin
     }
 
     private void setPredicateValues(final P<Object> predicate, final Traverser.Admin<S> traverser, final Iterator<String> selectKeysIterator) {
-        if (predicate instanceof ConjunctionP)
-            ((ConjunctionP<Object>) predicate).getPredicates().forEach(p -> this.setPredicateValues(p, traverser, selectKeysIterator));
+        if (predicate instanceof ConnectiveP)
+            ((ConnectiveP<Object>) predicate).getPredicates().forEach(p -> this.setPredicateValues(p, traverser, selectKeysIterator));
         else
             predicate.setValue(this.getScopeValue(Pop.last, selectKeysIterator.next(), traverser));
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTraversalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/WhereTraversalStep.java
@@ -27,7 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StartStep;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConjunctionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
@@ -56,10 +56,10 @@ public final class WhereTraversalStep<S> extends FilterStep<S> implements Traver
     }
 
     private void configureStartAndEndSteps(final Traversal.Admin<?, ?> whereTraversal) {
-        ConjunctionStrategy.instance().apply(whereTraversal);
+        ConnectiveStrategy.instance().apply(whereTraversal);
         //// START STEP to WhereStartStep
         final Step<?, ?> startStep = whereTraversal.getStartStep();
-        if (startStep instanceof ConjunctionStep || startStep instanceof NotStep) {       // for conjunction- and not-steps
+        if (startStep instanceof ConnectiveStep || startStep instanceof NotStep) {       // for conjunction- and not-steps
             ((TraversalParent) startStep).getLocalChildren().forEach(this::configureStartAndEndSteps);
         } else if (StartStep.isVariableStartStep(startStep)) {  // as("a").out()... traversals
             final String label = startStep.getLabels().iterator().next();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.AndStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConjunctionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.OrStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StartStep;
@@ -35,7 +35,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import java.util.Set;
 
 /**
- * ConjunctionStrategy rewrites the binary conjunction form of {@code a.and().b} into a {@link AndStep} of
+ * ConnectiveStrategy rewrites the binary conjunction form of {@code a.and().b} into a {@link AndStep} of
  * {@code and(a,b)} (likewise for {@link OrStep}).
  * <p/>
  *
@@ -47,16 +47,16 @@ import java.util.Set;
  * __.as("a").out().as("b").and().as("c").in().as("d")                          // is replaced by __.and(__.as("a").out().as("b"), __.as("c").in().as("d"))
  * </pre>
  */
-public final class ConjunctionStrategy extends AbstractTraversalStrategy<TraversalStrategy.DecorationStrategy> implements TraversalStrategy.DecorationStrategy {
+public final class ConnectiveStrategy extends AbstractTraversalStrategy<TraversalStrategy.DecorationStrategy> implements TraversalStrategy.DecorationStrategy {
 
-    private static final ConjunctionStrategy INSTANCE = new ConjunctionStrategy();
+    private static final ConnectiveStrategy INSTANCE = new ConnectiveStrategy();
 
-    private ConjunctionStrategy() {
+    private ConnectiveStrategy() {
     }
 
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
-        if (TraversalHelper.hasStepOfAssignableClass(ConjunctionStep.class, traversal)) {
+        if (TraversalHelper.hasStepOfAssignableClass(ConnectiveStep.class, traversal)) {
             processConjunctionMarkers(traversal);
         }
     }
@@ -70,7 +70,7 @@ public final class ConjunctionStrategy extends AbstractTraversalStrategy<Travers
         processConjunctionMarker(AndStep.class, traversal);
     }
 
-    private static void processConjunctionMarker(final Class<? extends ConjunctionStep> markerClass, final Traversal.Admin<?, ?> traversal) {
+    private static void processConjunctionMarker(final Class<? extends ConnectiveStep> markerClass, final Traversal.Admin<?, ?> traversal) {
 
         TraversalHelper.getStepsOfClass(markerClass, traversal).stream()
                 .filter(conjunctionStep -> conjunctionStep.getLocalChildren().isEmpty())
@@ -108,7 +108,7 @@ public final class ConjunctionStrategy extends AbstractTraversalStrategy<Travers
         });
     }
 
-    public static ConjunctionStrategy instance() {
+    public static ConnectiveStrategy instance() {
         return INSTANCE;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/AdjacentToIncidentStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/AdjacentToIncidentStrategy.java
@@ -22,7 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConjunctionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
@@ -74,7 +74,7 @@ public final class AdjacentToIncidentStrategy extends AbstractTraversalStrategy<
             final Step curr = steps.get(i);
             if (i == size && isOptimizable(curr)) {
                 final TraversalParent parent = curr.getTraversal().getParent();
-                if (parent instanceof NotStep || parent instanceof TraversalFilterStep || parent instanceof WhereTraversalStep || parent instanceof ConjunctionStep) {
+                if (parent instanceof NotStep || parent instanceof TraversalFilterStep || parent instanceof WhereTraversalStep || parent instanceof ConnectiveStep) {
                     optimizeStep(traversal, curr);
                 }
             } else if (isOptimizable(prev)) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
@@ -25,13 +25,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.IsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.CountGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.util.ConjunctionP;
-import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.Contains;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -80,7 +78,7 @@ public final class RangeByIsCountStrategy extends AbstractTraversalStrategy<Trav
                     final IsStep isStep = (IsStep) next;
                     final P isStepPredicate = isStep.getPredicate();
                     Long highRange = null;
-                    for (P p : isStepPredicate instanceof ConjunctionP ? ((ConjunctionP<?>) isStepPredicate).getPredicates() : Collections.singletonList(isStepPredicate)) {
+                    for (P p : isStepPredicate instanceof ConnectiveP ? ((ConnectiveP<?>) isStepPredicate).getPredicates() : Collections.singletonList(isStepPredicate)) {
                         final Object value = p.getValue();
                         final BiPredicate predicate = p.getBiPredicate();
                         if (value instanceof Number) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/AndP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/AndP.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 
 import java.io.Serializable;
 import java.util.function.BiPredicate;
@@ -28,7 +27,7 @@ import java.util.function.Predicate;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class AndP<V> extends ConjunctionP<V> {
+public final class AndP<V> extends ConnectiveP<V> {
 
     public AndP(final P<V>... predicates) {
         super(predicates);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ConnectiveP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ConnectiveP.java
@@ -19,23 +19,21 @@
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public abstract class ConjunctionP<V> extends P<V> {
+public abstract class ConnectiveP<V> extends P<V> {
 
     protected List<P<V>> predicates;
 
-    public ConjunctionP(final P<V>... predicates) {
+    public ConnectiveP(final P<V>... predicates) {
         super(null, null);
         if (predicates.length < 2)
             throw new IllegalArgumentException("The provided " + this.getClass().getSimpleName() + " array must have at least two arguments: " + predicates.length);
@@ -57,7 +55,7 @@ public abstract class ConjunctionP<V> extends P<V> {
         return this;
     }
 
-    protected P<V> negate(final ConjunctionP<V> p) {
+    protected P<V> negate(final ConnectiveP<V> p) {
         final List<P<V>> negated = new ArrayList<>();
         for (final P<V> predicate : this.predicates) {
             negated.add(predicate.negate());
@@ -78,7 +76,7 @@ public abstract class ConjunctionP<V> extends P<V> {
     @Override
     public boolean equals(final Object other) {
         if (other != null && other.getClass().equals(this.getClass())) {
-            final List<P<V>> otherPredicates = ((ConjunctionP<V>) other).predicates;
+            final List<P<V>> otherPredicates = ((ConnectiveP<V>) other).predicates;
             if (this.predicates.size() == otherPredicates.size()) {
                 for (int i = 0; i < this.predicates.size(); i++) {
                     if (!this.predicates.get(i).equals(otherPredicates.get(i))) {
@@ -92,8 +90,8 @@ public abstract class ConjunctionP<V> extends P<V> {
     }
 
     @Override
-    public ConjunctionP<V> clone() {
-        final ConjunctionP<V> clone = (ConjunctionP<V>) super.clone();
+    public ConnectiveP<V> clone() {
+        final ConnectiveP<V> clone = (ConnectiveP<V>) super.clone();
         clone.predicates = new ArrayList<>();
         for (final P<V> p : this.predicates) {
             clone.predicates.add(p.clone());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/OrP.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/OrP.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrP<V> extends ConjunctionP<V> {
+public final class OrP<V> extends ConnectiveP<V> {
 
     public OrP(final P<V>... predicates) {
         super(predicates);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConjunctionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
@@ -424,7 +424,7 @@ public final class TraversalHelper {
                 variables.add(Scoping.Variable.START);
         } else if (startStep instanceof MatchStep) {
             ((MatchStep<?, ?>) startStep).getGlobalChildren().forEach(child -> TraversalHelper.getVariableLocations(variables, child));
-        } else if (startStep instanceof ConjunctionStep || startStep instanceof NotStep || startStep instanceof WhereTraversalStep)
+        } else if (startStep instanceof ConnectiveStep || startStep instanceof NotStep || startStep instanceof WhereTraversalStep)
             ((TraversalParent) startStep).getLocalChildren().forEach(child -> TraversalHelper.getVariableLocations(variables, child));
         ///
         final Step<?, ?> endStep = traversal.getEndStep();

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.CoinStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConjunctionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.ConnectiveStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.EmptyTraverser;
@@ -89,7 +89,7 @@ public class MatchStepTest extends StepTest {
             //
             pattern = matchStep.getGlobalChildren().get(1);
             assertEquals(MatchStep.class, pattern.getStartStep().getClass());
-            assertEquals(ConjunctionStep.Conjunction.OR, ((MatchStep<?, ?>) pattern.getStartStep()).getConjunction());
+            assertEquals(ConnectiveStep.Connective.OR, ((MatchStep<?, ?>) pattern.getStartStep()).getConnective());
             assertEquals("c", ((MatchStep.MatchStartStep) ((MatchStep<?, ?>) pattern.getStartStep()).getGlobalChildren().get(0).getStartStep()).getSelectKey().get());
             assertEquals(PathStep.class, ((MatchStep<?, ?>) pattern.getStartStep()).getGlobalChildren().get(0).getStartStep().getNextStep().getClass());
             assertEquals("d", ((MatchStep.MatchEndStep) ((MatchStep<?, ?>) pattern.getStartStep()).getGlobalChildren().get(0).getEndStep()).getMatchKey().get());
@@ -115,7 +115,7 @@ public class MatchStepTest extends StepTest {
             //
             pattern = matchStep.getGlobalChildren().get(1);
             assertEquals(MatchStep.class, pattern.getStartStep().getClass());
-            assertEquals(ConjunctionStep.Conjunction.AND, ((MatchStep<?, ?>) pattern.getStartStep()).getConjunction());
+            assertEquals(ConnectiveStep.Connective.AND, ((MatchStep<?, ?>) pattern.getStartStep()).getConnective());
             assertEquals("c", ((MatchStep.MatchStartStep) ((MatchStep<?, ?>) pattern.getStartStep()).getGlobalChildren().get(0).getStartStep()).getSelectKey().get());
             assertEquals(PathStep.class, ((MatchStep<?, ?>) pattern.getStartStep()).getGlobalChildren().get(0).getStartStep().getNextStep().getClass());
             assertEquals("d", ((MatchStep.MatchEndStep) ((MatchStep<?, ?>) pattern.getStartStep()).getGlobalChildren().get(0).getEndStep()).getMatchKey().get());

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategyTest.java
@@ -39,10 +39,10 @@ import static org.mockito.Mockito.when;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 @RunWith(Enclosed.class)
-public class ConjunctionStrategyTest {
+public class ConnectiveStrategyTest {
 
     @RunWith(Parameterized.class)
-    public static class StandardTest extends AbstractConjunctionStrategyTest {
+    public static class StandardTest extends AbstractConnectiveStrategyTest {
 
         @Parameterized.Parameters(name = "{0}")
         public static Iterable<Object[]> data() {
@@ -68,7 +68,7 @@ public class ConjunctionStrategyTest {
     }
 
     @RunWith(Parameterized.class)
-    public static class ComputerTest extends AbstractConjunctionStrategyTest {
+    public static class ComputerTest extends AbstractConnectiveStrategyTest {
 
         @Parameterized.Parameters(name = "{0}")
         public static Iterable<Object[]> data() {
@@ -93,13 +93,13 @@ public class ConjunctionStrategyTest {
         }
     }
 
-    private static abstract class AbstractConjunctionStrategyTest {
+    private static abstract class AbstractConnectiveStrategyTest {
 
         protected TraversalEngine traversalEngine;
 
         void applyMatchWhereStrategy(final Traversal traversal) {
             final TraversalStrategies strategies = new DefaultTraversalStrategies();
-            strategies.addStrategies(ConjunctionStrategy.instance());
+            strategies.addStrategies(ConnectiveStrategy.instance());
 
             traversal.asAdmin().setStrategies(strategies);
             traversal.asAdmin().applyStrategies();

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphNoStrategyComputerProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphNoStrategyComputerProvider.java
@@ -21,7 +21,7 @@ package org.apache.tinkerpop.gremlin.tinkergraph.process;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConjunctionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.EngineDependentStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
@@ -39,7 +39,7 @@ public class TinkerGraphNoStrategyComputerProvider extends TinkerGraphComputerPr
             ComputerVerificationStrategy.class,
             EngineDependentStrategy.class,
             ProfileStrategy.class,
-            ConjunctionStrategy.class,
+            ConnectiveStrategy.class,
             ComputerTraversalEngine.ComputerResultStrategy.class));
 
     @Override

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphNoStrategyProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/process/TinkerGraphNoStrategyProvider.java
@@ -22,7 +22,7 @@ import org.apache.tinkerpop.gremlin.GraphProvider;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConjunctionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.TinkerGraphProvider;
@@ -42,7 +42,7 @@ public class TinkerGraphNoStrategyProvider extends TinkerGraphProvider {
     private static final HashSet<Class<? extends TraversalStrategy>> REQUIRED_STRATEGIES = new HashSet<>(Arrays.asList(
             TinkerGraphStepStrategy.class,
             ProfileStrategy.class,
-            ConjunctionStrategy.class));
+            ConnectiveStrategy.class));
 
     @Override
     public GraphTraversalSource traversal(final Graph graph) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-898

In logic, "conjunction" implies AND. The general term for both AND and OR is "connective."

* Renamed all `ConjunctionXXX` to `ConnectiveXXX`.
* This is a breaking change but very internal to TinkerPop steps and given that we are not exposing the "instruction set" paradigm yet, its best this happens now than later.
* I ran `mvn clean install` and everything built. This does NOT effect docs nor integration testing.
* I updated the `CHANGELOG.asciidoc`.

I VOTE +1 (binding).