### PR TITLE
TINKERPOP3-899: Bump to the latest version of Neo4j.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,10 +25,11 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.0 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Bumped to Neo4j 2.3.0.
 * Renamed the `public static String` configuration variable names of TinkerGraph (deprecated old variables).
 * Added `GraphComputer.config(key,value)` to allow engine-specific configurations.
 * `GraphStep` is no longer in the `sideEffect`-package and is now in `map`-package (breaking change).
-* Added suppport for mid-traversal `V()`-steps (`GraphStep` semantics updated).
+* Added support for mid-traversal `V()`-steps (`GraphStep` semantics updated).
 * Fixed `Number` handling in `Operator` enums. Prior this change a lot of operations on mixed `Number` types returned a wrong result (wrong data type).
 * Fixed a bug in Gremlin Server/Driver serializer where empty buffers were getting returned in certain cases.
 * Renamed `ConjunctionX` to `ConnectiveX` because "conjunction" is assumed "and" (disjunction "or"), where "connective" is the parent concept.

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -136,7 +136,33 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.1-2.2</version>
+                    <version>0.3-2.3.0</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+                            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.scala-lang</groupId>
+                            <artifactId>scala-library</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                    <version>2.11.6</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+                    <artifactId>concurrentlinkedhashmap-lru</artifactId>
+                    <version>1.4.2</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- *** WARNING *** -->

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jHelper.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/structure/Neo4jHelper.java
@@ -19,15 +19,14 @@
 package org.apache.tinkerpop.gremlin.neo4j.structure;
 
 import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.neo4j.tinkerpop.api.Neo4jNode;
-import org.neo4j.tinkerpop.api.Neo4jRelationship;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class Neo4jHelper {
+
+    private static final String NOT_FOUND_EXCEPTION = "NotFoundException";
 
     private Neo4jHelper() {
     }
@@ -45,13 +44,16 @@ public final class Neo4jHelper {
         try {
             node.getKeys();
             return false;
-        } catch (final IllegalStateException e) {
-            return true;
+        } catch (final RuntimeException e) {
+            if (isNotFound(e))
+                return true;
+            else
+                throw e;
         }
     }
 
-    public static boolean isNotFound(RuntimeException ex) {
-        return ex.getClass().getSimpleName().equals("NotFoundException");
+    public static boolean isNotFound(final RuntimeException ex) {
+        return ex.getClass().getSimpleName().equals(NOT_FOUND_EXCEPTION);
     }
 
     public static Neo4jNode getVertexPropertyNode(final Neo4jVertexProperty vertexProperty) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-899

This has been implemented and tested with `-DincludeNeo4j`. Note the `<exclusions>` I had to do in `<scope>test</scope>` as Neo4j doesn't use enforcer-plugin and they have self conflicts. I picked the highest version number of the self-conflict as the version to use.

Again, tested with `mvn clean install -DincludeNeo4j`.

My VOTE is +1.