### PR TITLE
TINKERPOP-1023: Add a spark variable in SparkGremlinPlugin like we do hdfs for HadoopGremlinPlugin

### DIFF
--- a/docs/src/reference/implementations.asciidoc
+++ b/docs/src/reference/implementations.asciidoc
@@ -1203,8 +1203,8 @@ constructs directly. There is a `gremlin.spark.graphInputRDD` configuration that
 InputRDD>`. An `InputRDD` provides a read method that takes a `SparkContext` and returns a graphRDD. Likewise, use
 `gremlin.spark.graphOutputRDD` and the respective `OutputRDD`.
 
-Using Persisted Context
-+++++++++++++++++++++++
+Using a Persisted Context
++++++++++++++++++++++++++
 
 It is possible to persist the graph RDD between jobs within the `SparkContext` (e.g. SparkServer) by leveraging `PersistedOutputRDD`.
 Note that `gremlin.spark.persistContext` should be set to `true` or else the persisted RDD will be destroyed when the `SparkContext` closes.

--- a/docs/src/reference/implementations.asciidoc
+++ b/docs/src/reference/implementations.asciidoc
@@ -1203,19 +1203,19 @@ constructs directly. There is a `gremlin.spark.graphInputRDD` configuration that
 InputRDD>`. An `InputRDD` provides a read method that takes a `SparkContext` and returns a graphRDD. Likewise, use
 `gremlin.spark.graphOutputRDD` and the respective `OutputRDD`.
 
-Using Persisted Contexts
-++++++++++++++++++++++++
+Using Persisted Context
++++++++++++++++++++++++
 
 It is possible to persist the graph RDD between jobs within the `SparkContext` (e.g. SparkServer) by leveraging `PersistedOutputRDD`.
 Note that `gremlin.spark.persistContext` should be set to `true` or else the persisted RDD will be destroyed when the `SparkContext` closes.
 The persisted RDD is named by the `gremlin.hadoop.outputLocation` configuration.
 Similarly, `PersistedInputRDD` is used with respective  `gremlin.hadoop.inputLocation` to retrieve the persisted RDD from the `SparkContext`.
 
-There is a `spark` static object that can be leveraged must like `hdfs` to manage persisted RDDs.
+There is a static `spark` object that can be used to manage persisted RDDs much like `hdfs` is used to manage HDFS files (see <<interacting-with-hdfs, Interacting with HDFS>>).
 
 [gremlin-groovy]
 ----
-spark.create('local[4]')
+spark.create('local[4]') // the SparkContext location (master)
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
 graph.configuration().setProperty('gremlin.spark.persistContext',true)
 graph.configuration().setProperty('gremlin.spark.graphOutputRDD','org.apache.tinkerpop.gremlin.spark.structure.io.PersistedOutputRDD')
@@ -1570,6 +1570,7 @@ def stringify(vertex) {
     return [v, outE].join('\t')
 }
 
+[[interacting-with-hdfs]]
 Interacting with HDFS
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/src/reference/implementations.asciidoc
+++ b/docs/src/reference/implementations.asciidoc
@@ -1203,12 +1203,37 @@ constructs directly. There is a `gremlin.spark.graphInputRDD` configuration that
 InputRDD>`. An `InputRDD` provides a read method that takes a `SparkContext` and returns a graphRDD. Likewise, use
 `gremlin.spark.graphOutputRDD` and the respective `OutputRDD`.
 
+Using Persisted Contexts
+++++++++++++++++++++++++
+
 It is possible to persist the graph RDD between jobs within the `SparkContext` (e.g. SparkServer) by leveraging `PersistedOutputRDD`.
 Note that `gremlin.spark.persistContext` should be set to `true` or else the persisted RDD will be destroyed when the `SparkContext` closes.
-The persisted RDD is named by the `gremlin.hadoop.outputLocation` configuration (i.e. named in `SparkContext.getPersistedRDDs()`).
-Finally, `PersistedInputRDD` is used with respective  `gremlin.hadoop.inputLocation` to retrieve the persisted RDD from the `SparkContext`.
+The persisted RDD is named by the `gremlin.hadoop.outputLocation` configuration.
+Similarly, `PersistedInputRDD` is used with respective  `gremlin.hadoop.inputLocation` to retrieve the persisted RDD from the `SparkContext`.
 
-When using a persistent `Spark Context` the configuration used by the original Spark Configuration will be inherited by all threaded
+There is a `spark` static object that can be leveraged must like `hdfs` to manage persisted RDDs.
+
+[gremlin-groovy]
+----
+spark.create('local[4]')
+graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
+graph.configuration().setProperty('gremlin.spark.persistContext',true)
+graph.configuration().setProperty('gremlin.spark.graphOutputRDD','org.apache.tinkerpop.gremlin.spark.structure.io.PersistedOutputRDD')
+graph.configuration().setProperty('gremlin.hadoop.outputLocation','pageRankGraph')
+graph.compute(SparkGraphComputer).program(PageRankVertexProgram.build().create()).submit().get()
+spark.ls()
+graph.configuration().setProperty('gremlin.hadoop.outputLocation','peerPressureGraph')
+graph.compute(SparkGraphComputer).program(PeerPressureVertexProgram.build().create()).submit().get()
+spark.ls()
+spark.rm('pageRankGraph')
+spark.head('peerPressureGraph')
+spark.describe('peerPressureGraph')
+spark.rm('peerPressureGraph')
+spark.ls()
+spark.close()
+----
+
+When using a persistent `SparkContext` the configuration used by the original Spark Configuration will be inherited by all threaded
 references to that Spark Context. The exception to this rule are those properties which have a specific thread local effect.
 
 .Thread Local Properties

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/IncidentToAdjacentStrategy.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.javatuples.Pair;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -62,10 +63,7 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
         implements TraversalStrategy.OptimizationStrategy {
 
     private static final IncidentToAdjacentStrategy INSTANCE = new IncidentToAdjacentStrategy();
-    private static final Set<Class> InvalidatingStepClasses = new HashSet<Class>() {{
-        add(PathStep.class);
-        add(LambdaHolder.class);
-    }};
+    private static final Set<Class> INVALIDATING_STEP_CLASSES = new HashSet<>(Arrays.asList(PathStep.class, LambdaHolder.class));
 
     private IncidentToAdjacentStrategy() {
     }
@@ -73,7 +71,7 @@ public final class IncidentToAdjacentStrategy extends AbstractTraversalStrategy<
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
         final Traversal.Admin root = TraversalHelper.getRootTraversal(traversal);
-        if (TraversalHelper.hasStepOfAssignableClassRecursively(InvalidatingStepClasses, root))
+        if (TraversalHelper.hasStepOfAssignableClassRecursively(INVALIDATING_STEP_CLASSES, root))
             return;
         final Collection<Pair<VertexStep, Step>> stepsToReplace = new ArrayList<>();
         Step prev = null;

--- a/hadoop-gremlin/conf/hadoop-gryo.properties
+++ b/hadoop-gremlin/conf/hadoop-gryo.properties
@@ -28,11 +28,14 @@ gremlin.hadoop.outputLocation=output
 spark.master=local[4]
 spark.executor.memory=1g
 spark.serializer=org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerializer
+# gremlin.spark.persistContext=true
+# gremlin.spark.graphOutputRDD=org.apache.tinkerpop.gremlin.spark.structure.io.PersistedOutputRDD
 # spark.kryo.registrationRequired=true
 # spark.storage.memoryFraction=0.2
 # spark.eventLog.enabled=true
 # spark.eventLog.dir=/tmp/spark-event-logs
 # spark.ui.killEnabled=true
+
 
 #####################################
 # GiraphGraphComputer Configuration #

--- a/spark-gremlin/src/main/groovy/org/apache/tinkerpop/gremlin/spark/groovy/plugin/SparkLoader.groovy
+++ b/spark-gremlin/src/main/groovy/org/apache/tinkerpop/gremlin/spark/groovy/plugin/SparkLoader.groovy
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.spark.groovy.plugin
+
+import org.apache.spark.rdd.RDD
+import org.apache.tinkerpop.gremlin.spark.structure.Spark
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+class SparkLoader {
+
+    public static void load() {
+
+        Spark.metaClass.static.ls = {
+            final List<String> rdds = new ArrayList<>();
+            for (final RDD<?> rdd : Spark.getRDDs()) {
+                rdds.add(rdd.name() + " [" + rdd.getStorageLevel().description() + "]")
+            }
+            return rdds;
+        }
+
+        Spark.metaClass.static.rm = { final String rddName ->
+            for (final RDD<?> rdd : Spark.getRDDs()) {
+                if (rdd.name().matches(rddName))
+                    Spark.removeRDD(rdd.name());
+            }
+        }
+
+        Spark.metaClass.static.head = { final String rddName, final int totalLines ->
+            final List<Object> data = new ArrayList<>();
+            final Iterator<?> itty = Spark.getRDD(rddName).toLocalIterator();
+            for (int i = 0; i < totalLines; i++) {
+                if (itty.hasNext())
+                    data.add(itty.next());
+                else
+                    break;
+            }
+            return data;
+        }
+    }
+}

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/groovy/plugin/SparkGremlinPlugin.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/groovy/plugin/SparkGremlinPlugin.java
@@ -26,7 +26,7 @@ import org.apache.tinkerpop.gremlin.groovy.plugin.PluginAcceptor;
 import org.apache.tinkerpop.gremlin.groovy.plugin.PluginInitializationException;
 import org.apache.tinkerpop.gremlin.groovy.plugin.RemoteAcceptor;
 import org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer;
-import org.slf4j.Logger;
+import org.apache.tinkerpop.gremlin.spark.structure.Spark;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -42,6 +42,7 @@ public final class SparkGremlinPlugin extends AbstractGremlinPlugin {
     protected static final Set<String> IMPORTS = new HashSet<String>() {{
         add("import org.apache.log4j.*");
         add(IMPORT_SPACE + SparkGraphComputer.class.getPackage().getName() + DOT_STAR);
+        add(IMPORT_SPACE + Spark.class.getPackage().getName() + DOT_STAR);
     }};
 
     @Override
@@ -55,6 +56,8 @@ public final class SparkGremlinPlugin extends AbstractGremlinPlugin {
         try {
             pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.INFO)", SparkGraphComputer.class.getName()));
             pluginAcceptor.eval(String.format("Logger.getLogger(%s).setLevel(Level.ERROR)", MetricsSystem.class.getName()));
+            pluginAcceptor.eval("spark = Spark");
+            pluginAcceptor.eval(SparkLoader.class.getCanonicalName() + ".load()");
         } catch (final Exception e) {
             throw new PluginInitializationException(e.getMessage(), e);
         }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -103,7 +103,7 @@ public final class SparkExecutor {
                             workerVertexProgram.workerIterationEnd(memory.asImmutable()); // if no more vertices in the partition, end the worker's iteration
                         return new Tuple2<>(vertex.id(), new ViewOutgoingPayload<>(nextView, outgoingMessages));
                     });
-                })).setName("viewOutgoingRDD");
+                }));
 
         // "message pass" by reducing on the vertex object id of the view and message payloads
         final MessageCombiner<M> messageCombiner = VertexProgram.<VertexProgram<M>>createVertexProgram(HadoopGraph.open(apacheConfiguration), apacheConfiguration).getMessageCombiner().orElse(null);
@@ -131,7 +131,7 @@ public final class SparkExecutor {
                         (ViewIncomingPayload<M>) payload :                    // this happens if there is a vertex with incoming messages
                         new ViewIncomingPayload<>((ViewPayload) payload));    // this happens if there is a vertex with no incoming messages
 
-        newViewIncomingRDD.setName("viewIncomingRDD")
+        newViewIncomingRDD
                 .foreachPartition(partitionIterator -> {
                     HadoopPools.initialize(apacheConfiguration);
                 }); // need to complete a task so its BSP and the memory for this iteration is updated

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -141,9 +141,8 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
             // create the spark configuration from the graph computer configuration
             hadoopConfiguration.forEach(entry -> sparkConfiguration.set(entry.getKey(), entry.getValue()));
             // execute the vertex program and map reducers and if there is a failure, auto-close the spark context
-            JavaSparkContext sparkContext = null;
             try {
-                sparkContext = new JavaSparkContext(SparkContext.getOrCreate(sparkConfiguration));
+                final JavaSparkContext sparkContext =  new JavaSparkContext(SparkContext.getOrCreate(sparkConfiguration));
                 Spark.create(sparkContext.sc()); // this is the context RDD holder that prevents GC
                 updateLocalConfiguration(sparkContext, sparkConfiguration);
                 // add the project jars to the cluster

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -216,10 +216,10 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                         final HadoopConfiguration newApacheConfiguration = new HadoopConfiguration(apacheConfiguration);
                         mapReduce.storeState(newApacheConfiguration);
                         // map
-                        final JavaPairRDD mapRDD = SparkExecutor.executeMap((JavaPairRDD) mapReduceGraphRDD, mapReduce, newApacheConfiguration).setName("mapRDD");
+                        final JavaPairRDD mapRDD = SparkExecutor.executeMap((JavaPairRDD) mapReduceGraphRDD, mapReduce, newApacheConfiguration);
                         // combine TODO: is this really needed?
                         // reduce
-                        final JavaPairRDD reduceRDD = (mapReduce.doStage(MapReduce.Stage.REDUCE)) ? SparkExecutor.executeReduce(mapRDD, mapReduce, newApacheConfiguration).setName("reduceRDD") : null;
+                        final JavaPairRDD reduceRDD = (mapReduce.doStage(MapReduce.Stage.REDUCE)) ? SparkExecutor.executeReduce(mapRDD, mapReduce, newApacheConfiguration) : null;
                         // write the map reduce output back to disk (memory)
                         SparkExecutor.saveMapReduceRDD(null == reduceRDD ? mapRDD : reduceRDD, mapReduce, finalMemory, hadoopConfiguration);
                     }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/Spark.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/Spark.java
@@ -67,6 +67,8 @@ public class Spark {
     }
 
     public static void refresh() {
+        if (null == CONTEXT)
+            throw new IllegalStateException("The Spark context has not been created.");
         final Set<String> keepNames = new HashSet<>();
         for (final RDD<?> rdd : JavaConversions.asJavaIterable(CONTEXT.persistentRdds().values())) {
             if (null != rdd.name()) {

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.hadoop.HadoopGraphProvider;
 import org.apache.tinkerpop.gremlin.process.computer.bulkloading.BulkLoaderVertexProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
+import org.apache.tinkerpop.gremlin.spark.structure.Spark;
 import org.apache.tinkerpop.gremlin.spark.structure.io.ToyGraphInputRDD;
 import org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerializer;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -44,11 +45,11 @@ public final class SparkHadoopGraphProvider extends HadoopGraphProvider {
     public Map<String, Object> getBaseConfiguration(final String graphName, final Class<?> test, final String testMethodName, final LoadGraphWith.GraphData loadGraphWith) {
         final Map<String, Object> config = super.getBaseConfiguration(graphName, test, testMethodName, loadGraphWith);
         config.put(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, true);  // this makes the test suite go really fast
-        if (null != loadGraphWith &&
-                !test.equals(BulkLoaderVertexProgramTest.class) &&
-                RANDOM.nextBoolean()) {
-            // config.put(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputRDDFormat.class.getCanonicalName());
+        if (null != loadGraphWith && RANDOM.nextBoolean()) {
+            if (test.equals(BulkLoaderVertexProgramTest.class))
+                Spark.close(); // this forces workers to be 1 which is required for BulkLoaderVertexProgramTest
             config.put(Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD, ToyGraphInputRDD.class.getCanonicalName());
+            // config.put(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputRDDFormat.class.getCanonicalName());
         }
         /// spark configuration
         config.put("spark.master", "local[4]");

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
@@ -22,10 +22,8 @@ import org.apache.tinkerpop.gremlin.GraphProvider;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.HadoopGraphProvider;
-import org.apache.tinkerpop.gremlin.process.computer.bulkloading.BulkLoaderVertexProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
-import org.apache.tinkerpop.gremlin.spark.structure.Spark;
 import org.apache.tinkerpop.gremlin.spark.structure.io.ToyGraphInputRDD;
 import org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerializer;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -46,8 +44,6 @@ public final class SparkHadoopGraphProvider extends HadoopGraphProvider {
         final Map<String, Object> config = super.getBaseConfiguration(graphName, test, testMethodName, loadGraphWith);
         config.put(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, true);  // this makes the test suite go really fast
         if (null != loadGraphWith && RANDOM.nextBoolean()) {
-            if (test.equals(BulkLoaderVertexProgramTest.class))
-                Spark.close(); // this forces workers to be 1 which is required for BulkLoaderVertexProgramTest
             config.put(Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD, ToyGraphInputRDD.class.getCanonicalName());
             // config.put(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputRDDFormat.class.getCanonicalName());
         }

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/groovy/plugin/SparkGremlinPluginTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/groovy/plugin/SparkGremlinPluginTest.java
@@ -75,7 +75,7 @@ public class SparkGremlinPluginTest extends AbstractSparkTest {
         configuration.setProperty(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, PersistedOutputRDD.class.getCanonicalName());
         configuration.setProperty(Constants.GREMLIN_HADOOP_JARS_IN_DISTRIBUTED_CACHE, false);
         configuration.setProperty(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION, rddName);
-        configuration.setProperty(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, true);  // because the spark context is NOT persisted, neither is the RDD
+        configuration.setProperty(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, true);
         Graph graph = GraphFactory.open(configuration);
 
         Spark.create("local[4]");

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/groovy/plugin/SparkGremlinPluginTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/groovy/plugin/SparkGremlinPluginTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.spark.process.computer.groovy.plugin;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.groovy.util.TestableConsolePluginAcceptor;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
+import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.gryo.GryoInputFormat;
+import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
+import org.apache.tinkerpop.gremlin.spark.AbstractSparkTest;
+import org.apache.tinkerpop.gremlin.spark.groovy.plugin.SparkGremlinPlugin;
+import org.apache.tinkerpop.gremlin.spark.process.computer.SparkHadoopGraphProvider;
+import org.apache.tinkerpop.gremlin.spark.structure.Spark;
+import org.apache.tinkerpop.gremlin.spark.structure.io.PersistedOutputRDD;
+import org.apache.tinkerpop.gremlin.spark.structure.io.gryo.GryoSerializer;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class SparkGremlinPluginTest extends AbstractSparkTest {
+
+    @Before
+    public void setupTest() {
+        try {
+            this.console = new TestableConsolePluginAcceptor();
+            final SparkGremlinPlugin plugin = new SparkGremlinPlugin();
+            plugin.pluginTo(this.console);
+            this.console.eval("import " + PageRankVertexProgram.class.getPackage().getName() + ".*");
+        } catch (final Exception e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    ///////////////////
+
+    private TestableConsolePluginAcceptor console;
+
+    @Test
+    public void shouldSupportBasicRDDOperations() throws Exception {
+        String rddName = "target/test-output/graph-1";
+        final Configuration configuration = new BaseConfiguration();
+        configuration.setProperty("spark.master", "local[4]");
+        configuration.setProperty("spark.serializer", GryoSerializer.class.getCanonicalName());
+        configuration.setProperty(Graph.GRAPH, HadoopGraph.class.getName());
+        configuration.setProperty(Constants.GREMLIN_HADOOP_INPUT_LOCATION, SparkHadoopGraphProvider.PATHS.get("tinkerpop-modern.kryo"));
+        configuration.setProperty(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, GryoInputFormat.class.getCanonicalName());
+        configuration.setProperty(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, PersistedOutputRDD.class.getCanonicalName());
+        configuration.setProperty(Constants.GREMLIN_HADOOP_JARS_IN_DISTRIBUTED_CACHE, false);
+        configuration.setProperty(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION, rddName);
+        configuration.setProperty(Constants.GREMLIN_SPARK_PERSIST_CONTEXT, true);  // because the spark context is NOT persisted, neither is the RDD
+        Graph graph = GraphFactory.open(configuration);
+
+        Spark.create("local[4]");
+
+        assertEquals(0, ((List<String>) this.console.eval("spark.ls()")).size());
+
+        this.console.addBinding("graph", graph);
+        this.console.eval("graph.compute(SparkGraphComputer).program(PageRankVertexProgram.build().iterations(1).create()).submit().get()");
+        assertEquals(1, ((List<String>) this.console.eval("spark.ls()")).size());
+        assertEquals(rddName + " [Memory Deserialized 1x Replicated]", ((List<String>) this.console.eval("spark.ls()")).get(0));
+
+        rddName = "target/test-output/graph-2";
+        this.console.eval("graph.configuration().setProperty('" + Constants.GREMLIN_HADOOP_OUTPUT_LOCATION + "','" + rddName + "')");
+        this.console.eval("graph.compute(SparkGraphComputer).program(PageRankVertexProgram.build().iterations(1).create()).submit().get()");
+        assertEquals(2, ((List<String>) this.console.eval("spark.ls()")).size());
+        assertTrue(((List<String>) this.console.eval("spark.ls()")).contains(rddName + " [Memory Deserialized 1x Replicated]"));
+
+        this.console.eval("spark.rm('target/test-output/graph-2')");
+        assertEquals(1, ((List<String>) this.console.eval("spark.ls()")).size());
+        assertTrue(((List<String>) this.console.eval("spark.ls()")).contains("target/test-output/graph-1 [Memory Deserialized 1x Replicated]"));
+
+        assertEquals(6, ((List<Object>) this.console.eval("spark.head('target/test-output/graph-1')")).size());
+
+        this.console.eval("spark.rm('target/test-output/graph-*')");
+        assertEquals(0, ((List<String>) this.console.eval("spark.ls()")).size());
+
+        //////
+        rddName = "target/test-output/graph-1";
+        this.console.eval("graph.configuration().setProperty('" + Constants.GREMLIN_HADOOP_OUTPUT_LOCATION + "','" + rddName + "')");
+        this.console.eval("graph.compute(SparkGraphComputer).program(PageRankVertexProgram.build().iterations(1).create()).submit().get()");
+
+        rddName = "target/test-output/graph-2";
+        this.console.eval("graph.configuration().setProperty('" + Constants.GREMLIN_HADOOP_OUTPUT_LOCATION + "','" + rddName + "')");
+        this.console.eval("graph.compute(SparkGraphComputer).program(PageRankVertexProgram.build().iterations(1).create()).submit().get()");
+
+        rddName = "target/test-output/x";
+        this.console.eval("graph.configuration().setProperty('" + Constants.GREMLIN_HADOOP_OUTPUT_LOCATION + "','" + rddName + "')");
+        this.console.eval("graph.compute(SparkGraphComputer).program(PageRankVertexProgram.build().iterations(1).create()).submit().get()");
+
+        assertEquals(3, ((List<String>) this.console.eval("spark.ls()")).size());
+        this.console.eval("spark.rm('target/test-output/graph-*')");
+        assertEquals(1, ((List<String>) this.console.eval("spark.ls()")).size());
+        this.console.eval("spark.rm('*')");
+        assertEquals(0, ((List<String>) this.console.eval("spark.ls()")).size());
+
+        //
+    }
+}

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/groovy/plugin/SparkHadoopGremlinPluginTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/groovy/plugin/SparkHadoopGremlinPluginTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.spark.process.computer.groovy;
+package org.apache.tinkerpop.gremlin.spark.process.computer.groovy.plugin;
 
 import org.apache.tinkerpop.gremlin.GraphProviderClass;
 import org.apache.tinkerpop.gremlin.hadoop.groovy.plugin.HadoopPluginSuite;

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
@@ -69,16 +69,6 @@ public class SparkTest extends AbstractSparkTest {
             graph.compute(SparkGraphComputer.class).persist(GraphComputer.Persist.VERTEX_PROPERTIES).program(PageRankVertexProgram.build().iterations(1).create(graph)).submit().get();
             assertNotNull(Spark.getRDD(prefix + i));
             assertEquals(i + 1, Spark.getRDDs().size());
-
-            System.out.println(Spark.getRDD(prefix + i).getStorageLevel().description());
-            System.out.println(Spark.getRDD(prefix + i).getCreationSite());
-            System.out.println(Spark.getRDD(prefix + i).id());
-            System.out.println(Spark.getRDD(prefix + i).toDebugString());
-            System.out.println(Spark.getRDD(prefix + i).logName());
-            if(true) {
-                throw new IllegalArgumentException("HAA");
-            }
-
         }
 
         for (int i = 9; i >= 0; i--) {

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/SparkTest.java
@@ -69,6 +69,16 @@ public class SparkTest extends AbstractSparkTest {
             graph.compute(SparkGraphComputer.class).persist(GraphComputer.Persist.VERTEX_PROPERTIES).program(PageRankVertexProgram.build().iterations(1).create(graph)).submit().get();
             assertNotNull(Spark.getRDD(prefix + i));
             assertEquals(i + 1, Spark.getRDDs().size());
+
+            System.out.println(Spark.getRDD(prefix + i).getStorageLevel().description());
+            System.out.println(Spark.getRDD(prefix + i).getCreationSite());
+            System.out.println(Spark.getRDD(prefix + i).id());
+            System.out.println(Spark.getRDD(prefix + i).toDebugString());
+            System.out.println(Spark.getRDD(prefix + i).logName());
+            if(true) {
+                throw new IllegalArgumentException("HAA");
+            }
+
         }
 
         for (int i = 9; i >= 0; i--) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1023

Like `hdfs` there is now `spark` which allows the user to manage their persisted contexts. In essence, the Spark Server looks like a file system with (named) RDDs accessible. For instance, you can `spark.ls()`, `spark.rm()`, `spark.describe()`. I added a `SparkGremlinPluginTest` which ensures that all the proper imports/etc. work in the Console. I also added the information the reference docs. I published the reference docs so people can see it in action:

http://tinkerpop.apache.org/docs/3.1.1-SNAPSHOT/reference/#sparkgraphcomputer  (scroll down to "Using A Persisted Context" section)

VOTE +1. (`mvn clean install` and Spark integration tests)