### PR TITLE
TINKERPOP3-955 Registered HashMap$Node to GryoMapper.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
@@ -174,6 +174,22 @@ public final class GryoMapper implements Mapper<Kryo> {
         private static final Class LINKED_HASH_MAP_ENTRY_CLASS = m.entrySet().iterator().next().getClass();
 
         /**
+         * The {@code HashMap$Node} class comes into serialization play when a {@code Map.entrySet()} is
+         * serialized.
+         */
+        private static final Class HASH_MAP_NODE;
+
+        static {
+            // have to instantiate this via reflection because it is a private inner class of HashMap
+            final String className = HashMap.class.getName() + "$Node";
+            try {
+                HASH_MAP_NODE = Class.forName(className);
+            } catch (Exception ex) {
+                throw new RuntimeException("Could not access " + className, ex);
+            }
+        }
+
+        /**
          * Note that the following are pre-registered boolean, Boolean, byte, Byte, char, Character, double, Double,
          * int, Integer, float, Float, long, Long, short, Short, String, void.
          */
@@ -212,6 +228,7 @@ public final class GryoMapper implements Mapper<Kryo> {
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(EnumSet.class, null, 46));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(HashMap.class, null, 11));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(HashMap.Entry.class, null, 16));
+            add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(HASH_MAP_NODE, null, 92));   // ***LAST ID**
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(KryoSerializable.class, null, 36));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(LinkedHashMap.class, null, 47));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(LinkedHashSet.class, null, 71));
@@ -248,7 +265,7 @@ public final class GryoMapper implements Mapper<Kryo> {
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(B_LP_O_S_SE_SL_Traverser.class, null, 87));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(O_OB_S_SE_SL_Traverser.class, null, 89));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(LP_O_OB_S_SE_SL_Traverser.class, null, 90));
-            add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(LP_O_OB_P_S_SE_SL_TraverserGenerator.class, null, 91)); // ***LAST ID**
+            add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(LP_O_OB_P_S_SE_SL_TraverserGenerator.class, null, 91));
 
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(TraverserSet.class, null, 58));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(Tree.class, null, 61));

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinResultSetIntegrateTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.server;
 
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -36,7 +37,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -118,5 +124,28 @@ public class GremlinResultSetIntegrateTest extends AbstractGremlinServerIntegrat
         final ResultSet results = client.submit("g.V().out().path()");
         final Path p = results.all().get().get(0).getPath();
         assertThat(p, instanceOf(DetachedPath.class));
+    }
+
+    @Test
+    public void shouldHandleMapIteratedResult() throws Exception {
+        final ResultSet results = client.submit("g.V().groupCount().by(bothE().count())");
+        final List<Result> resultList = results.all().get();
+        final Map m = resultList.get(0).get(HashMap.class);
+        assertEquals(2, m.size());
+        assertEquals(3l, m.get(1l));
+        assertEquals(3l, m.get(3l));
+    }
+
+    @Test
+    public void shouldHandleMapObjectResult() throws Exception {
+        final ResultSet results = client.submit("g.V().groupCount().by(bothE().count()).next()");
+        final List<Result> resultList = results.all().get();
+        assertEquals(2, resultList.size());
+        final Map.Entry firstEntry = resultList.get(0).get(HashMap.Entry.class);
+        final Map.Entry secondEntry = resultList.get(1).get(HashMap.Entry.class);
+        assertThat(firstEntry.getKey(), anyOf(is(3l), is(1l)));
+        assertThat(firstEntry.getValue(), is(3l));
+        assertThat(secondEntry.getKey(), anyOf(is(3l), is(1l)));
+        assertThat(secondEntry.getValue(), is(3l));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-955

Note that this class had to be registered via reflection as it is a private class of HashMap. Added tests to validate that the change works with the code specified in the issue. 

Please review as it pertains to area of serialization that you are familiar with.  To test with gremlin-server you need to run the integration tests:

```text
mvn clean install
mvn verify -pl gremlin-server -DskipIntegrationTests=false
```

VOTE: +1

btw, we _could_ postpone this to 3.1.1 if we wanted - i think. there is a workaround to the bug in that the person just doesn't have to `next()` the result to get it to serialize.  