### PR TITLE
TINKERPOP-930 Added a strictTransactionManagement setting to Gremlin Server.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fixed a `SparkGraphComputer` sorting bug in MapReduce that occurred when there was more than one partition.
+* Added `strictTransactionManagement` to the Gremlin Server settings to indicate that the `aliases` parameter must be passed on requests and that transaction management will be scoped to the graphs provided in that argument.
 * Fixed a `NullPointerException` bug in `PeerPressureVertexProgram` that occurred when an adjacency traversal was not provided.
 * Improved Transaction Management consistency in Gremlin Server.
 * Fixed a long standing "view merge" issue requiring `reduceByKey()` on input data to Spark. It is no longer required.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -731,6 +731,7 @@ The following table describes the various configuration options that Gremlin Ser
 |ssl.keyFile |The `PKCS#8` private key file in PEM format. If this value is not present and `ssl.enabled` is `true` a self-signed certificate will be used (not suitable for production). |_none_
 |ssl.keyPassword |The password of the `keyFile` if it's not password-protected |_none_
 |ssl.trustCertChainFile |Trusted certificates for verifying the remote endpoint's certificate. The file should contain an X.509 certificate chain in PEM format. A system default will be used if this setting is not present. |_none_
+|strictTransactionManagement |Set to `true` to require `aliases` to be submitted on every requests, where the `aliases` become the scope of transaction management. |false
 |threadPoolBoss |The number of threads available to Gremlin Server for accepting connections. Should always be set to `1`. |1
 |threadPoolWorker |The number of threads available to Gremlin Server for processing non-blocking reads and writes. |1
 |writeBufferHighWaterMark | If the number of bytes in the network send buffer exceeds this value then the channel is no longer writeable, accepting no additional writes until buffer is drained and the `writeBufferLowWaterMark` is met. |65536
@@ -1155,6 +1156,13 @@ be iterated in order for the mutations to take place or else the commit will hav
 Server attempts to detect these types of traversals and treat them specially. The unfortunate downside is that the
 result of this script must be realized in memory which means that they aren't being streamed back to the client.
 For small results this likely should not present an issue.
+
+Another aspect of Transaction Management that should be considered is the usage of the `strictTransactionManagement`
+setting.  It is `false` by default, but when set to `true`, it forces the user to pass `aliases` for all requests.
+The aliases are then used to determine which graphs will have their transactions closed for that request. Running
+Gremlin Server in this configuration should be more efficient when there are multiple graphs being hosted as
+Gremlin Server will only close transactions on the graphs specified by the `aliases`. Keeping this setting `false`,
+will simply have Gremlin Server close transactions on all graphs for every request.
 
 NOTE: It is possible to bypass the transaction management system around `GraphTraversal` by using a lambda. Gremlin
 Server is only looking for `Mutating` steps, so a script like: `g.V().sideEffect{it.get().property('color','green')}`

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -46,7 +46,15 @@ the `Graph`, will fail to do so unless it is self-iterated.  In other words, ins
 `g.V().sideEffect{it.get().property('color','green')}` one would send:
 `g.V().sideEffect{it.get().property('color','green')}.toList()`
 
-See: link:https://issues.apache.org/jira/browse/TINKERPOP-1035[TINKERPOP-1035],
+In addition, Gremlin Server now has a new setting called `strictTransactionManagement`, which forces the user to pass
+`aliases` for all requests. The aliases are then used to determine which graphs will have their transactions closed
+for that request. The alternative is to continue with default operations where the transactions of all configured
+graphs will be closed. It is likely that `strictTransactionManagement` (which is `false` by default so as to be
+backward compatible with previous versions) will become the future standard mode of operation for Gremlin Server as
+it provides a more efficient method for transaction management.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-930[TINKERPOP-930],
+link:https://issues.apache.org/jira/browse/TINKERPOP-1035[TINKERPOP-1035],
 link:http://tinkerpop.apache.org/docs/3.1.1-incubating/#considering-transactions[Reference Documentation - Considering Transactions]
 
 Deprecated credentialsDbLocation

--- a/gremlin-server/conf/gremlin-server-classic.yaml
+++ b/gremlin-server/conf/gremlin-server-classic.yaml
@@ -35,6 +35,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-min.yaml
+++ b/gremlin-server/conf/gremlin-server-min.yaml
@@ -33,6 +33,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}         # application/json
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-modern-readonly.yaml
+++ b/gremlin-server/conf/gremlin-server-modern-readonly.yaml
@@ -35,6 +35,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-modern.yaml
@@ -35,6 +35,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}   # application/vnd.gremlin-v1.0+gryo-stringd
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-neo4j.yaml
+++ b/gremlin-server/conf/gremlin-server-neo4j.yaml
@@ -58,6 +58,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-rest-modern.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-modern.yaml
@@ -36,6 +36,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { useMapperFromGraph: graph }}         # application/json
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-rest-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-rest-secure.yaml
@@ -58,6 +58,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-secure.yaml
+++ b/gremlin-server/conf/gremlin-server-secure.yaml
@@ -58,6 +58,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server-spark.yaml
+++ b/gremlin-server/conf/gremlin-server-spark.yaml
@@ -71,6 +71,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/conf/gremlin-server.yaml
+++ b/gremlin-server/conf/gremlin-server.yaml
@@ -48,6 +48,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -161,6 +161,15 @@ public class Settings {
     public int writeBufferLowWaterMark = 1024 * 32;
 
     /**
+     * If set to {@code true} the {@code aliases} option is required on requests and Gremlin Server will use that
+     * information to control which {@link Graph} instances are transaction managed for that request.  If this
+     * setting is false (which is the default), specification of {@code aliases} is not required and Gremlin
+     * Server will simply apply a commit for all graphs.  This setting only applies to sessionless requests.
+     * With either setting the user is responsible for their own transaction management for in-session requests.
+     */
+    public boolean strictTransactionManagement = false;
+
+    /**
      * The full class name of the {@link Channelizer} to use in Gremlin Server.
      */
     public String channelizer = WebSocketChannelizer.class.getName();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
@@ -47,7 +47,7 @@ public class HttpChannelizer extends AbstractChannelizer {
     @Override
     public void init(final ServerGremlinExecutor<EventLoopGroup> serverGremlinExecutor) {
         super.init(serverGremlinExecutor);
-        httpGremlinEndpointHandler = new HttpGremlinEndpointHandler(serializers, gremlinExecutor, graphManager);
+        httpGremlinEndpointHandler = new HttpGremlinEndpointHandler(serializers, gremlinExecutor, graphManager, settings);
     }
 
     @Override

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/AbstractEvalOpProcessor.java
@@ -20,8 +20,6 @@ package org.apache.tinkerpop.gremlin.server.op;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
-import io.netty.channel.ChannelFuture;
-import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
@@ -29,31 +27,24 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
-import org.apache.tinkerpop.gremlin.server.handler.StateKey;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.server.Context;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.apache.tinkerpop.gremlin.server.OpProcessor;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.util.MetricManager;
-import org.apache.tinkerpop.gremlin.structure.io.Mapper;
-import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoMapper;
 import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.commons.lang.time.StopWatch;
-import org.apache.tinkerpop.shaded.kryo.Kryo;
-import org.apache.tinkerpop.shaded.kryo.io.ByteBufferOutputStream;
-import org.apache.tinkerpop.shaded.kryo.io.Input;
-import org.apache.tinkerpop.shaded.kryo.io.Output;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -224,7 +215,7 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
         if (!itty.hasNext()) {
             // as there is nothing left to iterate if we are transaction managed then we should execute a
             // commit here before we send back a NO_CONTENT which implies success
-            if (manageTransactions) context.getGraphManager().commitAll();
+            if (manageTransactions) attemptCommit(msg, context.getGraphManager(), settings.strictTransactionManagement);
             ctx.writeAndFlush(ResponseMessage.build(msg)
                     .code(ResponseStatusCode.NO_CONTENT)
                     .create());
@@ -255,7 +246,7 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
             // the script has been executed. failures will bubble up before we start to iterate results which makes
             // sense as we wouldn't want to waste time sending back results when the transaction is going to end up
             // failing
-            context.getGraphManager().commitAll();
+            attemptCommit(msg, context.getGraphManager(), settings.strictTransactionManagement);
         }
 
         // the batch size can be overridden by the request
@@ -306,6 +297,19 @@ public abstract class AbstractEvalOpProcessor implements OpProcessor {
         }
 
         stopWatch.stop();
+    }
+
+    private static void attemptCommit(final RequestMessage msg, final GraphManager graphManager, final boolean strict) {
+        if (strict) {
+            // assumes that validations will already have been performed in extending classes - they are performed
+            // in StandardOpProcessor when getting bindings right now
+            final boolean hasRebindings = msg.getArgs().containsKey(Tokens.ARGS_REBINDINGS);
+            final String rebindingOrAliasParameter = hasRebindings ? Tokens.ARGS_REBINDINGS : Tokens.ARGS_ALIASES;
+            final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
+            graphManager.commit(new HashSet<>(aliases.values()));
+        } else {
+            graphManager.commitAll();
+        }
     }
 
     @FunctionalInterface

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/session/SessionOpProcessor.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/standard/StandardOpProcessor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/op/standard/StandardOpProcessor.java
@@ -112,29 +112,42 @@ public class StandardOpProcessor extends AbstractEvalOpProcessor {
 
             // alias any global bindings to a different variable.
             if (msg.getArgs().containsKey(rebindingOrAliasParameter)) {
-                final Map<String, String> rebinds = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
-                for (Map.Entry<String,String> kv : rebinds.entrySet()) {
+                final Map<String, String> aliases = (Map<String, String>) msg.getArgs().get(rebindingOrAliasParameter);
+                for (Map.Entry<String,String> aliasKv : aliases.entrySet()) {
                     boolean found = false;
+
+                    // first check if the alias refers to a Graph instance
                     final Map<String, Graph> graphs = context.getGraphManager().getGraphs();
-                    if (graphs.containsKey(kv.getValue())) {
-                        bindings.put(kv.getKey(), graphs.get(kv.getValue()));
+                    if (graphs.containsKey(aliasKv.getValue())) {
+                        bindings.put(aliasKv.getKey(), graphs.get(aliasKv.getValue()));
                         found = true;
                     }
 
+                    // if the alias wasn't found as a Graph then perhaps it is a TraversalSource - it needs to be
+                    // something
                     if (!found) {
                         final Map<String, TraversalSource> traversalSources = context.getGraphManager().getTraversalSources();
-                        if (traversalSources.containsKey(kv.getValue())) {
-                            bindings.put(kv.getKey(), traversalSources.get(kv.getValue()));
+                        if (traversalSources.containsKey(aliasKv.getValue())) {
+                            bindings.put(aliasKv.getKey(), traversalSources.get(aliasKv.getValue()));
                             found = true;
                         }
                     }
 
+                    // this validation is important to calls to GraphManager.commit() and rollback() as they both
+                    // expect that the aliases supplied are valid
                     if (!found) {
                         final String error = String.format("Could not alias [%s] to [%s] as [%s] not in the Graph or TraversalSource global bindings",
-                                kv.getKey(), kv.getValue(), kv.getValue());
+                                aliasKv.getKey(), aliasKv.getValue(), aliasKv.getValue());
                         throw new OpProcessorException(error, ResponseMessage.build(msg)
                                 .code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).result(error).create());
                     }
+                }
+            } else {
+                // there's no bindings so determine if that's ok with Gremlin Server
+                if (context.getSettings().strictTransactionManagement) {
+                    final String error = "Gremlin Server is configured with strictTransactionManagement as 'true' - the 'aliases' arguments must be provided";
+                    throw new OpProcessorException(error, ResponseMessage.build(msg)
+                            .code(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS).result(error).create());
                 }
             }
 

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-integration.yaml
@@ -47,6 +47,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192

--- a/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-performance.yaml
+++ b/gremlin-server/src/test/resources/org/apache/tinkerpop/gremlin/server/gremlin-server-performance.yaml
@@ -46,6 +46,7 @@ metrics: {
   slf4jReporter: {enabled: true, interval: 180000},
   gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
   graphiteReporter: {enabled: false, interval: 180000}}
+strictTransactionManagement: false
 threadPoolBoss: 1
 maxInitialLineLength: 4096
 maxHeaderSize: 8192


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-930

Basically forces the user to pass the aliases argument.  Gremlin Server then uses that to determine the scope of the transactions to close.  This setting is false by default so as to be backward compatible.

Tested with:

```text
mvn clean install
mvn verify -DskipIntegrationTests=false -DincludeNeo4j -pl gremlin-server
```

VOTE +1