### PR TITLE
TINKERPOP-859 Moved logging setup to configuration in HadoopGremlinPlugin

### DIFF
--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -60,6 +60,14 @@ TinkerGraph instances.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP3-886[TINKERPOP3-886]
 
+Logging
+^^^^^^^
+
+Logging to Gremlin Server and Gremlin Console can now be consistently controlled by the `log4j-server.properties`
+and `log4j-console.properties` which are in the respective `conf/` directories of the packaged distributions.
+
+See: https://issues.apache.org/jira/browse/TINKERPOP-859[TINKERPOP-859]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/groovy/plugin/GiraphGremlinPlugin.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/groovy/plugin/GiraphGremlinPlugin.java
@@ -38,7 +38,6 @@ public final class GiraphGremlinPlugin extends AbstractGremlinPlugin {
     protected static String NAME = "tinkerpop.giraph";
 
     protected static final Set<String> IMPORTS = new HashSet<String>() {{
-        add("import org.apache.log4j.*");
         add(IMPORT_SPACE + GiraphGraphComputer.class.getPackage().getName() + DOT_STAR);
     }};
 

--- a/gremlin-console/conf/log4j-console.properties
+++ b/gremlin-console/conf/log4j-console.properties
@@ -15,9 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-log4j.appender.A2=org.apache.log4j.ConsoleAppender
-log4j.appender.A2.Threshold=TRACE
-log4j.appender.A2.layout=org.apache.log4j.PatternLayout
-log4j.appender.A2.layout.ConversionPattern=%-5p %c %x - %m%n
+log4j.rootLogger=${gremlin.log4j.level}, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%-5p %c %x - %m%n
 
-log4j.rootLogger=${gremlin.log4j.level}, A2
+log4j.logger.org.apache.hadoop.mapred.JobClient=INFO
+log4j.logger.org.apache.hadoop.mapreduce.Job=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.hadoop.process.computer.mapreduce.MapReduceGraphComputer=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph=INFO

--- a/gremlin-console/conf/log4j-console.properties
+++ b/gremlin-console/conf/log4j-console.properties
@@ -24,3 +24,5 @@ log4j.logger.org.apache.hadoop.mapred.JobClient=INFO
 log4j.logger.org.apache.hadoop.mapreduce.Job=INFO
 log4j.logger.org.apache.tinkerpop.gremlin.hadoop.process.computer.mapreduce.MapReduceGraphComputer=INFO
 log4j.logger.org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer=INFO
+log4j.logger.org.apache.spark.metrics.MetricsSystem=ERROR

--- a/gremlin-server/conf/log4j-server.properties
+++ b/gremlin-server/conf/log4j-server.properties
@@ -14,13 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%p] %C{1} - %m%n
+
 log4j.logger.org.apache.tinkerpop.gremlin.driver.Connection=OFF
 log4j.logger.org.apache.tinkerpop.gremlin.driver.ConnectionPool=OFF
 log4j.logger.org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph=ERROR
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-#log4j.appender.stdout=org.apache.log4j.FileAppender
-#log4j.appender.stdout.file=recless.log
-#log4j.appender.stdout.append=true
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%p] %C{1} - %m%n
+log4j.logger.org.apache.hadoop.mapred.JobClient=INFO
+log4j.logger.org.apache.hadoop.mapreduce.Job=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.hadoop.process.computer.mapreduce.MapReduceGraphComputer=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph=INFO

--- a/gremlin-server/conf/log4j-server.properties
+++ b/gremlin-server/conf/log4j-server.properties
@@ -27,3 +27,5 @@ log4j.logger.org.apache.hadoop.mapred.JobClient=INFO
 log4j.logger.org.apache.hadoop.mapreduce.Job=INFO
 log4j.logger.org.apache.tinkerpop.gremlin.hadoop.process.computer.mapreduce.MapReduceGraphComputer=INFO
 log4j.logger.org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph=INFO
+log4j.logger.org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer=INFO
+log4j.logger.org.apache.spark.metrics.MetricsSystem=ERROR

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/groovy/plugin/HadoopGremlinPlugin.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/groovy/plugin/HadoopGremlinPlugin.java
@@ -20,8 +20,6 @@ package org.apache.tinkerpop.gremlin.hadoop.groovy.plugin;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.mapred.JobClient;
-import org.apache.hadoop.mapreduce.Job;
 import org.apache.tinkerpop.gremlin.groovy.plugin.AbstractGremlinPlugin;
 import org.apache.tinkerpop.gremlin.groovy.plugin.IllegalEnvironmentException;
 import org.apache.tinkerpop.gremlin.groovy.plugin.PluginAcceptor;
@@ -80,12 +78,6 @@ public final class HadoopGremlinPlugin extends AbstractGremlinPlugin {
     public void afterPluginTo(final PluginAcceptor pluginAcceptor) throws PluginInitializationException, IllegalEnvironmentException {
         pluginAcceptor.addImports(IMPORTS);
         try {
-            pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.INFO)", JobClient.class.getName()));
-            pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.INFO)", Job.class.getName()));
-            ///
-            pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.INFO)", MapReduceGraphComputer.class.getName()));
-            ///
-            pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.INFO)", HadoopGraph.class.getName()));
             pluginAcceptor.eval(HadoopLoader.class.getCanonicalName() + ".load()");
 
             pluginAcceptor.addBinding("hdfs", FileSystem.get(new Configuration()));

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/groovy/plugin/SparkGremlinPlugin.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/groovy/plugin/SparkGremlinPlugin.java
@@ -19,14 +19,12 @@
 
 package org.apache.tinkerpop.gremlin.spark.groovy.plugin;
 
-import org.apache.spark.metrics.MetricsSystem;
 import org.apache.tinkerpop.gremlin.groovy.plugin.AbstractGremlinPlugin;
 import org.apache.tinkerpop.gremlin.groovy.plugin.IllegalEnvironmentException;
 import org.apache.tinkerpop.gremlin.groovy.plugin.PluginAcceptor;
 import org.apache.tinkerpop.gremlin.groovy.plugin.PluginInitializationException;
 import org.apache.tinkerpop.gremlin.groovy.plugin.RemoteAcceptor;
 import org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer;
-import org.slf4j.Logger;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -40,7 +38,6 @@ public final class SparkGremlinPlugin extends AbstractGremlinPlugin {
     protected static String NAME = "tinkerpop.spark";
 
     protected static final Set<String> IMPORTS = new HashSet<String>() {{
-        add("import org.apache.log4j.*");
         add(IMPORT_SPACE + SparkGraphComputer.class.getPackage().getName() + DOT_STAR);
     }};
 
@@ -52,12 +49,6 @@ public final class SparkGremlinPlugin extends AbstractGremlinPlugin {
     @Override
     public void afterPluginTo(final PluginAcceptor pluginAcceptor) throws PluginInitializationException, IllegalEnvironmentException {
         pluginAcceptor.addImports(IMPORTS);
-        try {
-            pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.INFO)", SparkGraphComputer.class.getName()));
-            pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.ERROR)", MetricsSystem.class.getName()));
-        } catch (final Exception e) {
-            throw new PluginInitializationException(e.getMessage(), e);
-        }
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-859

Logging setup shouldn't be hardcoded anywhere especially since we use slf4j.  With this approach the user has the ultimate control over what they want logged and what they don't.  TinkerPop provides a sensible default in the provided logging properties files using log4j.

I tested the console manually copying the examples in the reference documentation after these changes and didn't see any difference in the output to the console.

VOTE: +1