### PR TITLE
TINKERPOP3-981 - Deprecate credentialsDbLocation setting for gremlin server simple auth.

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -759,28 +759,13 @@ graph database, which must be provided to it as part of the configuration.
 authentication: {
   className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
-    credentialsDb: conf/credential-graph.properties}}
+    credentialsDb: conf/tinkergraph-credentials.properties}}
 
 Quick Start
 +++++++++++
 
 A quick way to get started with the `SimpleAuthenticator` is to use TinkerGraph for the "credentials graph" and the
-"sample" credential graph that is packaged with the server.  Recall that TinkerGraph is an in-memory graph and
-therefore always starts as "empty" when opened by `GraphFactory`.  To allow TinkerGraph to be used in this "getting
-started" capacity, Gremlin Server allows for a TinkerGraph-only configuration option called `credentialsDbLocation`.
-The following snippet comes from the `conf/gremlin-server-secure.yaml` file packaged with the server:
-
-[source,yaml]
-authentication: {
-  className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
-  config: {
-    credentialsDb: conf/tinkergraph-empty.properties,
-    credentialsDbLocation: data/credentials.kryo}}
-
-This added configuration tells Gremlin Server to look for a gryo file at that location containing the data for the
-graph which it loads via standard `io` methods.  The limitation is that this read is only performed at the
-initialization of the server so therefore credentials remain static for the life of the server.  In this case,
-`data/credentials.kryo` contains a single user named "stephen" with the imaginative password of "password".
+"sample" credential graph that is packaged with the server.
 
 [source,text]
 ----

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -70,7 +70,6 @@ writeBufferHighWaterMark: 65536
 authentication: {
   className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
-    credentialsDb: conf/tinkergraph-empty.properties,
-    credentialsDbLocation: data/credentials.kryo}}
+    credentialsDb: conf/tinkergraph-credentials.properties}}
 ssl: {
   enabled: true}

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -70,7 +70,6 @@ writeBufferHighWaterMark: 65536
 authentication: {
   className: org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator,
   config: {
-    credentialsDb: conf/tinkergraph-empty.properties,
-    credentialsDbLocation: data/credentials.kryo}}
+    credentialsDb: conf/tinkergraph-credentials.properties}}
 ssl: {
   enabled: true}

--- a/gremlin-server/conf/tinkergraph-credentials.properties
+++ b/gremlin-server/conf/tinkergraph-credentials.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+gremlin.graph=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
+gremlin.tinkergraph.vertexIdManager=LONG
+gremlin.tinkergraph.graphLocation=data/credentials.kryo
+gremlin.tinkergraph.graphFormat=gryo

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateOldTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateOldTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.server.auth.SimpleAuthenticator;
 import org.ietf.jgss.GSSException;
 import org.junit.Test;
@@ -31,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
-
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -40,8 +39,11 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated As of release 3.1.1-incubating, replaced by {@link GremlinServerAuthIntegrateTest}
+ * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP3-981">TINKERPOP3-981</a>
  */
-public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegrationTest {
+@Deprecated
+public class GremlinServerAuthIntegrateOldTest extends AbstractGremlinServerIntegrationTest {
 
     /**
      * Configure specific Gremlin Server settings for specific tests.
@@ -53,7 +55,8 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
 
         // use a credentials graph with one user in it: stephen/password
         final Map<String,Object> authConfig = new HashMap<>();
-        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_DB, "conf/tinkergraph-credentials.properties");
+        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_DB, "conf/tinkergraph-empty.properties");
+        authConfig.put(SimpleAuthenticator.CONFIG_CREDENTIALS_LOCATION, "data/credentials.kryo");
 
         authSettings.config = authConfig;
         settings.authentication = authSettings;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-981

Fixed up docs and altered packaged config files. This is a non-breaking change as the setting is still supported.  It offers a warning when it is used. Kept tests in place and added new ones to test both features.

```text
mvn clean install
mvn verify -DskipIntegrationTests=false -pl gremlin-server
```

Did the above tests and some manual testing of REST as well as the driver in the console.

VOTE: +1