### PR TITLE
TINKERPOP3-926: Renamed TinkerGraph public statics to common pattern used for other statics.

### DIFF
--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerFactory.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerFactory.java
@@ -41,9 +41,9 @@ public final class TinkerFactory {
 
     public static TinkerGraph createClassic() {
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_VERTEX_ID, TinkerGraph.DefaultIdManager.INTEGER.name());
-        conf.setProperty(TinkerGraph.CONFIG_EDGE_ID, TinkerGraph.DefaultIdManager.INTEGER.name());
-        conf.setProperty(TinkerGraph.CONFIG_VERTEX_PROPERTY_ID, TinkerGraph.DefaultIdManager.INTEGER.name());
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, TinkerGraph.DefaultIdManager.INTEGER.name());
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, TinkerGraph.DefaultIdManager.INTEGER.name());
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, TinkerGraph.DefaultIdManager.INTEGER.name());
 
         final TinkerGraph g = TinkerGraph.open(conf);
         generateClassic(g);
@@ -88,7 +88,7 @@ public final class TinkerFactory {
 
     public static TinkerGraph createTheCrew() {
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.name());
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.name());
         final TinkerGraph g = TinkerGraph.open(conf);
         generateTheCrew(g);
         return g;

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -30,7 +30,6 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.IoCore;
-import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoMapper;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -78,12 +77,43 @@ public final class TinkerGraph implements Graph {
         this.setProperty(Graph.GRAPH, TinkerGraph.class.getName());
     }};
 
+    /**
+     * @deprecated As of release 3.1.0, replaced by {@link TinkerGraph#GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER}
+     */
+    @Deprecated
     public static final String CONFIG_VERTEX_ID = "gremlin.tinkergraph.vertexIdManager";
+    /**
+     * @deprecated As of release 3.1.0, replaced by {@link TinkerGraph#GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER}
+     */
+    @Deprecated
     public static final String CONFIG_EDGE_ID = "gremlin.tinkergraph.edgeIdManager";
+    /**
+     * @deprecated As of release 3.1.0, replaced by {@link TinkerGraph#GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER}
+     */
+    @Deprecated
     public static final String CONFIG_VERTEX_PROPERTY_ID = "gremlin.tinkergraph.vertexPropertyIdManager";
+    /**
+     * @deprecated As of release 3.1.0, replaced by {@link TinkerGraph#GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY}
+     */
+    @Deprecated
     public static final String CONFIG_DEFAULT_VERTEX_PROPERTY_CARDINALITY = "gremlin.tinkergraph.defaultVertexPropertyCardinality";
+    /**
+     * @deprecated As of release 3.1.0, replaced by {@link TinkerGraph#GREMLIN_TINKERGRAPH_GRAPH_LOCATION}
+     */
+    @Deprecated
     public static final String CONFIG_GRAPH_LOCATION = "gremlin.tinkergraph.graphLocation";
+    /**
+     * @deprecated As of release 3.1.0, replaced by {@link TinkerGraph#GREMLIN_TINKERGRAPH_GRAPH_FORMAT}
+     */
+    @Deprecated
     public static final String CONFIG_GRAPH_FORMAT = "gremlin.tinkergraph.graphFormat";
+    ///////
+    public static final String GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER = "gremlin.tinkergraph.vertexIdManager";
+    public static final String GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER = "gremlin.tinkergraph.edgeIdManager";
+    public static final String GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER = "gremlin.tinkergraph.vertexPropertyIdManager";
+    public static final String GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY = "gremlin.tinkergraph.defaultVertexPropertyCardinality";
+    public static final String GREMLIN_TINKERGRAPH_GRAPH_LOCATION = "gremlin.tinkergraph.graphLocation";
+    public static final String GREMLIN_TINKERGRAPH_GRAPH_FORMAT = "gremlin.tinkergraph.graphFormat";
 
     private final TinkerGraphFeatures features = new TinkerGraphFeatures();
 
@@ -110,18 +140,18 @@ public final class TinkerGraph implements Graph {
      */
     private TinkerGraph(final Configuration configuration) {
         this.configuration = configuration;
-        vertexIdManager = selectIdManager(configuration, CONFIG_VERTEX_ID, Vertex.class);
-        edgeIdManager = selectIdManager(configuration, CONFIG_EDGE_ID, Edge.class);
-        vertexPropertyIdManager = selectIdManager(configuration, CONFIG_VERTEX_PROPERTY_ID, VertexProperty.class);
+        vertexIdManager = selectIdManager(configuration, GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, Vertex.class);
+        edgeIdManager = selectIdManager(configuration, GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, Edge.class);
+        vertexPropertyIdManager = selectIdManager(configuration, GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, VertexProperty.class);
         defaultVertexPropertyCardinality = VertexProperty.Cardinality.valueOf(
-                configuration.getString(CONFIG_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.single.name()));
+                configuration.getString(GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.single.name()));
 
-        graphLocation = configuration.getString(CONFIG_GRAPH_LOCATION, null);
-        graphFormat = configuration.getString(CONFIG_GRAPH_FORMAT, null);
+        graphLocation = configuration.getString(GREMLIN_TINKERGRAPH_GRAPH_LOCATION, null);
+        graphFormat = configuration.getString(GREMLIN_TINKERGRAPH_GRAPH_FORMAT, null);
 
         if ((graphLocation != null && null == graphFormat) || (null == graphLocation && graphFormat != null))
             throw new IllegalStateException(String.format("The %s and %s must both be specified if either is present",
-                    CONFIG_GRAPH_LOCATION, CONFIG_GRAPH_FORMAT));
+                    GREMLIN_TINKERGRAPH_GRAPH_LOCATION, GREMLIN_TINKERGRAPH_GRAPH_FORMAT));
 
         if (graphLocation != null) loadGraph();
     }
@@ -324,9 +354,9 @@ public final class TinkerGraph implements Graph {
     public class TinkerGraphFeatures implements Features {
 
         private final TinkerGraphGraphFeatures graphFeatures = new TinkerGraphGraphFeatures();
-private final TinkerGraphEdgeFeatures edgeFeatures = new TinkerGraphEdgeFeatures();
+        private final TinkerGraphEdgeFeatures edgeFeatures = new TinkerGraphEdgeFeatures();
         private final TinkerGraphVertexFeatures vertexFeatures = new TinkerGraphVertexFeatures();
-        
+
         private TinkerGraphFeatures() {
         }
 
@@ -351,11 +381,11 @@ private final TinkerGraphEdgeFeatures edgeFeatures = new TinkerGraphEdgeFeatures
         }
 
     }
-    
+
     public class TinkerGraphVertexFeatures implements Features.VertexFeatures {
 
         private final TinkerGraphVertexPropertyFeatures vertexPropertyFeatures = new TinkerGraphVertexPropertyFeatures();
-        
+
         private TinkerGraphVertexFeatures() {
         }
 
@@ -379,7 +409,7 @@ private final TinkerGraphEdgeFeatures edgeFeatures = new TinkerGraphEdgeFeatures
             return defaultVertexPropertyCardinality;
         }
     }
-    
+
     public class TinkerGraphEdgeFeatures implements Features.EdgeFeatures {
 
         private TinkerGraphEdgeFeatures() {
@@ -395,7 +425,7 @@ private final TinkerGraphEdgeFeatures edgeFeatures = new TinkerGraphEdgeFeatures
             return edgeIdManager.allow(id);
         }
     }
-    
+
     public class TinkerGraphGraphFeatures implements Features.GraphFeatures {
 
         private TinkerGraphGraphFeatures() {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/TinkerGraphProvider.java
@@ -65,15 +65,15 @@ public class TinkerGraphProvider extends AbstractGraphProvider {
         final String idMaker = (idManager.equals(TinkerGraph.DefaultIdManager.ANY) ? selectIdMakerFromTest(test, testMethodName) : idManager).name();
         return new HashMap<String, Object>() {{
             put(Graph.GRAPH, TinkerGraph.class.getName());
-            put(TinkerGraph.CONFIG_VERTEX_ID, idMaker);
-            put(TinkerGraph.CONFIG_EDGE_ID, idMaker);
-            put(TinkerGraph.CONFIG_VERTEX_PROPERTY_ID, idMaker);
+            put(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, idMaker);
+            put(TinkerGraph.GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, idMaker);
+            put(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, idMaker);
             if (requiresListCardinalityAsDefault(loadGraphWith, test, testMethodName))
-                put(TinkerGraph.CONFIG_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.name());
+                put(TinkerGraph.GREMLIN_TINKERGRAPH_DEFAULT_VERTEX_PROPERTY_CARDINALITY, VertexProperty.Cardinality.list.name());
             if (requiresPersistence(test, testMethodName)) {
-                put(TinkerGraph.CONFIG_GRAPH_FORMAT, "gryo");
+                put(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "gryo");
                 final File tempDir = TestHelper.makeTestDataPath(test, "temp");
-                put(TinkerGraph.CONFIG_GRAPH_LOCATION,
+                put(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION,
                         tempDir.getAbsolutePath() + File.separator + testMethodName + ".kryo");
             }
         }};
@@ -85,7 +85,7 @@ public class TinkerGraphProvider extends AbstractGraphProvider {
             graph.close();
 
         // in the even the graph is persisted we need to clean up
-        final String graphLocation = configuration.getString(TinkerGraph.CONFIG_GRAPH_LOCATION, null);
+        final String graphLocation = configuration.getString(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, null);
         if (graphLocation != null) {
             final File f = new File(graphLocation);
             f.delete();

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIdManagerTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphIdManagerTest.java
@@ -72,13 +72,13 @@ public class TinkerGraphIdManagerTest {
 
         @BeforeClass
         public static void setup() {
-            longIdManagerConfig.addProperty(TinkerGraph.CONFIG_EDGE_ID, TinkerGraph.DefaultIdManager.LONG.name());
-            longIdManagerConfig.addProperty(TinkerGraph.CONFIG_VERTEX_ID, TinkerGraph.DefaultIdManager.LONG.name());
-            longIdManagerConfig.addProperty(TinkerGraph.CONFIG_VERTEX_PROPERTY_ID, TinkerGraph.DefaultIdManager.LONG.name());
+            longIdManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, TinkerGraph.DefaultIdManager.LONG.name());
+            longIdManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, TinkerGraph.DefaultIdManager.LONG.name());
+            longIdManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, TinkerGraph.DefaultIdManager.LONG.name());
 
-            integerIdManagerConfig.addProperty(TinkerGraph.CONFIG_EDGE_ID, TinkerGraph.DefaultIdManager.INTEGER.name());
-            integerIdManagerConfig.addProperty(TinkerGraph.CONFIG_VERTEX_ID, TinkerGraph.DefaultIdManager.INTEGER.name());
-            integerIdManagerConfig.addProperty(TinkerGraph.CONFIG_VERTEX_PROPERTY_ID, TinkerGraph.DefaultIdManager.INTEGER.name());
+            integerIdManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, TinkerGraph.DefaultIdManager.INTEGER.name());
+            integerIdManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, TinkerGraph.DefaultIdManager.INTEGER.name());
+            integerIdManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, TinkerGraph.DefaultIdManager.INTEGER.name());
         }
 
         @Test
@@ -138,9 +138,9 @@ public class TinkerGraphIdManagerTest {
 
         @BeforeClass
         public static void setup() {
-            idManagerConfig.addProperty(TinkerGraph.CONFIG_EDGE_ID, TinkerGraph.DefaultIdManager.UUID.name());
-            idManagerConfig.addProperty(TinkerGraph.CONFIG_VERTEX_ID, TinkerGraph.DefaultIdManager.UUID.name());
-            idManagerConfig.addProperty(TinkerGraph.CONFIG_VERTEX_PROPERTY_ID, TinkerGraph.DefaultIdManager.UUID.name());
+            idManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_EDGE_ID_MANAGER, TinkerGraph.DefaultIdManager.UUID.name());
+            idManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_ID_MANAGER, TinkerGraph.DefaultIdManager.UUID.name());
+            idManagerConfig.addProperty(TinkerGraph.GREMLIN_TINKERGRAPH_VERTEX_PROPERTY_ID_MANAGER, TinkerGraph.DefaultIdManager.UUID.name());
         }
 
         @Test

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -285,7 +285,7 @@ public class TinkerGraphTest {
     @Test(expected = IllegalStateException.class)
     public void shouldRequireGraphLocationIfFormatIsSet() {
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_FORMAT, "graphml");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "graphml");
         TinkerGraph.open(conf);
     }
 
@@ -325,7 +325,7 @@ public class TinkerGraphTest {
     @Test(expected = IllegalStateException.class)
     public void shouldRequireGraphFormatIfLocationIsSet() {
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_LOCATION, "/tmp");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, "/tmp");
         TinkerGraph.open(conf);
     }
 
@@ -336,8 +336,8 @@ public class TinkerGraphTest {
         if (f.exists() && f.isFile()) f.delete();
 
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_FORMAT, "graphml");
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_LOCATION, graphLocation);
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "graphml");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
         final TinkerGraph graph = TinkerGraph.open(conf);
         TinkerFactory.generateModern(graph);
         graph.close();
@@ -354,8 +354,8 @@ public class TinkerGraphTest {
         if (f.exists() && f.isFile()) f.delete();
 
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_FORMAT, "graphson");
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_LOCATION, graphLocation);
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "graphson");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
         final TinkerGraph graph = TinkerGraph.open(conf);
         TinkerFactory.generateModern(graph);
         graph.close();
@@ -372,8 +372,8 @@ public class TinkerGraphTest {
         if (f.exists() && f.isFile()) f.delete();
 
         final Configuration conf = new BaseConfiguration();
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_FORMAT, "gryo");
-        conf.setProperty(TinkerGraph.CONFIG_GRAPH_LOCATION, graphLocation);
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_FORMAT, "gryo");
+        conf.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, graphLocation);
         final TinkerGraph graph = TinkerGraph.open(conf);
         TinkerFactory.generateModern(graph);
         graph.close();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-926

Renamed the `public statics` to use the standard TinkerPop pattern of spelling out the full property name is capital case with new words (and or camel case) having a `_` split.