### PR TITLE
TINKERPOP3-912 Improve the ability to embed Gremlin Server with Channelizer injection

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -511,7 +511,7 @@ public abstract class Client {
         @Deprecated
         @Override
         public Client rebind(final String graphOrTraversalSourceName){
-            throw new UnsupportedOperationException("Sessioned client do no support aliasing");
+            throw new UnsupportedOperationException("Sessioned client does not support aliasing");
         }
 
         /**
@@ -521,7 +521,7 @@ public abstract class Client {
          */
         @Override
         public Client alias(String graphOrTraversalSource) {
-            throw new UnsupportedOperationException("Sessioned client do no support aliasing");
+            throw new UnsupportedOperationException("Sessioned client does not support aliasing");
         }
 
         /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/GremlinServer.java
@@ -86,7 +86,6 @@ public class GremlinServer {
             logger.warn("cannot use epoll in non-linux env, falling back to NIO");
         }
 
-
         Runtime.getRuntime().addShutdownHook(new Thread(() -> this.stop().join(), SERVER_THREAD_PREFIX + "shutdown"));
 
         final ThreadFactory threadFactoryBoss = ThreadFactoryUtil.create("boss-%d");
@@ -114,7 +113,11 @@ public class GremlinServer {
      * pre-constructed objects used by the server as well as the {@link Settings} object itself.  This constructor
      * is useful when Gremlin Server is being used in an embedded style and there is a need to share thread pools
      * with the hosting application.
+     *
+     * @deprecated As of release 3.1.1-incubating, not replaced.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP3-912">TINKERPOP3-912</a>
      */
+    @Deprecated
     public GremlinServer(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
         this.serverGremlinExecutor = serverGremlinExecutor;
         this.settings = serverGremlinExecutor.getSettings();
@@ -308,6 +311,10 @@ public class GremlinServer {
         }, SERVER_THREAD_PREFIX + "stop").start();
 
         return serverStopped;
+    }
+
+    public ServerGremlinExecutor<EventLoopGroup> getServerGremlinExecutor() {
+        return serverGremlinExecutor;
     }
 
     public static void main(final String[] args) throws Exception {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -142,7 +142,7 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
      *                         {@link GremlinExecutor#eval} method.
      */
     protected void evalOpInternal(final Context context, final Supplier<GremlinExecutor> gremlinExecutorSupplier,
-                              final BindingSupplier<Bindings> bindingsSupplier) throws OpProcessorException {
+                              final BindingSupplier bindingsSupplier) throws OpProcessorException {
         final Timer.Context timerContext = evalOpTimer.time();
         final ChannelHandlerContext ctx = context.getChannelHandlerContext();
         final RequestMessage msg = context.getRequestMessage();
@@ -279,7 +279,7 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
     }
 
     @FunctionalInterface
-    public interface BindingSupplier<T> {
-        public T get() throws OpProcessorException;
+    public interface BindingSupplier {
+        public Bindings get() throws OpProcessorException;
     }
 }

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.server.util;
 
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
+import org.apache.tinkerpop.gremlin.server.Channelizer;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.apache.tinkerpop.gremlin.server.Settings;
@@ -27,8 +28,11 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -37,11 +41,11 @@ import java.util.stream.Collectors;
 
 /**
  * The core of script execution in Gremlin Server.  Given {@link Settings} and optionally other arguments, this
- * class will construct a {@link GremlinExecutor} to be used by Gremlin Server.  Those expecting to build their
- * own version of Gremlin Server might consider coring their implementation with this class as it provides some
- * basic infrastructure required for most of Gremlin Server script processing features.  Those embedding Gremlin
- * Server in another application might consider using this class to initialize the {@link GremlinServer} class
- * as it will allow sharing of thread pool resources.
+ * class will construct a {@link GremlinExecutor} to be used by Gremlin Server.  A typical usage would be to
+ * instantiate the {@link GremlinServer} and then immediately call {@link GremlinServer#getServerGremlinExecutor()}
+ * which would allow the opportunity to assign "host options" which could be used by a custom {@link Channelizer}.
+ * Add these options before calling {@link GremlinServer#start()} to be sure the {@link Channelizer} gets access to
+ * those.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
@@ -55,6 +59,8 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
     private final T scheduledExecutorService;
     private final ExecutorService gremlinExecutorService;
     private final GremlinExecutor gremlinExecutor;
+
+    private final Map<String,Object> hostOptions = new ConcurrentHashMap<>();
 
     /**
      * Create a new object from {@link Settings} where thread pools are internally created. Note that the
@@ -136,6 +142,22 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
                 .filter(kv -> kv.getValue() instanceof LifeCycleHook)
                 .map(kv -> (LifeCycleHook) kv.getValue())
                 .collect(Collectors.toList());
+    }
+
+    public void addHostOption(final String key, final Object value) {
+        hostOptions.put(key, value);
+    }
+
+    public Map<String,Object> getHostOptions() {
+        return Collections.unmodifiableMap(hostOptions);
+    }
+
+    public Object removeHostOption(final String key) {
+        return hostOptions.remove(key);
+    }
+
+    public void clearHostOptions() {
+        hostOptions.clear();
     }
 
     public T getScheduledExecutorService() {

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -66,7 +66,7 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
     }
 
     /**
-     * Create a new object from {@link Settings} where thread pools are internally created. Note that if the
+     * Create a new object from {@link Settings} where thread pools are externally assigned. Note that if the
      * {@code scheduleExecutorServiceClass} is set to {@code null} it will be created via
      * {@link Executors#newScheduledThreadPool(int, ThreadFactory)}.  If either of the {@link ExecutorService}
      * instances are supplied, the {@link Settings#gremlinPool} value will be ignored for the pool size.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-912

I folded in a couple of changes related to general refactoring that were above and beyond the scope described in the JIRA ticket.  Most notably was the removal of more code related the deprecated "rebinding" term.  

I thought this ticket was going to be much bigger when i started, but it seemed to be less so for 3.1.1 anyway. Anyway, it is pretty deep in the guts of Gremlin Server, so reviewers should focus mostly on ensuring that there are no regressions as a result of this refactoring work.

I tested with:

```text
mvn clean install
mvn verify -DskipIntegrationTests=false -pl gremlin-server
```

VOTE: +1