### PR TITLE
Fixed feature check in shouldPersistDataOnClose()

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -1205,7 +1205,7 @@ public class GraphTest extends AbstractGremlinTest {
 
         final Vertex v = graph.addVertex();
         final Vertex u = graph.addVertex();
-        if (graph.features().edge().properties().supportsStringValues()) {
+        if (graph.features().vertex().properties().supportsStringValues()) {
             v.property(VertexProperty.Cardinality.single, "name", "marko");
             u.property(VertexProperty.Cardinality.single, "name", "pavel");
         }


### PR DESCRIPTION
GraphTests.shouldPersistDataOnClose checked that *edges* supported String type properties before adding String type properties to *vertices*. Changed this check to be consistent with the operation being performed.

Additional Notes:
1) This unit test adds properties to vertices, but does not *explicitly* make the check for Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY support in its feature requirements. The feature requirement set SIMPLE does not include Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY, but rather includes the feature Graph.Features.VertexPropertyFeatures.FEATURE_ADD_PROPERTY, which is a check for being able to add meta properties. Therefore, since meta properties cannot be supported without basic add property support for vertices, the check for adding properties to vertices is *implicit*, not explicit. 
2) Although Graph.Features.VertexPropertyFeatures.FEATURE_ADD_PROPERTY is included in the feature set requirements for this unit test, this unit test does not actually depend on meta property support. This unit test will not run for graphs that support persistence, but do not support meta properties.