### PR TITLE
TINKERPOP3-905 Harden time oriented tests in ResultQueueTest

### DIFF
--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultQueueTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ResultQueueTest.java
@@ -40,11 +40,8 @@ public class ResultQueueTest extends AbstractResultQueueTest {
 
     @Test
     public void shouldGetSizeUntilError() throws Exception {
-        final Thread t = addToQueue(100, 10, true);
+        final Thread t = addToQueue(100, 10, true, false, 1);
         try {
-            // make sure some items get added to the queue before assert
-            TimeUnit.MILLISECONDS.sleep(50);
-
             assertThat(resultQueue.size(), is(greaterThan(0)));
             assertThat(readCompleted.isDone(), is(false));
 
@@ -72,11 +69,8 @@ public class ResultQueueTest extends AbstractResultQueueTest {
 
     @Test
     public void shouldNotBeEmptyUntilError() throws Exception {
-        final Thread t = addToQueue(100, 10, true);
+        final Thread t = addToQueue(100, 10, true, false, 1);
         try {
-            // make sure some items get added to the queue before assert
-            TimeUnit.MILLISECONDS.sleep(50);
-
             assertThat(resultQueue.isEmpty(), is(false));
             assertThat(readCompleted.isDone(), is(false));
 
@@ -97,11 +91,8 @@ public class ResultQueueTest extends AbstractResultQueueTest {
 
     @Test
     public void shouldDrainUntilError() throws Exception {
-        final Thread t = addToQueue(100, 10, true);
+        final Thread t = addToQueue(100, 10, true, false, 1);
         try {
-            // make sure some items get added to the queue before assert
-            TimeUnit.MILLISECONDS.sleep(50);
-
             assertThat(resultQueue.isEmpty(), is(false));
             final List<Result> drain = new ArrayList<>();
             resultQueue.drainTo(drain);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-905

Now that the test relies on a CountDownLatch to explicitly block until a specified number of items are in the queue, the test should not randomly fail if items are slow to get to that queue. 

If you've seen this test fail before please run the standard `mvn clean install` test suite a few times to see if there are problems.