### PR TITLE
Getters for RepeatStep.emitTraversal / untilTraversal and LoopTraversal.maxLoops

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/LoopTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/LoopTraversal.java
@@ -32,6 +32,10 @@ public final class LoopTraversal<S, E> extends AbstractLambdaTraversal<S, E> {
         this.maxLoops = maxLoops;
     }
 
+    public long getMaxLoops() {
+        return maxLoops;
+    }
+
     @Override
     public boolean hasNext() {
         return this.allow;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/branch/RepeatStep.java
@@ -75,11 +75,19 @@ public final class RepeatStep<S> extends ComputerAwareStep<S, S> implements Trav
         this.untilTraversal = this.integrateChild(untilTraversal);
     }
 
+    public Traversal.Admin<S, ?> getUntilTraversal() {
+        return this.untilTraversal;
+    }
+
     public void setEmitTraversal(final Traversal.Admin<S, ?> emitTraversal) {
         if (null != this.emitTraversal)
             throw new IllegalStateException("The repeat()-step already has its emit()-modulator declared: " + this);
         if (null == this.repeatTraversal) this.emitFirst = true;
         this.emitTraversal = this.integrateChild(emitTraversal);
+    }
+
+    public Traversal.Admin<S, ?> getEmitTraversal() {
+        return this.emitTraversal;
     }
 
     public List<Traversal.Admin<S, S>> getGlobalChildren() {


### PR DESCRIPTION
These getters are required for providers to access the state of the RepeatStep when optimizing it.