### PR TITLE
TINKERPOP3-914 Gremlin Console :remote to Gremlin Server supports alias

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.0 (NOT OFFICIALLY RELEASED YET)
 
 * Optimized `BulkLoaderVertexProgram`. It now uses `EventStrategy` to monitor what the underlying `BulkLoader` implementation does (e.g. whether it creates a new vertex or returns an existing).
 * Integrated `NumberHelper` in `SumStep`, `MinStep`, `MaxStep` and `MeanStep` (local and global step variants).
+* Gremlin Console remoting to Gremlin Server now supports a configuration option for assigning aliases.
 * `CountMatchAlgorithm`, in OLAP, now biases traversal selection towards those traversals that start at the current traverser location to reduce message passing.
 * Fixed a file stream bug in Hadoop OLTP that showed up if the streamed file was more than 2G of data.
 * Added the ability to set thread local properties in `SparkGraphComputer` when using a persistent context.

--- a/docs/src/gremlin-applications.asciidoc
+++ b/docs/src/gremlin-applications.asciidoc
@@ -438,6 +438,33 @@ submitting `:> graph` will return a `Graph` instance and in most cases those are
 and will return a serialization error.  It should be noted that `TinkerGraph`, as a convenience for shipping around
 small sub-graphs, is serializable from Gremlin Server.
 
+The Gremlin Server `:remote` command has the following configuration options:
+
+[width="100%",cols="3,10a",options="header"]
+|=========================================================
+|Command |Description
+|alias |
+[width="100%",cols="3,10",options="header"]
+!=========================================================
+!Option !Description
+! _pairs_ !A set of key/value alias/binding pairs to apply to requests.
+!`reset` !Clears any aliases that were supplied in previous configurations of the remote.
+!`show` !Shows the current set of aliases which is returned as a `Map`
+!=========================================================
+|timeout |Specifies the length of time in milliseconds that the remote will wait for a response from the server.
+|=========================================================
+
+The `alias` configuration command for the Gremlin Server `:remote` can be useful in situations where there are
+multiple `Graph` or `TraversalSource` instances on the server, as it becomes possible to rename them from the client
+for purposes of execution within the context of a script.  Therefore, it becomes possible to submit commands this way:
+
+[gremlin-groovy]
+----
+:remote connect tinkerpop.server conf/remote-objects.yaml
+:remote config alias x g
+:> x.E().label().groupCount()
+----
+
 Connecting via Java
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/src/upgrade-release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade-release-3.1.x-incubating.asciidoc
@@ -85,7 +85,6 @@ TinkerGraph-Gremlin Updates
 
 * The `public static String` configurations have been renamed. The old `public static` variables have been deprecated.
 
-
 Gremlin Process
 ^^^^^^^^^^^^^^^
 
@@ -108,11 +107,31 @@ Graph Traversal Updates
 ** Use `select(keys)` and `select(columns)`. However, note that `select()` will not unroll the keys/values. Thus, `mapKeys()` => `select(keys).unfold()`.
 
 Gremlin-Groovy Updates
-++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^
 
 * The closure wrappers classes `GFunction`, `GSupplier`, `GConsumer` have been deprecated.
 ** In Groovy, a closure can be specified using `as Function` and thus, these wrappers are not needed.
 * The `GremlinExecutor.promoteBindings()` method which was previously deprecated has been removed.
+
+
+Gremlin Console
+^^^^^^^^^^^^^^^
+
+Aliasing Remotes
+++++++++++++++++
+
+The `:remote` command in Gremlin Console has a new `alias` configuration option.  This `alias` option allows
+specification of a set of key/value alias/binding pairs to apply to the remote.  In this way, it becomes possible
+to refer to a variable on the server as something other than what it is referred to for purpose of the submitted
+script.  For example once a `:remote` is created, this command:
+
+[source,text]
+:remote alias x g
+
+would allow "g" on the server to be referred to as "x".
+
+[source,text]
+:> x.E().label().groupCount()
 
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
@@ -105,6 +105,14 @@ public class DriverRemoteAcceptorIntegrateTest extends AbstractGremlinServerInte
     }
 
     @Test
+    public void shouldConnectAndReturnVerticesWithAnAlias() throws Exception {
+        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        acceptor.configure(Arrays.asList("alias", "x", "g"));
+        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("x.addVertex('name','stephen');x.addVertex('name','marko');x.traversal().V()")))), hasSize(2));
+        assertThat(((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).stream().map(Result::getString).collect(Collectors.toList()), hasSize(2));
+    }
+
+    @Test
     public void shouldConnectAndSubmitForNull() throws Exception {
         assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
         assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("g.traversal().V().drop().iterate();null")))), contains("null"));

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorTest.java
@@ -27,8 +27,10 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -51,6 +53,44 @@ public class DriverRemoteAcceptorTest {
         } catch (Exception ex) {
             ex.printStackTrace();
         }
+    }
+
+    @Test(expected = RemoteException.class)
+    public void shouldNotConfigureWithBadCommand() throws Exception {
+        acceptor.configure(Arrays.asList("test"));
+    }
+
+    @Test(expected = RemoteException.class)
+    public void shouldNotConfigureWithUnevenPairsOfAliases() throws Exception {
+        acceptor.configure(Arrays.asList("alias g social x"));
+    }
+
+    @Test
+    public void shouldResetAliases() throws Exception {
+        final Map<String,String> resetAliases = (Map<String,String>) acceptor.configure(Arrays.asList("alias", "g", "main.social"));
+        assertEquals(1, resetAliases.size());
+        assertEquals("main.social", resetAliases.get("g"));
+
+        assertEquals("Aliases cleared", acceptor.configure(Arrays.asList("alias", "reset")));
+
+        final Map<String,String> shownAliases = (Map<String,String>) acceptor.configure(Arrays.asList("alias", "show"));
+        assertEquals(0, shownAliases.size());
+    }
+
+    @Test
+    public void shouldAddOverwriteAndShowAliases() throws Exception {
+        final Map<String,String> aliases = (Map<String,String>) acceptor.configure(Arrays.asList("alias", "g", "social", "graph", "main"));
+        assertEquals(2, aliases.size());
+        assertEquals("social", aliases.get("g"));
+        assertEquals("main", aliases.get("graph"));
+
+        final Map<String,String> resetAliases = (Map<String,String>) acceptor.configure(Arrays.asList("alias", "g", "main.social"));
+        assertEquals(1, resetAliases.size());
+        assertEquals("main.social", resetAliases.get("g"));
+
+        final Map<String,String> shownAliases = (Map<String,String>) acceptor.configure(Arrays.asList("alias", "show"));
+        assertEquals(1, shownAliases.size());
+        assertEquals("main.social", shownAliases.get("g"));
     }
 
     @Test(expected = RemoteException.class)

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -262,6 +262,30 @@ public abstract class Client {
         }
 
         /**
+         * The asynchronous version of {@link #submit(String, Map)}} where the returned future will complete when the
+         * write of the request completes.
+         *
+         * @param gremlin the gremlin script to execute
+         * @param parameters a map of parameters that will be bound to the script on execution
+         * @param aliases aliases the specified global Gremlin Server variable some other name that then be used in the
+         *                script where the key is the alias name and the value represents the global variable on the
+         *                server
+         */
+        public CompletableFuture<ResultSet> submitAsync(final String gremlin, final Map<String,String> aliases,
+                                                        final Map<String, Object> parameters) {
+            final RequestMessage.Builder request = RequestMessage.build(Tokens.OPS_EVAL)
+                    .add(Tokens.ARGS_GREMLIN, gremlin)
+                    .add(Tokens.ARGS_BATCH_SIZE, cluster.connectionPoolSettings().resultIterationBatchSize);
+
+            Optional.ofNullable(parameters).ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, parameters));
+
+            if (aliases != null && !aliases.isEmpty())
+                request.addArg(Tokens.ARGS_REBINDINGS, aliases);
+
+            return submitAsync(buildMessage(request));
+        }
+
+        /**
          * {@inheritDoc}
          */
         @Override

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -77,8 +77,8 @@ public final class Cluster {
      * error will not be raised at this point.  Connections get initialized in the {@link Client} when a request is
      * submitted or can be directly initialized via {@link Client#init()}.
      */
-    public Client connect() {
-        return new Client.ClusteredClient(this);
+    public <T extends Client> T connect() {
+        return (T) new Client.ClusteredClient(this);
     }
 
     /**
@@ -94,10 +94,10 @@ public final class Cluster {
      *
      * @param sessionId user supplied id for the session which should be unique (a UUID is ideal).
      */
-    public Client connect(final String sessionId) {
+    public <T extends Client> T connect(final String sessionId) {
         if (null == sessionId || sessionId.isEmpty())
             throw new IllegalArgumentException("sessionId cannot be null or empty");
-        return new Client.SessionedClient(this, sessionId);
+        return (T) new Client.SessionedClient(this, sessionId);
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-914

Added a "alias" option to :remote config that lets the user supply key/value pairs representing the aliases.  Included "show" and "reset" options as well.  Updated docs which generate nicely. 

Unit tests were added as well as integration tests so build/test should be:

```text
mvn clean install
mvn clean install -DskipIntegrationTests=false -pl gremlin-console
```

Test manually after starting gremlin server with:

```text
gremlin> :remote connect tinkerpop.server conf/remote.yaml
==>Connected - localhost/127.0.0.1:8182
gremlin> :> TinkerFactory.generateModern(graph)
==>null
gremlin> :> graph
==>tinkergraph[vertices:6 edges:6]
gremlin> :> g.V()
==>v[1]
==>v[2]
==>v[3]
==>v[4]
==>v[5]
==>v[6]
gremlin> :remote config alias x g
==>x=g
gremlin> :> x.V()
==>v[1]
==>v[2]
==>v[3]
==>v[4]
==>v[5]
==>v[6]
gremlin> :remote config alias show
==>x=g
gremlin> :remote config alias reset
==>Aliases cleared
gremlin> :remote config alias show
gremlin> 
```

VOTE: +1