### PR TITLE
TINKERPOP3-984

### DIFF
--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/loaders/SugarLoaderTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/loaders/SugarLoaderTest.groovy
@@ -78,11 +78,11 @@ class SugarLoaderTest extends AbstractGremlinTest {
         assertEquals(6, g.V.count.next())
         assertEquals(6, g.V.out.count.next())
         assertEquals(6, g.V.out.name.count.next())
-        assertEquals(2, g.V(1).out.out.name.count.next());
-        g.V(1).next().name = 'okram'
-        assertEquals('okram', g.V(1).next().name);
-        g.V(1).next()['name'] = 'marko a. rodriguez'
-        assertEquals(["okram", "marko a. rodriguez"] as Set, g.V(1).values('name').toSet());
+        assertEquals(2, g.V(graphProvider.convertId(1, Vertex.class)).out.out.name.count.next());
+        g.V(graphProvider.convertId(1, Vertex.class)).next().name = 'okram'
+        assertEquals('okram', g.V(graphProvider.convertId(1, Vertex.class)).next().name);
+        g.V(graphProvider.convertId(1, Vertex.class)).next()['name'] = 'marko a. rodriguez'
+        assertEquals(["okram", "marko a. rodriguez"] as Set, g.V(graphProvider.convertId(1, Vertex.class)).values('name').toSet());
         assertEquals(29, g.V.age.is(eq(29)).next())
     }
 

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineIntegrateTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineIntegrateTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 
 import javax.script.Bindings;
@@ -51,7 +52,7 @@ public class GremlinGroovyScriptEngineIntegrateTest extends AbstractGremlinTest 
             for (int ix = 0; ix < 50001; ix++) {
                 final Bindings bindings = engine.createBindings();
                 bindings.put("g", g);
-                bindings.put("xxx", (ix % 4) + 1);
+                bindings.put("xxx", graphProvider.convertId((ix % 4) + 1, Vertex.class));
                 engine.eval(gremlins[ix % 4], bindings);
 
                 if (ix > 0 && ix % 5000 == 0) {

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineSandboxedStandardTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineSandboxedStandardTest.java
@@ -65,13 +65,15 @@ public class GremlinGroovyScriptEngineSandboxedStandardTest extends AbstractGrem
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine()) {
             final Bindings bindings = engine.createBindings();
             bindings.put("g", g);
-            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(" + convertToVertexId("marko") + ").next()", bindings));
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(marko).next()", bindings));
         }
 
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(notSandboxed)) {
             final Bindings bindings = engine.createBindings();
             bindings.put("g", g);
-            engine.eval("g.V(" + convertToVertexId("marko") + ").next()", bindings);
+            bindings.put("marko", convertToVertexId("marko"));
+            engine.eval("g.V(marko).next()", bindings);
             fail("Type checking should have forced an error as 'g' is not defined");
         } catch (Exception ex) {
             assertEquals(MultipleCompilationErrorsException.class, ex.getCause().getClass());
@@ -81,8 +83,9 @@ public class GremlinGroovyScriptEngineSandboxedStandardTest extends AbstractGrem
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(sandboxed)) {
             final Bindings bindings = engine.createBindings();
             bindings.put("g", g);
-            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(" + convertToVertexId("marko") + ").next()", bindings));
-            assertEquals(g.V(convertToVertexId("marko")).out("created").count().next(), engine.eval("g.V(" + convertToVertexId("marko") + ").out(\"created\").count().next()", bindings));
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(marko).next()", bindings));
+            assertEquals(g.V(convertToVertexId("marko")).out("created").count().next(), engine.eval("g.V(marko).out(\"created\").count().next()", bindings));
         }
     }
 
@@ -92,13 +95,15 @@ public class GremlinGroovyScriptEngineSandboxedStandardTest extends AbstractGrem
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine()) {
             final Bindings bindings = engine.createBindings();
             bindings.put("graph", graph);
-            assertEquals(graph.vertices(convertToVertexId("marko")).next(), engine.eval("graph.vertices(" + convertToVertexId("marko") + ").next()", bindings));
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(graph.vertices(convertToVertexId("marko")).next(), engine.eval("graph.vertices(marko).next()", bindings));
         }
 
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(notSandboxed)) {
             final Bindings bindings = engine.createBindings();
             bindings.put("graph", graph);
-            assertEquals(graph.vertices(convertToVertexId("marko")).next(), engine.eval("graph.vertices(" + convertToVertexId("marko") + ").next()", bindings));
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(graph.vertices(convertToVertexId("marko")).next(), engine.eval("graph.vertices(marko).next()", bindings));
             fail("Type checking should have forced an error as 'graph' is not defined");
         } catch (Exception ex) {
             assertEquals(MultipleCompilationErrorsException.class, ex.getCause().getClass());
@@ -119,7 +124,8 @@ public class GremlinGroovyScriptEngineSandboxedStandardTest extends AbstractGrem
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(sandboxed)) {
             final Bindings bindings = engine.createBindings();
             bindings.put("graph", graph);
-            assertEquals(graph.vertices(convertToVertexId("marko")).next(), engine.eval("graph.vertices(" + convertToVertexId("marko") + ").next()", bindings));
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(graph.vertices(convertToVertexId("marko")).next(), engine.eval("graph.vertices(marko).next()", bindings));
         }
 
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(sandboxed)) {

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTinkerPopSandboxTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTinkerPopSandboxTest.java
@@ -56,8 +56,9 @@ public class GremlinGroovyScriptEngineTinkerPopSandboxTest extends AbstractGreml
         try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
             final Bindings bindings = engine.createBindings();
             bindings.put("g", g);
-            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(" + convertToVertexId("marko") + ").next()", bindings));
-            assertEquals(g.V(convertToVertexId("marko")).out("created").count().next(), engine.eval("g.V(" + convertToVertexId("marko") + ").out(\"created\").count().next()", bindings));
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(marko).next()", bindings));
+            assertEquals(g.V(convertToVertexId("marko")).out("created").count().next(), engine.eval("g.V(marko).out(\"created\").count().next()", bindings));
         }
     }
 


### PR DESCRIPTION
Made possible to use GraphProvider to convert ids into Strings

The idea is to prevent this:
````
Script1.groovy: 1: unexpected char: '#' @ line 1, column 5.
   g.V(#11:0).next()
````