### PR TITLE
TINKERPOP3-768: MatchStep in OLAP should be smart about current vertex.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.0 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `CountMatchAlgorithm`, in OLAP, now biases traversal selection towards those traversals that start at the current traverser location to reduce message passing.
+* Fixed a file stream bug in Hadoop OLTP that showed up if the streamed file was more than 2G of data.
 * Bumped to Neo4j 2.3.0.
 * Added `PersistedInputRDD` and `PersistedOutputRDD` which enables `SparkGraphComputer` to store the graph RDD in the context between jobs (no HDFS serialization required).
 * Renamed the `public static String` configuration variable names of TinkerGraph (deprecated old variables).

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
@@ -314,7 +314,7 @@ public class MatchStepTest extends StepTest {
 
     @Test
     public void testComputerAwareCountMatchAlgorithm() {
-        // MAKE SURE THE SORT ORDER CHANGES AS MORE RESULTS ARE RETURNED BY ONE OR THE OTHER TRAVERSAL
+        // MAKE SURE OLAP JOBS ARE BIASED TOWARDS STAR GRAPH DATA
         final Consumer doNothing = s -> {
         };
         Traversal.Admin<?, ?> traversal = __.match(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-768

The previous implementation of MatchStep was not biased to patterns that start at the current vertex. In OLTP, this is good. In OLAP, this is really really really bad as you are incuring a massive overhead with inter process communication. Thus, optimization, in OLAP, will sort the patterns first by whether the traverser needs to leave the current object location and then by TraversalType and then by multiplicity of the pattern. In the process, I cleaned up a few things here and there in MatchStep.

Ran `mvn clean install` and all is good.

VOTE +1.