### PR TITLE
TINKERPOP3-978 Native GraphSON Serialization for Gremlin Server

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `TinkerGraph` has "native" serialization in GraphSON, which enables it to be a return value from Gremlin Server.
 * Added `explain()`-step which yields a `TraversalExplanation` with a pretty `toString()` detailing the compilation process.
 * Fixed a traversal strategy ordering bug in `AdjacentToIncidentStrategy` and `IncidentToAdjacentStrategy`.
 * Made a number of changes to improve traversal startup and execution performance.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONReader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONReader.java
@@ -252,8 +252,8 @@ public final class GraphSONReader implements GraphReader {
     private Stream<String> readVertexStrings(final InputStream inputStream) throws IOException {
         if (unwrapAdjacencyList) {
             final JsonNode root = mapper.readTree(inputStream);
-            final JsonNode vertices = root.get("vertices");
-            if (!vertices.getNodeType().equals(JsonNodeType.ARRAY)) throw new IOException("The 'vertices' key must be an array");
+            final JsonNode vertices = root.get(GraphSONTokens.VERTICES);
+            if (!vertices.getNodeType().equals(JsonNodeType.ARRAY)) throw new IOException(String.format("The '%s' key must be an array", GraphSONTokens.VERTICES));
             return IteratorUtils.stream(vertices.elements()).map(Object::toString);
         } else {
             final BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTokens.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTokens.java
@@ -32,7 +32,9 @@ public final class GraphSONTokens {
     public static final String PROPERTIES = "properties";
     public static final String KEY = "key";
     public static final String EDGE = "edge";
+    public static final String EDGES = "edges";
     public static final String VERTEX = "vertex";
+    public static final String VERTICES = "vertices";
     public static final String IN = "inV";
     public static final String OUT = "outV";
     public static final String IN_E = "inE";

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONUtil.java
@@ -34,18 +34,24 @@ public final class GraphSONUtil {
 
     private GraphSONUtil() {}
 
+    public static void writeWithType(final Object object, final JsonGenerator jsonGenerator,
+                                     final SerializerProvider serializerProvider,
+                                     final TypeSerializer typeSerializer) throws IOException {
+        writeWithType(null, object, jsonGenerator, serializerProvider, typeSerializer);
+    }
+
     public static void writeWithType(final String key, final Object object, final JsonGenerator jsonGenerator,
                                      final SerializerProvider serializerProvider,
                                      final TypeSerializer typeSerializer) throws IOException {
         final JsonSerializer<Object> serializer = serializerProvider.findValueSerializer(object.getClass(), null);
         if (typeSerializer != null) {
             // serialize with types embedded
-            jsonGenerator.writeFieldName(key);
+            if (key != null && !key.isEmpty()) jsonGenerator.writeFieldName(key);
             serializer.serializeWithType(object, jsonGenerator, serializerProvider, typeSerializer);
         } else {
             // types are not embedded, but use the serializer when possible or else custom serializers will get
             // bypassed and you end up with the default jackson serializer when you don't want it.
-            jsonGenerator.writeFieldName(key);
+            if (key != null && !key.isEmpty()) jsonGenerator.writeFieldName(key);
             serializer.serialize(object, jsonGenerator, serializerProvider);
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONWriter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONWriter.java
@@ -100,7 +100,7 @@ public final class GraphSONWriter implements GraphWriter {
     public void writeVertices(final OutputStream outputStream, final Iterator<Vertex> vertexIterator, final Direction direction) throws IOException {
         final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            if (wrapAdjacencyList) writer.write("{\"vertices\":[");
+            if (wrapAdjacencyList) writer.write("{\"" + GraphSONTokens.VERTICES + "\":[");
             while (vertexIterator.hasNext()) {
                 writeVertex(baos, vertexIterator.next(), direction);
                 writer.write(new String(baos.toByteArray()));

--- a/gremlin-server/conf/gremlin-server-min.yaml
+++ b/gremlin-server/conf/gremlin-server-min.yaml
@@ -29,8 +29,8 @@ scriptEngines: {
   gremlin-groovy: {
     imports: []}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }}  # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}         # application/json
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
 threadPoolBoss: 1

--- a/gremlin-server/conf/gremlin-server-neo4j.yaml
+++ b/gremlin-server/conf/gremlin-server-neo4j.yaml
@@ -45,10 +45,10 @@ scriptEngines: {
       imports: [java.lang.Math],
       staticImports: [java.lang.Math.PI]}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0 }                                             # application/vnd.gremlin-v1.0+gryo
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}            # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}        # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }} # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}        # application/json
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -32,8 +32,8 @@ scriptEngines: {
     staticImports: [java.lang.Math.PI],
     scripts: [scripts/generate-modern.groovy]}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }}  # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}         # application/json
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
 threadPoolBoss: 1

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -45,10 +45,10 @@ scriptEngines: {
               "org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptCustomizerProvider":[10000],
               "org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.CompileStaticCustomizerProvider":["org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.SimpleSandboxExtension"]}}}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0 }                                             # application/vnd.gremlin-v1.0+gryo
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}            # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}        # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }} # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}        # application/json
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -45,10 +45,10 @@ scriptEngines: {
               "org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptCustomizerProvider":[10000],
               "org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.CompileStaticCustomizerProvider":["org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.SimpleSandboxExtension"]}}}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}       # application/vnd.gremlin-v1.0+gryo
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}            # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}        # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }} # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}        # application/json
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/gremlin-server/conf/gremlin-server-spark.yaml
+++ b/gremlin-server/conf/gremlin-server-spark.yaml
@@ -58,10 +58,10 @@ scriptEngines: {
       imports: [java.lang.Math],
       staticImports: [java.lang.Math.PI]}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}       # application/vnd.gremlin-v1.0+gryo
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}            # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}        # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }} # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}        # application/json
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/gremlin-server/conf/gremlin-server.yaml
+++ b/gremlin-server/conf/gremlin-server.yaml
@@ -35,10 +35,10 @@ scriptEngines: {
       imports: [java.lang.Math],
       staticImports: [java.lang.Math.PI]}}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}       # application/vnd.gremlin-v1.0+gryo
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }                                  # application/vnd.gremlin-v1.0+json
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }                                         # application/json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}            # application/vnd.gremlin-v1.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}        # application/vnd.gremlin-v1.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }} # application/vnd.gremlin-v1.0+json
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}        # application/json
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -36,8 +36,8 @@ scriptEngines: {
 serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph, custom: [groovy.json.JsonBuilder;org.apache.tinkerpop.gremlin.driver.ser.JsonBuilderGryoSerializer]}}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true}}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { useMapperFromGraph: graph }}
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistry.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistry.java
@@ -18,18 +18,44 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.AbstractIoRegistry;
+import org.apache.tinkerpop.gremlin.structure.io.GraphReader;
+import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
 import org.apache.tinkerpop.gremlin.structure.io.IoRegistry;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONTokens;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONUtil;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoReader;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoWriter;
+import org.apache.tinkerpop.gremlin.structure.util.Attachable;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
+import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
+import org.apache.tinkerpop.shaded.jackson.core.JsonGenerator;
+import org.apache.tinkerpop.shaded.jackson.core.JsonParser;
+import org.apache.tinkerpop.shaded.jackson.core.JsonProcessingException;
+import org.apache.tinkerpop.shaded.jackson.databind.DeserializationContext;
+import org.apache.tinkerpop.shaded.jackson.databind.SerializerProvider;
+import org.apache.tinkerpop.shaded.jackson.databind.deser.std.StdDeserializer;
+import org.apache.tinkerpop.shaded.jackson.databind.jsontype.TypeSerializer;
+import org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule;
+import org.apache.tinkerpop.shaded.jackson.databind.ser.std.StdSerializer;
 import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.Serializer;
 import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
+import org.javatuples.Pair;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * An implementation of the {@link IoRegistry} interface that provides serializers with custom configurations for
@@ -48,7 +74,8 @@ public final class TinkerIoRegistry extends AbstractIoRegistry {
     private static final TinkerIoRegistry INSTANCE = new TinkerIoRegistry();
 
     private TinkerIoRegistry() {
-        register(GryoIo.class, TinkerGraph.class, new TinkerGraphSerializer());
+        register(GryoIo.class, TinkerGraph.class, new TinkerGraphGryoSerializer());
+        register(GraphSONIo.class, null, new TinkerModule());
     }
 
     public static TinkerIoRegistry getInstance() {
@@ -56,10 +83,10 @@ public final class TinkerIoRegistry extends AbstractIoRegistry {
     }
 
     /**
-     * Provides a method to serialize an entire {@link TinkerGraph} into itself.  This is useful when shipping small
-     * graphs around through Gremlin Server. Reuses the existing Kryo instance for serialization.
+     * Provides a method to serialize an entire {@link TinkerGraph} into itself for Gryo.  This is useful when
+     * shipping small graphs around through Gremlin Server. Reuses the existing Kryo instance for serialization.
      */
-    final static class TinkerGraphSerializer extends Serializer<TinkerGraph> {
+    final static class TinkerGraphGryoSerializer extends Serializer<TinkerGraph> {
         @Override
         public void write(final Kryo kryo, final Output output, final TinkerGraph graph) {
             try (final ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
@@ -81,6 +108,147 @@ public final class TinkerIoRegistry extends AbstractIoRegistry {
                 GryoReader.build().mapper(() -> kryo).create().readGraph(stream, graph);
             } catch (Exception io) {
                 throw new RuntimeException(io);
+            }
+
+            return graph;
+        }
+    }
+
+    /**
+     * Provides a method to serialize an entire {@link TinkerGraph} into itself for GraphSON.  This is useful when
+     * shipping small graphs around through Gremlin Server.
+     */
+    final static class TinkerModule extends SimpleModule {
+        public TinkerModule() {
+            super("tinkergraph-1.0");
+            addSerializer(TinkerGraph.class, new TinkerGraphJacksonSerializer());
+            addDeserializer(TinkerGraph.class, new TinkerGraphJacksonDeserializer());
+        }
+    }
+
+    /**
+     * Serializes the graph into an edge list format.  Edge list is a better choices than adjacency list (which is
+     * typically standard from the {@link GraphReader} and {@link GraphWriter} perspective) in this case because
+     * the use case for this isn't around massive graphs.  The use case is for "small" subgraphs that are being
+     * shipped over the wire from Gremlin Server. Edge list is format is a bit easier for non-JVM languages to work
+     * with as a format and doesn't require a cache for loading (as vertex labels are not serialized in adjacency
+     * list).
+     */
+    final static class TinkerGraphJacksonSerializer extends StdSerializer<TinkerGraph> {
+
+        public TinkerGraphJacksonSerializer() {
+            super(TinkerGraph.class);
+        }
+
+        @Override
+        public void serialize(final TinkerGraph graph, final JsonGenerator jsonGenerator, final SerializerProvider serializerProvider)
+                throws IOException {
+            jsonGenerator.writeStartObject();
+
+            jsonGenerator.writeFieldName(GraphSONTokens.VERTICES);
+            jsonGenerator.writeStartArray();
+
+            final Iterator<Vertex> vertices = graph.vertices();
+            while (vertices.hasNext()) {
+                serializerProvider.defaultSerializeValue(vertices.next(), jsonGenerator);
+            }
+
+            jsonGenerator.writeEndArray();
+
+            jsonGenerator.writeFieldName(GraphSONTokens.EDGES);
+            jsonGenerator.writeStartArray();
+
+            final Iterator<Edge> edges = graph.edges();
+            while (edges.hasNext()) {
+                serializerProvider.defaultSerializeValue(edges.next(), jsonGenerator);
+            }
+
+            jsonGenerator.writeEndArray();
+
+            jsonGenerator.writeEndObject();
+        }
+
+        @Override
+        public void serializeWithType(final TinkerGraph graph, final JsonGenerator jsonGenerator,
+                                      final SerializerProvider serializerProvider, final TypeSerializer typeSerializer) throws IOException {
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField(GraphSONTokens.CLASS, TinkerGraph.class.getName());
+
+            jsonGenerator.writeFieldName(GraphSONTokens.VERTICES);
+            jsonGenerator.writeStartArray();
+            jsonGenerator.writeString(ArrayList.class.getName());
+            jsonGenerator.writeStartArray();
+
+            final Iterator<Vertex> vertices = graph.vertices();
+            while (vertices.hasNext()) {
+                GraphSONUtil.writeWithType(vertices.next(), jsonGenerator, serializerProvider, typeSerializer);
+            }
+
+            jsonGenerator.writeEndArray();
+            jsonGenerator.writeEndArray();
+
+            jsonGenerator.writeFieldName(GraphSONTokens.EDGES);
+            jsonGenerator.writeStartArray();
+            jsonGenerator.writeString(ArrayList.class.getName());
+            jsonGenerator.writeStartArray();
+
+            final Iterator<Edge> edges = graph.edges();
+            while (edges.hasNext()) {
+                GraphSONUtil.writeWithType(edges.next(), jsonGenerator, serializerProvider, typeSerializer);
+            }
+
+            jsonGenerator.writeEndArray();
+            jsonGenerator.writeEndArray();
+
+            jsonGenerator.writeEndObject();
+        }
+    }
+
+    /**
+     * Deserializes the edge list format.
+     */
+    static class TinkerGraphJacksonDeserializer extends StdDeserializer<TinkerGraph> {
+        public TinkerGraphJacksonDeserializer() {
+            super(TinkerGraph.class);
+        }
+
+        @Override
+        public TinkerGraph deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            final TinkerGraph graph = TinkerGraph.open();
+
+            final List<Map<String, Object>> edges;
+            final List<Map<String, Object>> vertices;
+            if (!jsonParser.getCurrentToken().isStructStart()) {
+                if (!jsonParser.getCurrentName().equals(GraphSONTokens.VERTICES))
+                    throw new IOException(String.format("Expected a '%s' key", GraphSONTokens.VERTICES));
+
+                jsonParser.nextToken();
+                vertices = (List<Map<String, Object>>) deserializationContext.readValue(jsonParser, ArrayList.class);
+                jsonParser.nextToken();
+
+                if (!jsonParser.getCurrentName().equals(GraphSONTokens.EDGES))
+                    throw new IOException(String.format("Expected a '%s' key", GraphSONTokens.EDGES));
+
+                jsonParser.nextToken();
+                edges = (List<Map<String, Object>>) deserializationContext.readValue(jsonParser, ArrayList.class);
+            } else {
+                final Map<String, Object> graphData = deserializationContext.readValue(jsonParser, HashMap.class);
+                vertices = (List<Map<String,Object>>) graphData.get("vertices");
+                edges = (List<Map<String,Object>>) graphData.get("edges");
+            }
+
+            for (Map<String, Object> vertexData : vertices) {
+                final DetachedVertex detached = new DetachedVertex(vertexData.get(GraphSONTokens.ID),
+                        vertexData.get(GraphSONTokens.LABEL).toString(), (Map<String,Object>) vertexData.get(GraphSONTokens.PROPERTIES));
+                detached.attach(Attachable.Method.getOrCreate(graph));
+            }
+
+            for (Map<String, Object> edgeData : edges) {
+                final DetachedEdge detached = new DetachedEdge(edgeData.get(GraphSONTokens.ID),
+                        edgeData.get(GraphSONTokens.LABEL).toString(), (Map<String,Object>) edgeData.get(GraphSONTokens.PROPERTIES),
+                        Pair.with(edgeData.get(GraphSONTokens.OUT), edgeData.get(GraphSONTokens.OUT_LABEL).toString()),
+                        Pair.with(edgeData.get(GraphSONTokens.IN), edgeData.get(GraphSONTokens.IN_LABEL).toString()));
+                detached.attach(Attachable.Method.getOrCreate(graph));
             }
 
             return graph;

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistry.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerIoRegistry.java
@@ -233,8 +233,8 @@ public final class TinkerIoRegistry extends AbstractIoRegistry {
                 edges = (List<Map<String, Object>>) deserializationContext.readValue(jsonParser, ArrayList.class);
             } else {
                 final Map<String, Object> graphData = deserializationContext.readValue(jsonParser, HashMap.class);
-                vertices = (List<Map<String,Object>>) graphData.get("vertices");
-                edges = (List<Map<String,Object>>) graphData.get("edges");
+                vertices = (List<Map<String,Object>>) graphData.get(GraphSONTokens.VERTICES);
+                edges = (List<Map<String,Object>>) graphData.get(GraphSONTokens.EDGES);
             }
 
             for (Map<String, Object> vertexData : vertices) {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGryoSerializerTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphGryoSerializerTest.java
@@ -38,10 +38,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistry.TinkerGraphSerializer}
+ * Unit tests for {@link TinkerIoRegistry.TinkerGraphGryoSerializer}
  */
 @RunWith(MockitoJUnitRunner.class)
-public class TinkerGraphSerializerTest {
+public class TinkerGraphGryoSerializerTest {
 
     @Mock
     private Kryo kryo;
@@ -53,7 +53,7 @@ public class TinkerGraphSerializerTest {
     private Input input;
 
     private TinkerGraph graph = TinkerGraph.open();
-    private TinkerIoRegistry.TinkerGraphSerializer serializer = new TinkerIoRegistry.TinkerGraphSerializer();
+    private TinkerIoRegistry.TinkerGraphGryoSerializer serializer = new TinkerIoRegistry.TinkerGraphGryoSerializer();
 
     @Before
     public void setUp() throws Exception {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphTest.java
@@ -20,12 +20,19 @@ package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.IOUtils;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.io.GraphReader;
+import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
 import org.apache.tinkerpop.gremlin.structure.io.IoCore;
 import org.apache.tinkerpop.gremlin.structure.io.IoTest;
+import org.apache.tinkerpop.gremlin.structure.io.Mapper;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONReader;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -282,6 +289,34 @@ public class TinkerGraphTest {
             }
         }
     }
+
+    @Test
+    public void shouldSerializeTinkerGraphToGraphSON() throws Exception {
+        final TinkerGraph graph = TinkerFactory.createModern();
+        try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            graph.io(IoCore.graphson()).writer().create().writeObject(out, graph);
+            try (final ByteArrayInputStream inputStream = new ByteArrayInputStream(out.toByteArray())) {
+                final TinkerGraph target = graph.io(IoCore.graphson()).reader().create().readObject(inputStream, TinkerGraph.class);
+                IoTest.assertModernGraph(target, true, false);
+            }
+        }
+    }
+
+    @Test
+    public void shouldSerializeTinkerGraphToGraphSONWithTypes() throws Exception {
+        final TinkerGraph graph = TinkerFactory.createModern();
+        final Mapper<ObjectMapper> mapper = graph.io(IoCore.graphson()).mapper().embedTypes(true).create();
+        try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            final GraphWriter writer = GraphSONWriter.build().mapper(mapper).create();
+            writer.writeObject(out, graph);
+            try (final ByteArrayInputStream inputStream = new ByteArrayInputStream(out.toByteArray())) {
+                final GraphReader reader = GraphSONReader.build().mapper(mapper).create();
+                final TinkerGraph target = reader.readObject(inputStream, TinkerGraph.class);
+                IoTest.assertModernGraph(target, true, false);
+            }
+        }
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldRequireGraphLocationIfFormatIsSet() {
         final Configuration conf = new BaseConfiguration();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-978

We already had this feature for Gryo but it wasn't built for GraphSON as the original idea was to mostly support serialization over `:remote`.  That was a bit short-sighted in thinking so I've added the same capability for GraphSON as will be especially useful to non-JVM languages.

you can test with `mvn clean install` followed by the Gremlin Server integration tests:

```text
mvn verify -DskipIntegrationTests=false -pl gremlin-server
```

my vote is +1

@PommeVerte @jbmusso @davebshow - this one may be interesting to you and your driver work