### PR TITLE
initial travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+os:
+  - linux
+jdk:
+  - oraclejdk8
+sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+script: 
+  - "mvn clean install"
+  - "bin/process-docs.sh --dryRun"
+  - "mvn process-resources -Djavadoc"

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,7 @@ limitations under the License.
                 <configuration>
                     <excludeSubProjects>false</excludeSubProjects>
                     <excludes>
+                        <exclude>.travis.yml</exclude>
                         <exclude>.repository/**</exclude>
                         <exclude>docs/static/**</exclude>
                         <exclude>**/target/**</exclude>


### PR DESCRIPTION
Hey guys, 

This isn't so much ready for merge. I just wanted to put it out there for review and suggestions.
This PR aims at adding travis support. It currently checks:
-  `mvn clean install` 
- `bin/process-docs.sh --dryRun` (will fail if an error occurs, doesn't actually check docs)
- `mvn process-resources -Djavadoc` (will fail if an error occurs, doesn't actually check docs)

And the checks [pass](https://travis-ci.org/PommeVerte/incubator-tinkerpop/builds/92270450) and take about 20mn to run. There are however a few issues mentioned bellow.

I also ran into some rat-check issues early on. Excluded the `.travis.yml` from the checks but I don't know if any work needs to be done with licensing here? I'm guessing not but shout out if it's required.

Suggestions
=========
- adding support for [coveralls](https://coveralls.io/) could be cool. (test code coverage reports)
- use `ant` as a basis. I'm working on the assumption that that's what you guys are using in trying to set jenkins up? It should theoretically be possible to run the same build in both CI systems.

Issues
=====
- `-DincludeNeo4j` currently fails, not really sure why, will need to investigate. Waiting to sort this out before running integration tests.
- `osx` building/testing is possible but doesn't support the apt addons (it doesn't even skip them, it just fails). There's a possible workaround for this. 
- Need to add support for `bin/process-docs.sh` if you guys have any setup scripts for hadoop let me know.

Moving forward
============

If you feel that having these checks systematically run on PRs is desirable, we can merge this early and bring changes to it as we go.
It will only require a PMC with write rights to this repo to setup the travis account (or configure it)

If there's more stuff you want to see here let me know.