### PR TITLE
TINKERPOP3-1013: Traverser tags as a safer way of using path labels

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Traverser.java
@@ -272,5 +272,14 @@ public interface Traverser<T> extends Serializable, Comparable<Traverser<T>>, Cl
          * @return the traversal sideEffects of the traverser
          */
         public TraversalSideEffects getSideEffects();
+
+        /**
+         * Get the tags associated with the traverser.
+         * Tags are used to categorize historic behavior of a traverser.
+         * The returned set is mutable.
+         *
+         * @return the set of tags associated with the traverser.
+         */
+        public Set<String> getTags();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComputerAwareStep.java
@@ -77,7 +77,7 @@ public abstract class ComputerAwareStep<S, E> extends AbstractStep<S, E> impleme
             final Traverser.Admin<S> start = this.starts.next();
             if (this.traverserStepIdAndLabelsSetByChild) {
                 start.setStepId(((ComputerAwareStep<?, ?>) this.getTraversal().getParent()).getNextStep().getId());
-                start.addLabels(((ComputerAwareStep<?, ?>) this.getTraversal().getParent()).getLabels());
+                start.path().extend(((ComputerAwareStep<?, ?>) this.getTraversal().getParent()).getLabels());
             }
             return start;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/O_Traverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/O_Traverser.java
@@ -18,12 +18,19 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.traverser;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.AbstractTraverser;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class O_Traverser<T> extends AbstractTraverser<T> {
+
+    protected Set<String> tags = null;
 
     protected O_Traverser() {
     }
@@ -32,4 +39,34 @@ public class O_Traverser<T> extends AbstractTraverser<T> {
         super(t);
     }
 
+
+    public Set<String> getTags() {
+        if (null == this.tags) this.tags = new HashSet<>();
+        return this.tags;
+    }
+
+    @Override
+    public <R> Admin<R> split(final R r, final Step<T, R> step) {
+        final O_Traverser<R> clone = (O_Traverser<R>) super.split(r, step);
+        if (null != this.tags)
+            clone.tags = new HashSet<>(this.tags);
+        return clone;
+    }
+
+    @Override
+    public Admin<T> split() {
+        final O_Traverser<T> clone = (O_Traverser<T>) super.split();
+        if (null != this.tags)
+            clone.tags = new HashSet<>(this.tags);
+        return clone;
+    }
+
+    @Override
+    public void merge(final Traverser.Admin<?> other) {
+        super.merge(other);
+        if (!other.getTags().isEmpty()) {
+            if (this.tags == null) this.tags = new HashSet<>();
+            this.tags.addAll(other.getTags());
+        }
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/EmptyTraverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/EmptyTraverser.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyPath;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -141,6 +142,11 @@ public final class EmptyTraverser<T> implements Traverser<T>, Traverser.Admin<T>
     @Override
     public TraversalSideEffects getSideEffects() {
         return null;
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MatchStepTest.java
@@ -365,23 +365,28 @@ public class MatchStepTest extends StepTest {
         traverser.addLabels(Collections.singleton("a"));
         assertEquals(firstPattern, countMatchAlgorithm.apply(traverser));
         traverser = traverser.split(1, EmptyStep.instance());
-        traverser.addLabels(new HashSet<>(Arrays.asList("b", firstPattern.getStartStep().getId())));
+        traverser.getTags().add(firstPattern.getStartStep().getId());
+        traverser.addLabels(Collections.singleton("b"));
         //
         assertEquals(secondPattern, countMatchAlgorithm.apply(traverser));
         traverser = traverser.split(1, EmptyStep.instance());
-        traverser.addLabels(new HashSet<>(Arrays.asList("c", secondPattern.getStartStep().getId())));
+        traverser.getTags().add(secondPattern.getStartStep().getId());
+        traverser.addLabels(Collections.singleton("c"));
         //
         assertEquals(fifthPattern, countMatchAlgorithm.apply(traverser));
         traverser = traverser.split(1, EmptyStep.instance());
-        traverser.addLabels(new HashSet<>(Arrays.asList("f", fifthPattern.getStartStep().getId())));
+        traverser.getTags().add(fifthPattern.getStartStep().getId());
+        traverser.addLabels(Collections.singleton("f"));
         //
         assertEquals(forthPattern, countMatchAlgorithm.apply(traverser));
         traverser = traverser.split(1, EmptyStep.instance());
-        traverser.addLabels(new HashSet<>(Arrays.asList("e", forthPattern.getStartStep().getId())));
+        traverser.getTags().add(forthPattern.getStartStep().getId());
+        traverser.addLabels(Collections.singleton("e"));
         //
         assertEquals(thirdPattern, countMatchAlgorithm.apply(traverser));
         traverser = traverser.split(1, EmptyStep.instance());
-        traverser.addLabels(new HashSet<>(Arrays.asList("d", thirdPattern.getStartStep().getId())));
+        traverser.getTags().add(thirdPattern.getStartStep().getId());
+        traverser.addLabels(Collections.singleton("d"));
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP3-1013

We have had a hack in `MatchStep` this whole time where we use path labels to store branch history. This is not only semantically awkward (as labels are added that were not provided via `as()`), it also means we will not be able to do https://issues.apache.org/jira/browse/TINKERPOP3-736. Also, this will allow us to cleanly implement `IntersectStep` and `SymetricDifferenceStep` (down the road).

The implementation is really simple. `Traverser.getTags()`. This method returns a mutable set and thus, we can remove, add, size, contains, etc. tags associated with a traverser.

Ran `mvn clean install` and all is golden.

VOTE +1.