### PR TITLE
TINKERPOP3-995 Add Authenticator.newSaslNegotiator(InetAddress)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,9 +26,10 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Deprecate `credentialsDbLocation` from `SimpleAuthenticator` in Gremlin Server.
+* Deprecated `credentialsDbLocation` from `SimpleAuthenticator` in Gremlin Server.
 * `TinkerGraph` has "native" serialization in GraphSON, which enables it to be a return value from Gremlin Server.
 * Improved the ability to embed Gremlin Server by providing a way to get the `ServerGremlinExecutor` and improve reusability of `AbstractEvalOpProcessor` and related classes.
+* Added `Authenticator.newSaslNegotiator(InetAddress)` and deprecated the zero-arg version of that method.
 * `ProfileStep` is now available off of `Traversal` via `profile()`. To be consistent with `Traversal.explain()`.
 * If no comparator is provided to `order()`, `Order.incr` is assumed (previously, an exception occurred).
 * Fixed various Gremlin-Groovy tests that assumed `toString()`-able ids.

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -60,6 +60,20 @@ TinkerGraph instances.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP3-886[TINKERPOP3-886]
 
+Authenticator Method Deprecation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For users who have a custom `Authenticator` implementation for Gremlin Server, there will be a new method present:
+
+[source,java]
+public default SaslNegotiator newSaslNegotiator(final InetAddress remoteAddress)
+
+Implementation of this method is now preferred over the old method with the same name that has no arguments. The old
+method has been deprecated.  This is a non-breaking change as the new method has a default implementation that simply
+calls the old deprecated method.  In this way, existing `Authenticator` implementations will still work.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP3-995[TINKERPOP3-995]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/AllowAllAuthenticator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/AllowAllAuthenticator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.server.auth;
 
+import java.net.InetAddress;
 import java.util.Map;
 
 /**
@@ -41,7 +42,16 @@ public final class AllowAllAuthenticator implements Authenticator {
         return AuthenticatedUser.ANONYMOUS_USER;
     }
 
+    /**
+     * @deprecated As of release 3.1.1-incubating, replaced by {@link #newSaslNegotiator(InetAddress)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP3-995">TINKERPOP3-995</a>
+     */
+    @Override
+    @Deprecated
     public SaslNegotiator newSaslNegotiator() {
+        // While this method is deprecated, it remains here to ensure backward compatibility with the old method. In
+        // this way the integration tests can continue to execute here
+        // todo: remove this method on a future version and implement the new one
         return AUTHENTICATOR_INSTANCE;
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/Authenticator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/Authenticator.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.server.Channelizer;
 
+import java.net.InetAddress;
 import java.util.Map;
 
 /**
@@ -45,11 +46,31 @@ public interface Authenticator {
     public void setup(final Map<String,Object> config);
 
     /**
-     * Provide a SASL handler to perform authentication for an single connection. SASL
-     * is a stateful protocol, so a new instance must be used for each authentication
-     * attempt.)
+     * Provide a SASL handler to perform authentication for an single connection. SASL is a stateful protocol, so a
+     * new instance must be used for each authentication attempt.)
+     *
+     * @deprecated As of release 3.1.1-incubating, replaced by {@link #newSaslNegotiator(InetAddress)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP3-995">TINKERPOP3-995</a>
      */
+    @Deprecated
     public SaslNegotiator newSaslNegotiator();
+
+    /**
+     * Provide a SASL handler to perform authentication for an single connection. SASL is a stateful protocol, so
+     * a new instance must be used for each authentication attempt.
+     *
+     * As of 3.1.1, this method by default calls the {@link #newSaslNegotiator()} method so as not to introduce a
+     * breaking change. Implementers should move their code from {@link #newSaslNegotiator()} to this method as
+     * this is the method now called by Gremlin Server during authentication. For full backwards compatibility,
+     * it makes sense to call this method from {@link #newSaslNegotiator()} passing {@code null} for the
+     * {@code remoteAddress} parameter.
+     *
+     * @param remoteAddress the IP address of the client to authenticate to authenticate or null if an internal
+     *                      client (one not connected over the remote transport).
+     */
+    public default SaslNegotiator newSaslNegotiator(final InetAddress remoteAddress) {
+        return newSaslNegotiator();
+    }
 
     /**
      * A "standard" authentication implementation that can be used more generically without SASL support.  This

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/SimpleAuthenticator.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/auth/SimpleAuthenticator.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -104,8 +105,16 @@ public class SimpleAuthenticator implements Authenticator {
         logger.info("CredentialGraph initialized at {}", credentialStore);
     }
 
+    /**
+     * @deprecated As of release 3.1.1-incubating, replaced by {@link #newSaslNegotiator(InetAddress)}.
+     * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP3-995">TINKERPOP3-995</a>
+     */
     @Override
+    @Deprecated
     public SaslNegotiator newSaslNegotiator() {
+        // While this method is deprecated, it remains here to ensure backward compatibility with the old method. In
+        // this way the integration tests can continue to execute here
+        // todo: remove this method on a future version and implement the new one
         return new PlainTextSaslAuthenticator();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-995

This change is non-breaking despite the deprecation. Reviewers should focus on validating that there are no regressions:

```text
mvn clean install
mvn verify -DskipIntegrationTests=false -pl gremlin-server
```

VOTE: +1