### PR TITLE
TINKERPOP-891 Refactored the sandboxing abstractions for Gremlin Server

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 * Fixed a `SparkGraphComputer` sorting bug in MapReduce that occurred when there was more than one partition.
 * Fixed a `NullPointerException` bug in `PeerPressureVertexProgram` that occurred when an adjacency traversal was not provided.
 * Improved Transaction Management consistency in Gremlin Server.
+* Added `FileSandboxExtension` which takes a configuration file to white list methods and classes that can be used in `ScriptEngine` execution.
+* Deprecated `SandboxExtension` and `SimpleSandboxExtension` in favor of `AbstractSandboxExtension` which provides better abstractions for those writing sandboxes.
 * Fixed a long standing "view merge" issue requiring `reduceByKey()` on input data to Spark. It is no longer required.
 * Added `Spark` static object to allow "file system" control of persisted RDDs in Spark.
 * Added a Spark "job server" to ensure that persisted RDDs are not garbage collected by Spark.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -940,6 +940,10 @@ this documentation.  Consult the latest link:http://docs.groovy-lang.org/latest/
 for information on the differences. It is important to understand the impact that these configuration will have on
 submitted scripts before enabling this feature.
 
+NOTE: The import of classes to the script engine is handled by the `ImportCustomizerProvider`.  As the concept of
+"imports" is a first-class citizen (i.e. has its own configuration options), it is not recommended that the
+`ImportCustomizerProvider` be used as a configuration option to `compilerCustomizerProviders`.
+
 This configuration uses the `SimpleSandboxExtension`, which blacklists calls to methods on the `System` class,
 thereby preventing someone from remotely killing the server:
 
@@ -955,18 +959,70 @@ Script8.groovy: 1: [Static type checking] - Not authorized to call this method: 
 ----
 
 The `SimpleSandboxExtension` is by no means a "complete" implementation protecting against all manner of nefarious
-scripts, but it does provide an example for how such a capability might be implemented.  A full implementation would
-likely represent domain specific white-listing of methods (and possibly variables) available for execution in the
-script engine.
+scripts, but it does provide an example for how such a capability might be implemented.  A more complete implementation
+is offered in the `FileSandboxExtension` which uses a configuration file to white list certain classes and methods.
+The configuration file is YAML-based and an example is presented as follows:
+
+[source,yaml]
+----
+autoTypeUnknown: true
+methodWhiteList:
+  - java\.lang\.Boolean
+  - java\.lang\.Byte
+  - java\.lang\.Character
+  - java\.lang\.Double
+  - java\.lang\.Enum
+  - java\.lang\.Float
+  - java\.lang\.Integer
+  - java\.lang\.Long
+  - java\.lang\.Math
+  - java\.lang\.Number
+  - java\.lang\.Object
+  - java\.lang\.Short
+  - java\.lang\.String
+  - java\.lang\.StringBuffer
+  - java\.lang\.Throwable
+  - java\.lang\.Void
+  - java\.util\..*
+  - org\.codehaus\.groovy\.runtime\.DefaultGroovyMethods
+  - org\.codehaus\.groovy\.runtime\.StringGroovyMethods
+  - org\.apache\.tinkerpop\.gremlin\.structure\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.bulkloading\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.clustering\.peerpressure\.*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.ranking\.pagerank\.*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.traversal\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\.dsl\.graph\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\.engine\..*
+staticVariableTypes:
+  graph: org.apache.tinkerpop.gremlin.structure.Graph
+  g: org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
+----
+
+There are three keys in this configuration file that control different aspects of the sandbox:
+
+. `autoTypeUnknown` - When set to `true`, unresolved variables are typed as `Object`.
+. `methodWhiteList` - A white list of classes and methods that follow a regex pattern which can then be matched against
+method descriptors to determine if they can be executed.  The method descriptor is the fully-qualified class name
+of the method, its name and parameters. For example, `Math.ceil` would have a descriptor of
+`java.lang.Math#ceil(double)`.
+. `staticVariableTypes` - A list of variables that will be used in the `ScriptEngine` for which the types are
+always known.  In the above example, the variable "graph" will always be bound to a `Graph` instance.
+
+At Gremlin Server startup, the `FileSandboxExtension` looks in the root of Gremlin Server installation directory for a
+file called `sandbox.yaml` and configures itself.  To use a file in a different location set the
+`gremlinServerSandbox` system property to the location of the file (e.g. `-DgremlinServerSandbox=conf/my-sandbox.yaml`).
+
+The `FileSandboxExtension` provides for a basic configurable security function in Gremlin Server. More complex
+sandboxing implementations can be developed by using this white listing model and extending from the
+`AbstractSandboxExtension`.
 
 A final thought on the topic of `CompilerCustomizerProvider` implementations is that they are not just for
 "security" (though they are demonstrated in that capacity here).  They can be used for a variety of features that
 can fine tune the Groovy compilation process.  Read more about compilation customization in the
 link:http://docs.groovy-lang.org/latest/html/documentation/#compilation-customizers[Groovy Documentation].
-
-NOTE: The import of classes to the script engine is handled by the `ImportCustomizerProvider`.  As the concept of
-"imports" is a first-class citizen (i.e. has its own configuration options), it is not recommended that the
-`ImportCustomizerProvider` be used as a configuration option to `compilerCustomizerProviders`.
 
 Serialization
 ^^^^^^^^^^^^^

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -113,6 +113,19 @@ and `log4j-console.properties` which are in the respective `conf/` directories o
 
 See: https://issues.apache.org/jira/browse/TINKERPOP-859[TINKERPOP-859]
 
+Gremlin Server Sandboxing
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A number of improvements were made to the sandboxing feature of Gremlin Server (more specifically the
+`GremlinGroovyScriptEngine`).  A new base class for sandboxing was introduce with the `AbstractSandboxExtension`,
+which makes it a bit easier to build white list style sandboxes. A usable implementation of this was also supplied
+with the `FileSandboxExtension`, which takes a configuration file containing a white list of accessible methods and
+variables that can be used in scripts. Note that the original `SandboxExtension` has been deprecated in favor of
+the `AbsstractSandboxExtension` or extending directly from Groovy's `TypeCheckingDSL`.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-891[TINKERPOP-891],
+link:http://tinkerpop.apache.org/docs/3.1.0-incubating/#script-execution[Reference Documentation - Script Execution]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/GroovyEnvironmentSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/GroovyEnvironmentSuite.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.AbstractGremlinSuite;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.GraphManager;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutorOverGraphTest;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngineFileSandboxTest;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngineOverGraphTest;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngineSandboxCustomTest;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngineSandboxedStandardTest;
@@ -58,6 +59,7 @@ public class GroovyEnvironmentSuite extends AbstractGremlinSuite {
             GremlinGroovyScriptEngineSandboxCustomTest.class,
             GremlinGroovyScriptEngineSandboxedStandardTest.class,
             GremlinGroovyScriptEngineTinkerPopSandboxTest.class,
+            GremlinGroovyScriptEngineFileSandboxTest.class,
             GremlinExecutorOverGraphTest.class,
             SugarLoaderTest.class,
     };

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineFileSandboxTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineFileSandboxTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223;
+
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.TestHelper;
+import org.apache.tinkerpop.gremlin.groovy.CompilerCustomizerProvider;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.CompileStaticCustomizerProvider;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.FileSandboxExtension;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.script.Bindings;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class GremlinGroovyScriptEngineFileSandboxTest extends AbstractGremlinTest {
+    @BeforeClass
+    public static void init() throws Exception {
+        final File f = TestHelper.generateTempFileFromResource(GremlinGroovyScriptEngineFileSandboxTest.class, "sandbox.yaml", ".yaml");
+        System.setProperty(FileSandboxExtension.GREMLIN_SERVER_SANDBOX, f.getAbsolutePath());
+    }
+
+    @AfterClass
+    public static void destroy() {
+        System.clearProperty(FileSandboxExtension.GREMLIN_SERVER_SANDBOX);
+    }
+
+    @Test
+    public void shouldEvalAsTheMethodIsWhiteListed() throws Exception {
+        final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
+        try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
+            assertEquals(123, engine.eval("java.lang.Math.abs(-123)"));
+        }
+    }
+
+    @Test
+    public void shouldEvalAsGroovyPropertiesWhenWhiteListed() throws Exception {
+        final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
+        try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
+            assertThat(Arrays.equals("test".getBytes(), (byte[]) engine.eval("'test'.bytes")), is(true));
+        }
+    }
+
+    @Test
+    public void shouldPreventMaliciousStuffWithSystem() throws Exception {
+        final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
+        try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
+            engine.eval("System.exit(0)");
+            fail("Should have a compile error because class/method is not white listed");
+        } catch (Exception ex) {
+            assertEquals(MultipleCompilationErrorsException.class, ex.getCause().getClass());
+            assertThat(ex.getCause().getMessage(), containsString("Not authorized to call this method"));
+        }
+    }
+
+    @Test
+    public void shouldPreventMaliciousStuffWithFile() throws Exception {
+        final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
+        try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
+            engine.eval("java.nio.file.FileSystems.getDefault()");
+            fail("Should have a compile error because class/method is not white listed");
+        } catch (Exception ex) {
+            assertEquals(MultipleCompilationErrorsException.class, ex.getCause().getClass());
+            assertThat(ex.getCause().getMessage(), containsString("Not authorized to call this method"));
+        }
+    }
+
+    @Test
+    @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
+    public void shouldEvalOnGAsTheMethodIsWhiteListed() throws Exception {
+        final CompilerCustomizerProvider standardSandbox = new CompileStaticCustomizerProvider(FileSandboxExtension.class.getName());
+        try (GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(standardSandbox)) {
+            final Bindings bindings = engine.createBindings();
+            bindings.put("g", g);
+            bindings.put("marko", convertToVertexId("marko"));
+            assertEquals(g.V(convertToVertexId("marko")).next(), engine.eval("g.V(marko).next()", bindings));
+            assertEquals(g.V(convertToVertexId("marko")).out("created").count().next(), engine.eval("g.V(marko).out(\"created\").count().next()", bindings));
+        }
+    }
+}

--- a/gremlin-groovy-test/src/main/resources/org/apache/tinkerpop/gremlin/groovy/jsr223/sandbox.yaml
+++ b/gremlin-groovy-test/src/main/resources/org/apache/tinkerpop/gremlin/groovy/jsr223/sandbox.yaml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This is an example configuration for the FileSandboxExtension.
+
+autoTypeUnknown: true
+methodWhiteList:
+  - java\.lang\.Boolean
+  - java\.lang\.Byte
+  - java\.lang\.Character
+  - java\.lang\.Double
+  - java\.lang\.Enum
+  - java\.lang\.Float
+  - java\.lang\.Integer
+  - java\.lang\.Long
+  - java\.lang\.Math
+  - java\.lang\.Number
+  - java\.lang\.Object
+  - java\.lang\.Short
+  - java\.lang\.String
+  - java\.lang\.StringBuffer
+  - java\.lang\.Throwable
+  - java\.lang\.Void
+  - java\.util\..*
+  - org\.codehaus\.groovy\.runtime\.DefaultGroovyMethods
+  - org\.codehaus\.groovy\.runtime\.StringGroovyMethods
+  - org\.apache\.tinkerpop\.gremlin\.structure\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.bulkloading\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.clustering\.peerpressure\.*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.ranking\.pagerank\.*
+  - org\.apache\.tinkerpop\.gremlin\.process\.computer\.traversal\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\.dsl\.graph\..*
+  - org\.apache\.tinkerpop\.gremlin\.process\.traversal\.engine\..*
+  - org\.apache\.tinkerpop\.gremlin\.server\.util\.LifeCycleHook
+staticVariableTypes:
+  graph: org.apache.tinkerpop.gremlin.structure.Graph
+  g: org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/AbstractSandboxExtension.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/AbstractSandboxExtension.groovy
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.customizer
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.transform.stc.GroovyTypeCheckingExtensionSupport
+
+/**
+ * A base class for building sandboxes for the {@code ScriptEngine}. Uses a "white list" method to validate what
+ * variables and methods can be used in scripts.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+abstract class AbstractSandboxExtension extends GroovyTypeCheckingExtensionSupport.TypeCheckingDSL {
+
+    /**
+     * Return a list of methods that are acceptable for the {@code ScriptEngine} to execute.  The methods in the
+     * list should be defined in a regex format for pattern matching.
+     */
+    abstract List<String> getMethodWhiteList()
+
+    abstract Map<String,Class<?>> getStaticVariableTypes()
+
+    boolean allowAutoTypeOfUnknown() {
+        return true
+    }
+
+    @Override
+    Object run() {
+        def staticVariableTyping = getStaticVariableTypes()
+        def methodWhiteList = getMethodWhiteList()
+        def boolean autoTypeUnknown = allowAutoTypeOfUnknown()
+
+        unresolvedVariable { var ->
+            if (staticVariableTyping.containsKey(var.name)) {
+                storeType(var, classNodeFor(staticVariableTyping[var.name]))
+                handled = true
+                return
+            }
+
+            final Map<String,ClassNode> varTypes = (Map<String,ClassNode>) GremlinGroovyScriptEngine.COMPILE_OPTIONS.get()
+                    .get(GremlinGroovyScriptEngine.COMPILE_OPTIONS_VAR_TYPES)
+
+            // use the types of the bound variables where they match up
+            if (varTypes.containsKey(var.name))  {
+                storeType(var, varTypes.get(var.name))
+                handled = true
+                return
+            }
+
+            if (autoTypeUnknown) {
+                // everything else just gets bound to Object
+                storeType(var, ClassHelper.OBJECT_TYPE)
+                handled = true
+            }
+        }
+
+        // evaluate methods to be sure they are on the whitelist
+        onMethodSelection { expr, MethodNode methodNode ->
+            def descriptor = SandboxHelper.toMethodDescriptor(methodNode)
+            if (!methodWhiteList.any { descriptor =~ it })
+                addStaticTypeError("Not authorized to call this method: $descriptor", expr)
+        }
+
+        // handles calls to properties to be sure they are on the whitelist
+        afterVisitMethod { methodNode ->
+            def visitor = new PropertyExpressionEvaluator(context.source, methodWhiteList, this)
+            visitor.visitMethod(methodNode)
+        }
+    }
+}

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/FileSandboxExtension.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/FileSandboxExtension.groovy
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.customizer
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.yaml.snakeyaml.TypeDescription
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+
+/**
+ * A sandbox implementation that uses an external file to control the settings of the sandbox. The file is yaml based
+ * and looks like:
+ *
+ * <pre>
+ * {@code
+ * autoTypeUnknown: true
+ * methodWhiteList:
+ *   - java\.util\..*
+ *   - org\.codehaus\.groovy\.runtime\.DefaultGroovyMethods
+ * staticVariableTypes:
+ *   graph: org.apache.tinkerpop.structure.Graph
+ * }
+ * </pre>
+ *
+ * The file is assumed to be at the root of execution and should be called {@code sandbox.yaml}.  Its location can be
+ * overriden by a system property called {@code gremlinServerSandbox}.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+class FileSandboxExtension extends AbstractSandboxExtension {
+    public static final String GREMLIN_SERVER_SANDBOX = "gremlinServerSandbox"
+
+    private static final Logger logger = LoggerFactory.getLogger(FileSandboxExtension.class)
+
+    private boolean autoTypeUnknown
+    private List<String> methodWhiteList
+    private Map<String,Class<?>> staticVariableTypes
+
+    public FileSandboxExtension() {
+        def file = new File(System.getProperty(GREMLIN_SERVER_SANDBOX, "sandbox.yaml"))
+
+        if (!file.exists())
+            throw new RuntimeException("FileSandboxExtension could not find its configuration file at $file")
+
+        final Settings settings = Settings.read(file)
+
+        autoTypeUnknown = settings.autoTypeUnknown
+        methodWhiteList = settings.methodWhiteList
+        staticVariableTypes = settings.staticVariableTypes.collectEntries { kv ->
+            try {
+                return [(kv.key): Class.forName(kv.value)]
+            } catch (Exception ex) {
+                logger.error("Could not convert ${kv.value} to a Class for variable ${kv.key}", ex)
+                throw ex
+            }
+        }
+    }
+
+    @Override
+    List<String> getMethodWhiteList() {
+        return methodWhiteList
+    }
+
+    @Override
+    Map<String, Class<?>> getStaticVariableTypes() {
+        return staticVariableTypes
+    }
+
+    @Override
+    boolean allowAutoTypeOfUnknown() {
+        return autoTypeUnknown
+    }
+
+    static class Settings {
+        public boolean autoTypeUnknown
+        public List<String> methodWhiteList
+        public Map<String,String> staticVariableTypes
+
+        public static Settings read(final File file) throws Exception {
+            final Constructor constructor = new Constructor(Settings.class)
+            final TypeDescription settingsDescription = new TypeDescription(Settings.class)
+            settingsDescription.putListPropertyType("methodWhiteList", String.class)
+            settingsDescription.putMapPropertyType("staticVariableTypes", String.class, String.class)
+            constructor.addTypeDescription(settingsDescription)
+
+            final Yaml yaml = new Yaml(constructor)
+            return yaml.loadAs(new FileInputStream(file), Settings.class)
+        }
+    }
+}

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/PropertyExpressionEvaluator.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/PropertyExpressionEvaluator.groovy
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.customizer
+
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.PropertyExpression
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.transform.sc.StaticCompilationMetadataKeys
+import org.codehaus.groovy.transform.stc.GroovyTypeCheckingExtensionSupport
+import org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport
+
+/**
+ * Evaluates methods selected by groovy property magic (i.e. {@code Person.name} -> {@code Person.getName()}).
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+class PropertyExpressionEvaluator extends ClassCodeVisitorSupport {
+    private final SourceUnit unit
+    private final List<String> methodWhiteList
+    private final GroovyTypeCheckingExtensionSupport.TypeCheckingDSL dsl
+
+    public PropertyExpressionEvaluator(final SourceUnit unit, final List<String> whiteList,
+                                       final GroovyTypeCheckingExtensionSupport.TypeCheckingDSL dsl) {
+        this.unit = unit
+        this.methodWhiteList = whiteList
+        this.dsl = dsl
+    }
+
+    @Override
+    protected SourceUnit getSourceUnit() {
+        unit
+    }
+
+    @Override
+    void visitPropertyExpression(final PropertyExpression expression) {
+        super.visitPropertyExpression(expression)
+
+        ClassNode owner = expression.objectExpression.getNodeMetaData(StaticCompilationMetadataKeys.PROPERTY_OWNER)
+        if (owner) {
+            if (expression.spreadSafe && StaticTypeCheckingSupport.implementsInterfaceOrIsSubclassOf(owner, classNodeFor(Collection)))
+                owner = typeCheckingVisitor.inferComponentType(owner, ClassHelper.int_TYPE)
+
+            def descriptor = "${SandboxHelper.prettyPrint(owner)}#${expression.propertyAsString}"
+            if (!methodWhiteList.any { descriptor =~ it })
+                dsl.addStaticTypeError("Not authorized to call this method: $descriptor", expression)
+        }
+    }
+}

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/SandboxExtension.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/SandboxExtension.groovy
@@ -45,7 +45,10 @@ import java.util.function.BiPredicate
  * sandbox extension a bit easier than starting from a base groovy type checking extension.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
+ * @deprecated As of release 3.1.1-incubating, replaced by {@link AbstractSandboxExtension}
+ * @see <a href="https://issues.apache.org/jira/browse/TINKERPOP-891">TINKERPOP-891</a>
  */
+@Deprecated
 class SandboxExtension extends GroovyTypeCheckingExtensionSupport.TypeCheckingDSL {
 
     /**

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/SandboxHelper.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/SandboxHelper.groovy
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.customizer
+
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.ast.Parameter
+import org.codehaus.groovy.transform.stc.ExtensionMethodNode
+
+/**
+ * Re-usable utility methods that might be useful in building custom sandboxes.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+class SandboxHelper {
+    /**
+     * Helper method for those extending the sandbox.
+     */
+    static String prettyPrint(final ClassNode node) {
+        node.isArray() ? "${prettyPrint(node.componentType)}[]" : node.toString(false)
+    }
+
+    /**
+     * Helper method for those extending the sandbox and useful in turning methods into regex matchable strings.
+     */
+    static String toMethodDescriptor(final MethodNode node) {
+        if (node instanceof ExtensionMethodNode)
+            return toMethodDescriptor(node.extensionMethodNode)
+
+        def sb = new StringBuilder()
+        sb.append(node.declaringClass.toString(false))
+        sb.append("#")
+        sb.append(node.name)
+        sb.append('(')
+        sb.append(node.parameters.collect { Parameter it ->
+            prettyPrint(it.originType)
+        }.join(','))
+        sb.append(')')
+        sb
+    }
+}

--- a/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/TinkerPopSandboxExtension.groovy
+++ b/gremlin-groovy/src/main/groovy/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/TinkerPopSandboxExtension.groovy
@@ -18,30 +18,38 @@
  */
 package org.apache.tinkerpop.gremlin.groovy.jsr223.customizer
 
-import org.codehaus.groovy.ast.MethodNode
-
-import java.util.function.BiPredicate
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
+import org.apache.tinkerpop.gremlin.structure.Graph
 
 /**
+ * This is an example class showing how one might use the {@link AbstractSandboxExtension}.  It uses a static method
+ * white list and variable type mappings. It also prevents assigning non-typed variables the type of {@code Object}.
+ * It is doubtful that this class would be useful for production applications and it simply serves as an example
+ * on which users can extend and learn from.
+ *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-class TinkerPopSandboxExtension extends SandboxExtension {
+class TinkerPopSandboxExtension extends AbstractSandboxExtension {
 
-    TinkerPopSandboxExtension() {
-        gIsAlwaysGraphTraversalSource = false
-        graphIsAlwaysGraphInstance = false
+    private static final List<String> methodWhiteList = ["java\\.util\\..*",
+                                                         "org\\.codehaus\\.groovy\\.runtime\\.DefaultGroovyMethods",
+                                                         "org\\.apache\\.tinkerpop\\.gremlin\\.structure\\..*",
+                                                         "org\\.apache\\.tinkerpop\\.gremlin\\.process\\..*",
+                                                         "org\\.apache\\.tinkerpop\\.gremlin\\.process\\.traversal\\.dsl\\.graph\\..*"]
+    private static final Map<String, Class<?>> staticVariableTypes = [graph:Graph, g: GraphTraversalSource]
 
-        def gremlinRoot = "org\\.apache\\.tinkerpop\\.gremlin"
-        def gremlinRootStructure = "$gremlinRoot\\.structure"
-        def gremlinRootProcess = "$gremlinRoot\\.process"
-        def methodWhiteList = ["java\\.util\\..*",
-                               "org\\.codehaus\\.groovy\\.runtime\\.DefaultGroovyMethods",
-                               "$gremlinRootStructure\\..*",
-                               "$gremlinRootProcess\\..*",
-                               "$gremlinRootProcess\\.traversal\\.dsl\\.graph\\..*"]
+    @Override
+    List<String> getMethodWhiteList() {
+        return methodWhiteList
+    }
 
-        methodFilter = (BiPredicate<String, MethodNode>) { descriptor, method ->
-            methodWhiteList.any { descriptor =~ it }
-        }
+    @Override
+    Map<String, Class<?>> getStaticVariableTypes() {
+        return staticVariableTypes
+    }
+
+    @Override
+    boolean allowAutoTypeOfUnknown() {
+        return false
     }
 }

--- a/gremlin-server/scripts/empty-sample-secure.groovy
+++ b/gremlin-server/scripts/empty-sample-secure.groovy
@@ -34,7 +34,9 @@ def addItUp(int x, int y) { x + y }
 def globals = [:]
 
 // defines a sample LifeCycleHook that prints some output to the Gremlin Server console.
-// note that the name of the key in the "global" map is unimportant.
+// note that the name of the key in the "global" map is unimportant. As this script,
+// runs as part of a sandbox configuration, type-checking is enabled and thus the
+// LifeCycleHook type needs to be defined for the "ctx" variable.
 globals << [hook : [
   onStartUp: { LifeCycleHook.Context ctx ->
     ctx.logger.info("Executed once at startup of Gremlin Server.")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-891

Deprecated the `SandboxExtension` and replaced it with the `AbstractSandboxExtension`.  Took existing implementations and had them extend from the new `AbstractSandboxExtension`.  Added a new "useful" implementation called `FileSandboxExtension` which gets its white list configuration from a file.  Updated appropriate docs and wrote a number of tests for the new `FileSandboxExtension`.

Both unit and integration tests pass.  Also tested manually by configuring Gremlin Server to use the different sandboxes.  

VOTE: +1