### PR TITLE
TINKERPOP-1035 Improved consistency of transaction management in gremlin server.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fixed a `NullPointerException` bug in `PeerPressureVertexProgram` that occurred when an adjacency traversal was not provided.
+* Improved Transaction Management consistency in Gremlin Server.
 * Fixed a long standing issue around having to use `reduceByKey()` on input data to Spark. It is no longer required.
 * Added `Spark` static object to allow "file system" control of persisted RDDs in Spark.
 * Improved logging control during builds with Maven.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1132,6 +1132,35 @@ of a `Graph` is bound to the thread it was initialized in.
 A session is a "heavier" approach to the simple "request/response" approach of sessionless requests, but is sometimes
 necessary for a given use case.
 
+[[considering-transactions]]
+Considering Transactions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Gremlin Server does automated transaction handling for "sessionless" requests (i.e. no state between requests). It
+will automatically commit or rollback transactions depending on the success or failure of the script. When submitting
+requests it is important to recognize that transaction management procedures may differ slightly depending on what is
+returned from the script.
+
+* If the script returns anything other than a `GraphTraversal`, a commit will be called just before results are
+iterated back to the client.
+* If the result is a `GraphTraversal` that has no `Mutating` steps, a commit will be called just before results are
+iterated back to the client.
+* If the result is a `GraphTraversal` that has one or more `Mutating` steps (i.e. one that modifies the `Graph`),
+the `GraphTraversal` will be iterated, it's results pushed to a `List`, commit called, and the result in the `List`
+iterated back to the client.
+
+The last bullet point above begs additional explanation.  Assume that the script `g.addV('name','stephen')` was
+submitted to the server.  That script returns a `GraphTraversal` and has a `Mutating` step. The traversal needs to
+be iterated in order for the mutations to take place or else the commit will have no effect. That's why Gremlin
+Server attempts to detect these types of traversals and treat them specially. The unfortunate downside is that the
+result of this script must be realized in memory which means that they aren't being streamed back to the client.
+For small results this likely should not present an issue.
+
+NOTE: It is possible to bypass the transaction management system around `GraphTraversal` by using a lambda. Gremlin
+Server is only looking for `Mutating` steps, so a script like: `g.V().sideEffect{it.get().property('color','green')}`
+would not be iterated prior to commit and the mutations not realized.  If lambdas must be used then it is important
+to self-iterate by doing something like: `g.V().sideEffect{it.get().property('color','green')}.toList()`.
+
 Developing a Driver
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -32,6 +32,23 @@ Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.1.1-inc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Gremlin Server Transaction Management
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There were some changes to how Gremlin Server manages transactions on sessionless requests to make the process more
+consistent across different graph databases. Commits now occur after evaluation and prior to result iteration, which
+ensures an earlier failure (i.e. prior to results getting to the client indicating a false success) and better
+handling of a result that is a `GraphTraversal` that mutates the `Graph`.
+
+This change likely does not require any changes to the code of users, but does introduce some items to be aware of
+when issuing scripts. Most specifically, using lambdas in a request that returns a `GraphTraversal`, designed to modify
+the `Graph`, will fail to do so unless it is self-iterated.  In other words, instead of sending:
+`g.V().sideEffect{it.get().property('color','green')}` one would send:
+`g.V().sideEffect{it.get().property('color','green')}.toList()`
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1035[TINKERPOP-1035],
+link:http://tinkerpop.apache.org/docs/3.1.1-incubating/#considering-transactions[Reference Documentation - Considering Transactions]
+
 Deprecated credentialsDbLocation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -54,7 +54,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/Session.java
@@ -19,7 +19,6 @@
 package org.apache.tinkerpop.gremlin.server.op.session;
 
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.server.Context;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.Settings;

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -697,12 +697,14 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         final Cluster cluster = Cluster.build().create();
         final Client client = cluster.connect();
 
-        final Vertex vertexRequest1 = client.submit("graph.addVertex(\"name\",\"stephen\")").all().get().get(0).getVertex();
+        // this line is important because it tests GraphTraversal which has a certain transactional path
+        final Vertex vertexRequest1 = client.submit("g.addV(\"name\",\"stephen\")").all().get().get(0).getVertex();
         assertEquals("stephen", vertexRequest1.values("name").next());
 
         final Vertex vertexRequest2 = client.submit("graph.vertices().next()").all().get().get(0).getVertex();
         assertEquals("stephen", vertexRequest2.values("name").next());
 
+        // this line is important because it tests the other transactional path
         final Vertex vertexRequest3 = client.submit("graph.addVertex(\"name\",\"marko\")").all().get().get(0).getVertex();
         assertEquals("marko", vertexRequest3.values("name").next());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1035

Sessionless requests now have special handling for `GraphTraversal` return results.  Gremlin Server now force iterates those results (when they include `Mutating` steps) to a `List`.  It then commits and then iterates that `List`. For all other results the commit occurs in the same spot, but doesn't force iterate which allows results to stream as they always have.

Tested manually and with:

```text
mvn clean install
mvn verify -DskipIntegrationTests=false -pl gremlin-server
```

VOTE: +1