### PR TITLE
TINKERPOP3-931 modified the scopes of OpProcessor

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -59,7 +59,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  */
 public abstract class AbstractEvalOpProcessor implements OpProcessor {
     private static final Logger logger = LoggerFactory.getLogger(AbstractEvalOpProcessor.class);
-    private static final Timer evalOpTimer = MetricManager.INSTANCE.getTimer(name(GremlinServer.class, "op", "eval"));
+    public static final Timer evalOpTimer = MetricManager.INSTANCE.getTimer(name(GremlinServer.class, "op", "eval"));
 
     /**
      * This may or may not be the full set of invalid binding keys.  It is dependent on the static imports made to

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -56,7 +56,7 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
     /**
      * Script engines are evaluated in a per session context where imports/scripts are isolated per session.
      */
-    private static ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
+    protected static ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
 
     static {
         MetricManager.INSTANCE.getGuage(sessions::size, name(GremlinServer.class, "sessions"));
@@ -159,8 +159,11 @@ public class SessionOpProcessor extends AbstractEvalOpProcessor {
         });
     }
 
-
-    private static Session getSession(final Context context, final RequestMessage msg) {
+    /**
+     * Examines the {@link RequestMessage} and extracts the session token. The session is then either found or a new
+     * one is created.
+     */
+    protected static Session getSession(final Context context, final RequestMessage msg) {
         final String sessionId = (String) msg.getArgs().get(Tokens.ARGS_SESSION);
 
         logger.debug("In-session request {} for eval for session {} in thread {}",


### PR DESCRIPTION
increases scope of various OpProcessor implementation to make them more extensible. Added javadoc.

https://issues.apache.org/jira/browse/TINKERPOP3-931