### PR TITLE
TINKERPOP-1019 Replaced all system.out.println and system.out.error with logger.

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/LambdaSideEffectStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/LambdaSideEffectStepTest.java
@@ -21,6 +21,8 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,12 +31,13 @@ import java.util.List;
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
 public class LambdaSideEffectStepTest extends StepTest {
+    private static final Logger logger = LoggerFactory.getLogger(LambdaSideEffectStepTest.class);
 
     @Override
     protected List<Traversal> getTraversals() {
         return Arrays.asList(
-                __.sideEffect(t -> System.out.println(t.get())),
-                __.sideEffect(t -> System.err.println(t.get()))
+                __.sideEffect(t -> logger.info(t.get().toString())),
+                __.sideEffect(t -> logger.error(t.get().toString()))
         );
     }
 }

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineIntegrateTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineIntegrateTest.java
@@ -22,6 +22,8 @@ import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
 import javax.script.ScriptException;
@@ -33,6 +35,7 @@ import static org.junit.Assert.fail;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinGroovyScriptEngineIntegrateTest extends AbstractGremlinTest {
+    private static final Logger logger = LoggerFactory.getLogger(GremlinGroovyScriptEngineIntegrateTest.class);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -47,7 +50,7 @@ public class GremlinGroovyScriptEngineIntegrateTest extends AbstractGremlinTest 
         };
 
         long parameterizedStartTime = System.currentTimeMillis();
-        System.out.println("Try to blow the heap with parameterized Gremlin.");
+        logger.info("Try to blow the heap with parameterized Gremlin.");
         try {
             for (int ix = 0; ix < 50001; ix++) {
                 final Bindings bindings = engine.createBindings();
@@ -56,7 +59,7 @@ public class GremlinGroovyScriptEngineIntegrateTest extends AbstractGremlinTest 
                 engine.eval(gremlins[ix % 4], bindings);
 
                 if (ix > 0 && ix % 5000 == 0) {
-                    System.out.println(String.format("%s scripts processed in %s (ms) - rate %s (ms/q).", ix, System.currentTimeMillis() - parameterizedStartTime, Double.valueOf(System.currentTimeMillis() - parameterizedStartTime) / Double.valueOf(ix)));
+                    logger.info(String.format("%s scripts processed in %s (ms) - rate %s (ms/q).", ix, System.currentTimeMillis() - parameterizedStartTime, Double.valueOf(System.currentTimeMillis() - parameterizedStartTime) / Double.valueOf(ix)));
                 }
             }
         } catch (OutOfMemoryError oome) {
@@ -68,13 +71,13 @@ public class GremlinGroovyScriptEngineIntegrateTest extends AbstractGremlinTest 
     public void shouldNotBlowTheHeapUnparameterized() throws ScriptException {
         final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine();
         long notParameterizedStartTime = System.currentTimeMillis();
-        System.out.println("Try to blow the heap with non-parameterized Gremlin.");
+        logger.info("Try to blow the heap with non-parameterized Gremlin.");
         try {
             for (int ix = 0; ix < 15001; ix++) {
                 final Bindings bindings = engine.createBindings();
                 engine.eval(String.format("1+%s", ix), bindings);
                 if (ix > 0 && ix % 5000 == 0) {
-                    System.out.println(String.format("%s scripts processed in %s (ms) - rate %s (ms/q).", ix, System.currentTimeMillis() - notParameterizedStartTime, Double.valueOf(System.currentTimeMillis() - notParameterizedStartTime) / Double.valueOf(ix)));
+                    logger.info(String.format("%s scripts processed in %s (ms) - rate %s (ms/q).", ix, System.currentTimeMillis() - notParameterizedStartTime, Double.valueOf(System.currentTimeMillis() - notParameterizedStartTime) / Double.valueOf(ix)));
                 }
             }
         } catch (OutOfMemoryError oome) {

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTest.java
@@ -24,6 +24,8 @@ import org.apache.tinkerpop.gremlin.groovy.NoImportCustomizerProvider;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -52,6 +54,7 @@ import static org.junit.Assert.fail;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinGroovyScriptEngineTest {
+    private static final Logger logger = LoggerFactory.getLogger(GremlinGroovyScriptEngineTest.class);
 
     @Test
     public void shouldCompileScriptWithoutRequiringVariableBindings() throws Exception {
@@ -245,7 +248,7 @@ public class GremlinGroovyScriptEngineTest {
             fail("Should fail as class is not yet imported");
         } catch (ScriptException se) {
             // should get here as Color.BLACK is not imported yet.
-            System.out.println("Failed to execute Color.BLACK as expected.");
+            logger.info("Failed to execute Color.BLACK as expected.");
         }
 
         final Thread evalThread = new Thread(() -> {
@@ -268,7 +271,7 @@ public class GremlinGroovyScriptEngineTest {
         Thread.sleep(1000);
 
         final Thread importThread = new Thread(() -> {
-            System.out.println("Importing java.awt.Color...");
+            logger.info("Importing java.awt.Color...");
             final Set<String> imports = new HashSet<String>() {{
                 add("import java.awt.Color");
             }};

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/AbstractGremlinServerIntegrationTest.java
@@ -22,6 +22,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
@@ -38,6 +40,7 @@ public abstract class AbstractGremlinServerIntegrationTest {
     private GremlinServer server;
     private final static String epollOption = "gremlin.server.epoll";
     private static final boolean GREMLIN_SERVER_EPOLL = "true".equalsIgnoreCase(System.getProperty(epollOption));
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinServerIntegrationTest.class);
 
     @Rule
     public TestName name = new TestName();
@@ -52,8 +55,8 @@ public abstract class AbstractGremlinServerIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        System.out.println("* Testing: " + name.getMethodName());
-        System.out.println("* Epoll option enabled:" + GREMLIN_SERVER_EPOLL);
+        logger.info("* Testing: " + name.getMethodName());
+        logger.info("* Epoll option enabled:" + GREMLIN_SERVER_EPOLL);
 
         final InputStream stream = getSettingsInputStream();
         final Settings settings = Settings.read(stream);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinAdditionPerformanceTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinAdditionPerformanceTest.java
@@ -33,6 +33,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 
@@ -47,6 +49,7 @@ import static org.junit.Assert.assertEquals;
 @BenchmarkMethodChart(filePrefix = "gremlin-addition")
 @BenchmarkHistoryChart(labelWith = LabelType.CUSTOM_KEY, maxRuns = 20, filePrefix = "hx-gremlin-addition")
 public class GremlinAdditionPerformanceTest extends AbstractGremlinServerPerformanceTest {
+    private static final Logger logger = LoggerFactory.getLogger(GremlinAdditionPerformanceTest.class);
 
     public final static int DEFAULT_BENCHMARK_ROUNDS = 50;
     public final static int DEFAULT_WARMUP_ROUNDS = 5;
@@ -77,7 +80,7 @@ public class GremlinAdditionPerformanceTest extends AbstractGremlinServerPerform
     public void webSocketsGremlinConcurrentAlternateSerialization() throws Exception {
         final Serializers[] mimes = new Serializers[]{Serializers.GRAPHSON, Serializers.GRAPHSON_V1D0, Serializers.GRYO_V1D0};
         final Serializers mimeType = mimes[rand.nextInt(3)];
-        System.out.println(mimeType);
+        logger.info(mimeType.toString());
         final Cluster cluster = Cluster.build("localhost")
                 .serializer(mimeType)
                 .create();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -73,7 +73,7 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegrationTest {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinServerIntegrationTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(GremlinDriverIntegrateTest.class);
     /**
      * Configure specific Gremlin Server settings for specific tests.
      */

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -38,6 +38,8 @@ import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import groovy.json.JsonBuilder;
 import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -71,7 +73,7 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegrationTest {
-
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinServerIntegrationTest.class);
     /**
      * Configure specific Gremlin Server settings for specific tests.
      */
@@ -184,12 +186,12 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         assertFalse(futureFive.isDone());
         assertEquals("zero", futureZero.get().get(0).getString());
 
-        System.out.println("Eval of 'zero' complete: " + TimeUtil.millisSince(start));
+        logger.info("Eval of 'zero' complete: " + TimeUtil.millisSince(start));
 
         assertFalse(futureFive.isDone());
         assertEquals("five", futureFive.get(10, TimeUnit.SECONDS).get(0).getString());
 
-        System.out.println("Eval of 'five' complete: " + TimeUtil.millisSince(start));
+        logger.info("Eval of 'five' complete: " + TimeUtil.millisSince(start));
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGraphProvider.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGraphProvider.java
@@ -24,6 +24,8 @@ import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoReader;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,7 +39,7 @@ import java.util.Map;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public abstract class AbstractGraphProvider implements GraphProvider {
-
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGraphProvider.class);
     /**
      * Provides a basic configuration for a particular {@link org.apache.tinkerpop.gremlin.structure.Graph} instance and used
      * the {@code graphName} to ensure that the instance is unique.  It is up to the Gremlin implementation
@@ -108,7 +110,7 @@ public abstract class AbstractGraphProvider implements GraphProvider {
         // cleared between tests runs and this exception will make it clear if it is not. this code used to
         // throw an exception but that fails windows builds in some cases unecessarily - hopefully the print
         // to screen is enough to hint failures due to the old directory still being in place.
-        if (directory.exists()) System.err.println("unable to delete directory " + directory.getAbsolutePath());
+        if (directory.exists()) logger.error("unable to delete directory " + directory.getAbsolutePath());
     }
 
     /**

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinSuite.java
@@ -29,6 +29,8 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.Suite;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -46,6 +48,7 @@ import java.util.stream.Stream;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public abstract class AbstractGremlinSuite extends Suite {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinSuite.class);
     /**
      * Indicates that this suite is for testing a gremlin flavor and is therefore not responsible for validating
      * the suite against what the {@link Graph} implementation opts-in for. This setting will let Gremlin flavor
@@ -117,7 +120,7 @@ public abstract class AbstractGremlinSuite extends Suite {
         final Graph.OptIn[] optIns = klass.getAnnotationsByType(Graph.OptIn.class);
         if (!Arrays.stream(optIns).anyMatch(optIn -> optIn.value().equals(this.getClass().getCanonicalName())))
             if (gremlinFlavorSuite)
-                System.err.println(String.format("The %s will run for this Graph as it is testing a Gremlin flavor but the Graph does not publicly acknowledged it yet with the @OptIn annotation.", this.getClass().getSimpleName()));
+                logger.error(String.format("The %s will run for this Graph as it is testing a Gremlin flavor but the Graph does not publicly acknowledged it yet with the @OptIn annotation.", this.getClass().getSimpleName()));
             else
                 throw new InitializationError(String.format("The %s will not run for this Graph until it is publicly acknowledged with the @OptIn annotation on the Graph instance itself", this.getClass().getSimpleName()));
     }
@@ -154,7 +157,7 @@ public abstract class AbstractGremlinSuite extends Suite {
                 .collect(Collectors.toList());
 
         if (notSupplied.size() > 0)
-            System.err.println(String.format("Review the testsToExecute given to the test suite as the following are missing: %s", notSupplied));
+            logger.error(String.format("Review the testsToExecute given to the test suite as the following are missing: %s", notSupplied));
 
         return testsToExecute;
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -34,6 +34,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -57,6 +59,7 @@ import static org.junit.Assume.assumeThat;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public abstract class AbstractGremlinTest {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinTest.class);
     protected Graph graph;
     protected GraphTraversalSource g;
     protected Optional<Class<? extends GraphComputer>> graphComputerClass;
@@ -235,12 +238,10 @@ public abstract class AbstractGremlinTest {
     }
 
     public void printTraversalForm(final Traversal traversal) {
-        final boolean muted = Boolean.parseBoolean(System.getProperty("muteTestLogs", "false"));
-
-        if (!muted) System.out.println(String.format("Testing: %s", name.getMethodName()));
-        if (!muted) System.out.println("   pre-strategy:" + traversal);
+        logger.info(String.format("Testing: %s", name.getMethodName()));
+        logger.info("   pre-strategy:" + traversal);
         traversal.hasNext();
-        if (!muted) System.out.println("  post-strategy:" + traversal);
+        logger.info("  post-strategy:" + traversal);
         verifyUniqueStepIds(traversal.asAdmin());
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/CommunityGeneratorTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/algorithm/generator/CommunityGeneratorTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +45,7 @@ import static org.junit.Assert.*;
  */
 @RunWith(Enclosed.class)
 public class CommunityGeneratorTest {
+    private static final Logger logger = LoggerFactory.getLogger(CommunityGeneratorTest.class);
 
     @RunWith(Parameterized.class)
     public static class DifferentDistributionsTest extends AbstractGeneratorTest {
@@ -178,7 +181,7 @@ public class CommunityGeneratorTest {
                     tryCommit(graph);
                     afterLoadGraphWith(graph);
 
-                    System.out.println(String.format("Ran CommunityGeneratorTest with different CrossCommunityPercentage, expected %s but used %s", crossPcent, localCrossPcent));
+                    logger.info(String.format("Ran CommunityGeneratorTest with different CrossCommunityPercentage, expected %s but used %s", crossPcent, localCrossPcent));
 
                     if (generated) failures.incrementAndGet();
                 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/AbstractGremlinProcessTest.java
@@ -24,6 +24,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MapHelper;
 import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,6 +42,7 @@ import static org.junit.Assume.assumeTrue;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGremlinProcessTest.class);
 
     /**
      * Determines if a graph meets requirements for execution.  All gremlin process tests should check this
@@ -76,8 +79,8 @@ public abstract class AbstractGremlinProcessTest extends AbstractGremlinTest {
         final List<T> results = traversal.toList();
         assertFalse(traversal.hasNext());
         if(expectedResults.size() != results.size()) {
-            System.err.println("Expected results: " + expectedResults);
-            System.err.println("Actual results:   " + results);
+            logger.error("Expected results: " + expectedResults);
+            logger.error("Actual results:   " + results);
             assertEquals("Checking result size", expectedResults.size(), results.size());
         }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/GremlinProcessRunner.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/GremlinProcessRunner.java
@@ -26,6 +26,8 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.NotSerializableException;
 
@@ -33,7 +35,7 @@ import java.io.NotSerializableException;
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
 public class GremlinProcessRunner extends BlockJUnit4ClassRunner {
-
+    private static final Logger logger = LoggerFactory.getLogger(GremlinProcessRunner.class);
     public GremlinProcessRunner(Class<?> klass) throws InitializationError {
         super(klass);
     }
@@ -54,7 +56,7 @@ public class GremlinProcessRunner extends BlockJUnit4ClassRunner {
             } catch (Throwable e) {
                 if (validateForGraphComputer(e)) {
                     eachNotifier.fireTestIgnored();
-                    System.err.println(e.getMessage());
+                    logger.error(e.getMessage());
                     ignored = true;
                 } else
                     eachNotifier.addFailure(e);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategyProcessTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ElementIdStrategyProcessTest.java
@@ -28,6 +28,8 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,6 +41,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
+    private static final Logger logger = LoggerFactory.getLogger(ElementIdStrategyProcessTest.class);
 
     @Test
     @FeatureRequirementSet(FeatureRequirementSet.Package.VERTICES_ONLY)
@@ -50,11 +53,11 @@ public class ElementIdStrategyProcessTest extends AbstractGremlinProcessTest {
 
         final Traversal t1 = graph.traversal().V(v);
         t1.asAdmin().applyStrategies();
-        System.out.println(t1);
+        logger.info(t1.toString());
 
         final Traversal t2 = sg.V(v);
         t2.asAdmin().applyStrategies();
-        System.out.println(t2);
+        logger.info(t2.toString());
 
         assertNotNull(UUID.fromString(sg.V(v).id().next().toString()));
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/FeatureSupportTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/FeatureSupportTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.UUID;
@@ -55,6 +57,7 @@ import static org.junit.Assume.assumeThat;
 @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
 public class FeatureSupportTest {
     private static final String INVALID_FEATURE_SPECIFICATION = "Features for %s specify that %s is false, but the feature appears to be implemented.  Reconsider this setting or throw the standard Exception.";
+    private static final Logger logger = LoggerFactory.getLogger(FeatureSupportTest.class);
 
     public static class FeatureToStringTest extends AbstractGremlinTest {
         /**
@@ -83,8 +86,8 @@ public class FeatureSupportTest {
          */
         @Test
         public void shouldPrintTheFeatureList() {
-            System.out.println(String.format("Printing Features of %s for reference: ", g.getClass().getSimpleName()));
-            System.out.println(graph.features());
+            logger.info(String.format("Printing Features of %s for reference: ", g.getClass().getSimpleName()));
+            logger.info(graph.features().toString());
             assertTrue(true);
         }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoIntegrateTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/io/IoIntegrateTest.java
@@ -30,6 +30,8 @@ import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
 import org.javatuples.Pair;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -44,6 +46,8 @@ import static org.junit.Assert.assertTrue;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class IoIntegrateTest extends AbstractGremlinTest {
+    private static final Logger logger = LoggerFactory.getLogger(IoIntegrateTest.class);
+
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY)
@@ -89,9 +93,9 @@ public class IoIntegrateTest extends AbstractGremlinTest {
         final int detachedVertexSize = outputStream.size();
         assertTrue(starGraphSize < detachedVertexSize);
 
-        System.out.println("Size of star graph:        " + starGraphSize);
-        System.out.println("Size of detached vertex:   " + detachedVertexSize);
-        System.out.println("Size reduction:            " + (float) detachedVertexSize / (float) starGraphSize);
+        logger.info("Size of star graph:        {}", starGraphSize);
+        logger.info("Size of detached vertex:   {}", detachedVertexSize);
+        logger.info("Size reduction:            {}", (float) detachedVertexSize / (float) starGraphSize);
     }
 
     private Pair<StarGraph, Integer> serializeDeserialize(final StarGraph starGraph) {

--- a/gremlin-test/src/test/java/org/apache/tinkerpop/gremlin/structure/ExceptionCoverageTest.java
+++ b/gremlin-test/src/test/java/org/apache/tinkerpop/gremlin/structure/ExceptionCoverageTest.java
@@ -23,6 +23,8 @@ import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputerTest;
 import org.apache.tinkerpop.gremlin.process.traversal.CoreTraversalTest;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertTrue;
  * @author Pieter Martin
  */
 public class ExceptionCoverageTest {
+    private static final Logger logger = LoggerFactory.getLogger(ExceptionCoverageTest.class);
 
     @Test
     public void shouldCoverAllExceptionsInTests() {
@@ -98,7 +101,7 @@ public class ExceptionCoverageTest {
         Stream.of(exceptionDefinitionClasses).flatMap(c -> Stream.of(c.getDeclaredMethods()).map((Method m) -> String.format("%s#%s", c.getName(), m.getName())))
                 .filter(s -> !ignore.contains(s))
                 .forEach(s -> {
-                    System.out.println(s);
+                    logger.info(s);
                     assertTrue(implementedExceptions.contains(s));
                 });
     }

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/RecordReaderWriterTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/RecordReaderWriterTest.java
@@ -38,6 +38,8 @@ import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
@@ -54,6 +56,7 @@ import static org.junit.Assert.assertTrue;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public abstract class RecordReaderWriterTest {
+    private static final Logger logger = LoggerFactory.getLogger(RecordReaderWriterTest.class);
 
     protected abstract String getInputFilename();
 
@@ -65,7 +68,7 @@ public abstract class RecordReaderWriterTest {
     public void shouldSplitFileAndWriteProperSplits() throws Exception {
         for (int numberOfSplits = 1; numberOfSplits < 10; numberOfSplits++) {
             final File testFile = new File(HadoopGraphProvider.PATHS.get(getInputFilename()));
-            System.out.println("Testing: " + testFile + " (splits " + numberOfSplits + ")");
+            logger.info("Testing: {}", testFile + " (splits {}", numberOfSplits + ")");
             final List<FileSplit> splits = generateFileSplits(testFile, numberOfSplits);
             final Class<? extends InputFormat<NullWritable, VertexWritable>> inputFormatClass = getInputFormat();
             final Class<? extends OutputFormat<NullWritable, VertexWritable>> outputFormatClass = getOutputFormat();
@@ -109,7 +112,7 @@ public abstract class RecordReaderWriterTest {
 
         boolean foundKeyValue = false;
         for (final FileSplit split : fileSplits) {
-            System.out.println("\treading file split " + split.getPath().getName() + " (" + split.getStart() + "..." + (split.getStart() + split.getLength()) + " bytes)");
+            logger.info("\treading file split {}", split.getPath().getName() + " ({}", split.getStart() + "..." + (split.getStart() + split.getLength()), "{} {} bytes)");
             final RecordReader reader = inputFormat.createRecordReader(split, job);
 
             float lastProgress = -1f;

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/NativeNeo4jCypherTest.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/process/NativeNeo4jCypherTest.java
@@ -29,6 +29,8 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,6 +49,7 @@ import static org.junit.Assert.*;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class NativeNeo4jCypherTest extends AbstractNeo4jGremlinTest {
+    private static final Logger logger = LoggerFactory.getLogger(NativeNeo4jCypherTest.class);
 
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
@@ -200,11 +203,11 @@ public class NativeNeo4jCypherTest extends AbstractNeo4jGremlinTest {
         );
         int counter = 0;
         for (final Supplier<GraphTraversal<?, ?>> traversal : traversals) {
-            System.out.println("pre-strategy:  " + traversal.get());
-            System.out.println("post-strategy: " + traversal.get().iterate());
-            System.out.println(TimeUtil.clockWithResult(25, () -> traversal.get().count().next()));
+            logger.info("pre-strategy:  {}", traversal.get());
+            logger.info("post-strategy: {}", traversal.get().iterate());
+            logger.info(TimeUtil.clockWithResult(25, () -> traversal.get().count().next()).toString());
             if (++counter % 2 == 0)
-                System.out.println("------------------");
+                logger.info("------------------");
         }
     }
 

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/structure/NativeNeo4jIndexTest.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/structure/NativeNeo4jIndexTest.java
@@ -30,6 +30,8 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +41,7 @@ import static org.junit.Assert.*;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class NativeNeo4jIndexTest extends AbstractNeo4jGremlinTest {
+    private static final Logger logger = LoggerFactory.getLogger(NativeNeo4jIndexTest.class);
 
     @Test
     public void shouldHaveFasterRuntimeWithLabelKeyValueIndex() throws Exception {
@@ -74,7 +77,7 @@ public class NativeNeo4jIndexTest extends AbstractNeo4jGremlinTest {
         assertTrue(this.getBaseGraph().hasSchemaIndex("something", "myId"));
         TimeUtil.clock(20, traversal);
         final double indexTime = TimeUtil.clock(20, traversal);
-        System.out.println("Query time (no-index vs. index): " + noIndexTime + " vs. " + indexTime);
+        logger.info("Query time (no-index vs. index): {}", noIndexTime + " vs. {}", indexTime);
         assertTrue((noIndexTime / 10) > indexTime); // should be at least 10x faster
     }
 
@@ -115,7 +118,7 @@ public class NativeNeo4jIndexTest extends AbstractNeo4jGremlinTest {
         assertTrue(this.getBaseGraph().hasSchemaIndex("something", "myId"));
         TimeUtil.clock(20, traversal);
         final double indexTime = TimeUtil.clock(20, traversal);
-        System.out.println("Query time (no-index vs. index): " + noIndexTime + " vs. " + indexTime);
+        logger.info("Query time (no-index vs. index): {}", noIndexTime + " vs. {}", indexTime);
         assertTrue((noIndexTime / 10) > indexTime); // should be at least 10x faster
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -929,9 +929,6 @@ limitations under the License.
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version>
                         <configuration>
-                            <systemPropertyVariables>
-                                <muteTestLogs>true</muteTestLogs>
-                            </systemPropertyVariables>
                             <argLine>-Dlog4j.configuration=${log4j-silent.properties} -Dbuild.dir=${project.build.directory}
                             </argLine>
                             <excludes>

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/AbstractSparkTest.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/AbstractSparkTest.java
@@ -25,11 +25,14 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.tinkerpop.gremlin.spark.structure.Spark;
 import org.junit.After;
 import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public abstract class AbstractSparkTest {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractSparkTest.class);
 
     @After
     @Before
@@ -41,6 +44,6 @@ public abstract class AbstractSparkTest {
         sparkContext.close();
         Spark.create(sparkContext.sc());
         Spark.close();
-        System.out.println("SparkContext has been closed for " + this.getClass().getCanonicalName() + "-setupTest");
+        logger.info("SparkContext has been closed for " + this.getClass().getCanonicalName() + "-setupTest");
     }
 }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -36,6 +36,8 @@ import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
@@ -49,6 +51,7 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class TinkerGraphPlayTest {
+    private static final Logger logger = LoggerFactory.getLogger(TinkerGraphPlayTest.class);
 
     @Test
     @Ignore
@@ -56,7 +59,7 @@ public class TinkerGraphPlayTest {
         Graph graph = TinkerFactory.createModern();
         GraphTraversalSource g = graph.traversal(); //GraphTraversalSource.computer());
         //System.out.println(g.V().outE("knows").identity().inV().count().is(P.eq(5)).explain());
-        System.out.println(g.V().both().both().groupCount().order(Scope.local).by(Column.values, Order.incr).toList());
+        logger.info(g.V().both().both().groupCount().order(Scope.local).by(Column.values, Order.incr).toList().toString());
 
     }
 
@@ -68,32 +71,32 @@ public class TinkerGraphPlayTest {
         graph.io(GraphMLIo.build()).readGraph("data/grateful-dead.xml");
         /////////
 
-        g.V().group().by(T.label).by(values("name")).forEachRemaining(System.out::println);
+        g.V().group().by(T.label).by(values("name")).forEachRemaining(x->logger.info(x.toString()));
 
-        System.out.println("group: " + g.V().both("followedBy").both("followedBy").group().by("songType").by(count()).next());
-        System.out.println("groupV3d0: " + g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().by(__.count(Scope.local)).next());
+        logger.info("group: " + g.V().both("followedBy").both("followedBy").group().by("songType").by(count()).next());
+        logger.info("groupV3d0: " + g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().by(__.count(Scope.local)).next());
 
         //
-        System.out.println("\n\nBig Values -- by(songType)");
+        logger.info("\n\nBig Values -- by(songType)");
 
-        System.out.println("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("songType").by(count()).next()));
-        System.out.println("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().by(__.count(Scope.local)).next()) + "\n");
-
-        ///
-
-        System.out.println("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("songType").by(fold()).next()));
-        System.out.println("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().next()));
-
-        ///
-        System.out.println("\n\nBig Keys -- by(name)");
-
-        System.out.println("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("name").by(count()).next()));
-        System.out.println("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("name").by().by(__.count(Scope.local)).next()) + "\n");
+        logger.info("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("songType").by(count()).next()));
+        logger.info("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().by(__.count(Scope.local)).next()) + "\n");
 
         ///
 
-        System.out.println("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("name").by(fold()).next()));
-        System.out.println("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("name").by().next()));
+        logger.info("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("songType").by(fold()).next()));
+        logger.info("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().next()));
+
+        ///
+        logger.info("\n\nBig Keys -- by(name)");
+
+        logger.info("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("name").by(count()).next()));
+        logger.info("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("name").by().by(__.count(Scope.local)).next()) + "\n");
+
+        ///
+
+        logger.info("group: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").group().by("name").by(fold()).next()));
+        logger.info("groupV3d0: " + TimeUtil.clock(10, () -> g.V().both("followedBy").both("followedBy").groupV3d0().by("name").by().next()));
 
     }
 
@@ -123,7 +126,7 @@ public class TinkerGraphPlayTest {
         v7.addEdge("link", v9, "weight", 1f);
         v8.addEdge("link", v9, "weight", 7f);
 
-        g.traversal().withSack(Float.MIN_VALUE).V(v1).repeat(outE().sack(Operator.max, "weight").inV()).times(5).sack().forEachRemaining(System.out::println);
+        g.traversal().withSack(Float.MIN_VALUE).V(v1).repeat(outE().sack(Operator.max, "weight").inV()).times(5).sack().forEachRemaining(x->logger.info(x.toString()));
     }
 
    /* @Test
@@ -152,7 +155,7 @@ public class TinkerGraphPlayTest {
                 () -> g.V().out().map(v -> g.V(v.get()).out().out().values("name").toList())
         );
         traversals.forEach(traversal -> {
-            System.out.println("\nTESTING: " + traversal.get());
+            logger.info("\nTESTING: {}", traversal.get());
             for (int i = 0; i < 7; i++) {
                 final long t = System.currentTimeMillis();
                 traversal.get().iterate();
@@ -183,7 +186,7 @@ public class TinkerGraphPlayTest {
                 () -> g.V().has(T.label, "song").both().groupCount().<Vertex>by(t -> g.V(t).both().values("name").next()),
                 () -> g.V().has(T.label, "song").both().groupCount().by(both().values("name")));
         traversals.forEach(traversal -> {
-            System.out.println("\nTESTING: " + traversal.get());
+            logger.info("\nTESTING: {}", traversal.get());
             for (int i = 0; i < 10; i++) {
                 final long t = System.currentTimeMillis();
                 traversal.get().iterate();
@@ -205,9 +208,9 @@ public class TinkerGraphPlayTest {
         TinkerFactory.generateModern((TinkerGraph) graph2);
         graph2.close();
 
-        System.out.println("graph1 -> graph2");
+        logger.info("graph1 -> graph2");
         graph1.compute().workers(1).program(BulkLoaderVertexProgram.build().userSuppliedIds(true).writeGraph("/tmp/graph2.properties").create(graph1)).submit().get();
-        System.out.println("graph1 -> graph3");
+        logger.info("graph1 -> graph3");
         graph1.compute().workers(1).program(BulkLoaderVertexProgram.build().userSuppliedIds(true).writeGraph("/tmp/graph3.properties").create(graph1)).submit().get();
     }
 
@@ -227,9 +230,9 @@ public class TinkerGraphPlayTest {
         );
 
         traversals.forEach(traversal -> {
-            System.out.println("pre-strategy:  " + traversal.get());
-            System.out.println("post-strategy: " + traversal.get().iterate());
-            System.out.println(TimeUtil.clockWithResult(50, () -> traversal.get().toList()));
+            logger.info("pre-strategy:  {}", traversal.get());
+            logger.info("post-strategy: {}", traversal.get().iterate());
+            logger.info(TimeUtil.clockWithResult(50, () -> traversal.get().toList()).toString());
         });
     }
 
@@ -251,9 +254,9 @@ public class TinkerGraphPlayTest {
                         as("d").where(P.neq("a"))).select("a", "b", "c", "d").by("name");
 
 
-        System.out.println(traversal.get());
-        System.out.println(traversal.get().iterate());
-        traversal.get().forEachRemaining(System.out::println);
+        logger.info(traversal.get().toString());
+        logger.info(traversal.get().iterate().toString());
+        traversal.get().forEachRemaining(x->logger.info(x.toString()));
 
     }
 
@@ -273,6 +276,6 @@ public class TinkerGraphPlayTest {
             });
         });
         graph.vertices(50).next().addEdge("uncle", graph.vertices(70).next());
-        System.out.println(TimeUtil.clockWithResult(500, () -> g.V().match(as("a").out("knows").as("b"), as("a").out("uncle").as("b")).toList()));
+        logger.info(TimeUtil.clockWithResult(500, () -> g.V().match(as("a").out("knows").as("b"), as("a").out("uncle").as("b")).toList()).toString());
     }
 }


### PR DESCRIPTION
Removed the `muteTestLog` system property because logging can now be controlled by config file.

Ran `mvn clean install` and `mvn clean install -Dci`

Logging appear appropriate in both cases.