### PR TITLE
TINKERPOP3-970: ProfileStep should be off Traversal, not GraphTraversal

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traversal.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.StandardTraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
@@ -169,6 +170,15 @@ public interface Traversal<S, E> extends Iterator<E>, Serializable, Cloneable {
         } catch (final NoSuchElementException ignored) {
         }
         return (Traversal<A, B>) this;
+    }
+
+    /**
+     * Profile the traversal.
+     *
+     * @return the updated traversal with respective {@link ProfileStep}.
+     */
+    public default Traversal<S, E> profile() {
+        return this.asAdmin().addStep(new ProfileStep<>(this.asAdmin()));
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/__.java
@@ -827,10 +827,6 @@ public class __ {
         return __.<A>start().as(label, labels);
     }
 
-    public static <A> GraphTraversal<A, A> profile() {
-        return __.<A>start().profile();
-    }
-
     public static <A> GraphTraversal<A, A> barrier() {
         return __.<A>start().barrier();
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class GraphTraversalTest {
 
-    private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "option", "iterate", "to", "from"));
+    private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "option", "iterate", "to", "from", "profile"));
     private static Set<String> NO_ANONYMOUS = new HashSet<>(Arrays.asList("start", "__"));
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileStepTest.java
@@ -32,6 +32,6 @@ public class ProfileStepTest extends StepTest {
 
     @Override
     protected List<Traversal> getTraversals() {
-        return Collections.singletonList(__.profile());
+        return Collections.singletonList(__.identity().profile());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-970

A couple things.

* `Traversal.profile()` now exists. The point of the ticket.
* `__.profile()` does not exist. This shouldn't have been there to begin with.

Ran `mvn clean install` and all is golden. 

VOTE +1.