### PR TITLE
TINKERPOP3-941: Improve error message for wrong order().by() arguments

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
@@ -95,7 +95,7 @@ public final class OrderGlobalStep<S> extends CollectingBarrierStep<S> implement
 
     @Override
     public void addLocalChild(final Traversal.Admin<?, ?> localChildTraversal) {
-        throw new UnsupportedOperationException("Use OrderGlobalStep.addComparator(" + TraversalComparator.class.getSimpleName() + ") to add a local child traversal:" + this);
+        this.addComparator(new TraversalComparator<>((Traversal.Admin) localChildTraversal, Order.incr));
     }
 
     @Override
@@ -103,16 +103,10 @@ public final class OrderGlobalStep<S> extends CollectingBarrierStep<S> implement
         final OrderGlobalStep<S> clone = (OrderGlobalStep<S>) super.clone();
         clone.comparators = new ArrayList<>();
         for (final Comparator<S> comparator : this.comparators) {
-            if (comparator instanceof TraversalComparator) {
-                final TraversalComparator<S, ?> clonedTraversalComparator = ((TraversalComparator<S, ?>) comparator).clone();
-                clone.integrateChild(clonedTraversalComparator.getTraversal());
-                clone.comparators.add(clonedTraversalComparator);
-            } else
-                clone.comparators.add(comparator);
+            clone.addComparator(comparator instanceof TraversalComparator ? ((TraversalComparator) comparator).clone() : comparator);
         }
         return clone;
     }
-
 
     /////
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
@@ -96,5 +96,15 @@ public abstract class GroovyOrderTest {
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXvX_mapXbothE_weight_foldX_sumXlocalX_asXsX_selectXv_sX_order_byXselectXsX_decrX() {
             TraversalScriptHelper.compute("g.V.as('v').map(__.bothE.weight.fold).sum(local).as('s').select('v', 's').order.by(select('s'),decr)", g);
         }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_order_byXageX() {
+            TraversalScriptHelper.compute("g.V.hasLabel('person').order.by('age')", g);
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX() {
+            TraversalScriptHelper.compute("g.V.hasLabel('person').fold.order(local).by('age')", g)
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
@@ -74,6 +74,10 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, Object>> get_g_V_asXvX_mapXbothE_weight_foldX_sumXlocalX_asXsX_selectXv_sX_order_byXselectXsX_decrX();
 
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_order_byXageX();
+
+    public abstract Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_name_order() {
@@ -291,6 +295,26 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         assertEquals(0.2d, (Double) list.get(5).get("s"), 0.1d);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_order_byXageX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_hasLabelXpersonX_order_byXageX();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList(convertToVertex(graph, "vadas"), convertToVertex(graph, "marko"), convertToVertex(graph, "josh"), convertToVertex(graph, "peter")), traversal);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX() {
+        final Traversal<Vertex, List<Vertex>> traversal = get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX();
+        printTraversalForm(traversal);
+        final List<Vertex> list = traversal.next();
+        assertEquals(convertToVertex(graph, "vadas"), list.get(0));
+        assertEquals(convertToVertex(graph, "marko"), list.get(1));
+        assertEquals(convertToVertex(graph, "josh"), list.get(2));
+        assertEquals(convertToVertex(graph, "peter"), list.get(3));
+    }
+
     public static class Traversals extends OrderTest {
 
         @Override
@@ -360,6 +384,16 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXvX_mapXbothE_weight_foldX_sumXlocalX_asXsX_selectXv_sX_order_byXselectXsX_decrX() {
             return g.V().as("v").map(__.bothE().<Double>values("weight").fold()).sum(Scope.local).as("s").select("v", "s").order().by(__.select("s"), Order.decr);
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_order_byXageX() {
+            return g.V().hasLabel("person").order().by("age");
+        }
+
+        @Override
+        public Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX() {
+            return g.V().hasLabel("person").fold().order(Scope.local).by("age");
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-941

Instead of fixing the error message, I simply made it such that if you don't provide a comparator, it assumes you mean `Order.incr`. Added a test for both `OrderLocalStep` and `OrderGlobalStep` that demonstrate things working. Finally, I also realized we didn't have a proper `clone()` method for `OrderLobalStep`. Eek! Added it.

Ran `mvn clean install` and `SparkGraphComputerIntegrationTest` (for `OrderTest` only) and all is golden.

VOTE +1.
