### PR TITLE
TINKERPOP3-918: ComputerVerificationStrategy is too restrictive

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/TraversalComparator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/TraversalComparator.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 
 import java.io.Serializable;
@@ -44,7 +45,9 @@ public final class TraversalComparator<S, E> implements Comparator<S>, Serializa
 
     @Override
     public int compare(final S start1, final S start2) {
-        return this.comparator.compare(TraversalUtil.apply(start1, this.traversal), TraversalUtil.apply(start2, this.traversal));
+        return start1 instanceof Traverser ?
+                this.comparator.compare(TraversalUtil.apply((Traverser.Admin<S>) start1, this.traversal), TraversalUtil.apply((Traverser.Admin<S>) start2, this.traversal)) :
+                this.comparator.compare(TraversalUtil.apply(start1, this.traversal), TraversalUtil.apply(start2, this.traversal));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/ComputerVerificationStrategy.java
@@ -22,9 +22,6 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.Computer
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Bypassing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
@@ -46,9 +43,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierS
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.SupplyingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.T;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -83,10 +77,7 @@ public final class ComputerVerificationStrategy extends AbstractTraversalStrateg
                 throw new VerificationException("GraphComputer does not support traversals starting from a non-GraphStep: " + traversal.getStartStep(), traversal);
             ///
             if (endStep instanceof CollectingBarrierStep && endStep instanceof TraversalParent) {
-                if (((TraversalParent) endStep).getLocalChildren().stream().filter(t ->
-                        !(t instanceof IdentityTraversal) &&
-                                !(t instanceof ConstantTraversal) &&  // for SampleStep
-                                !(t instanceof TokenTraversal && ((TokenTraversal) t).getToken().equals(T.id))).findAny().isPresent())
+                if (((TraversalParent) endStep).getLocalChildren().stream().filter(t -> !TraversalHelper.isNotBeyondElementId(t)).findAny().isPresent())
                     throw new VerificationException("A final CollectingBarrierStep can not process an element beyond its id: " + endStep, traversal);
             }
             ///

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
@@ -86,5 +86,15 @@ public abstract class GroovyOrderTest {
         public Traversal<Vertex, Map<String, List<Vertex>>> get_g_V_group_byXlabelX_byXnameX_byXorderXlocalX_byXdecrXX() {
             TraversalScriptHelper.compute("g.V.group.by(label).by(values('name').order().by(decr).fold())", g)
         }
+
+        @Override
+        public Traversal<Vertex, List<Double>> get_g_V_localXbothE_weight_foldX_order_byXsumXlocalX_decrX() {
+            TraversalScriptHelper.compute("g.V.local(__.bothE.weight.fold).order.by(sum(local), decr)", g)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_asXvX_mapXbothE_weight_foldX_sumXlocalX_asXsX_selectXv_sX_order_byXselectXsX_decrX() {
+            TraversalScriptHelper.compute("g.V.as('v').map(__.bothE.weight.fold).sum(local).as('s').select('v', 's').order.by(select('s'),decr)", g);
+        }
     }
 }


### PR DESCRIPTION
@dkuppitz found a restrictive verification that has now been loosened up. I added the two examples that Kuppitz demonstrated that should be allowed but were not. In the process, I found a bug in how MapReduce comparators work and fixed it. 

I ran `mvn clean install`. I also did Spark integration testing and tested the known tests that this effects in Giraph.

When merged, I will updated CHANGELOG.

VOTE +1.