### PR TITLE
TINKERPOP-1026 BVLP should store vertex IDs as String

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added another `BulkLoader` implementation (`OneTimeBulkLoader`) that doesn't store temporary properties in the target graph.
 * Fixed a `SparkGraphComputer` sorting bug in MapReduce that occurred when there was more than one partition.
 * Added `strictTransactionManagement` to the Gremlin Server settings to indicate that the `aliases` parameter must be passed on requests and that transaction management will be scoped to the graphs provided in that argument.
 * Fixed a `NullPointerException` bug in `PeerPressureVertexProgram` that occurred when an adjacency traversal was not provided.

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -338,7 +338,7 @@ writeGraphConf.setProperty("gremlin.tinkergraph.graphFormat", "gryo")
 writeGraphConf.setProperty("gremlin.tinkergraph.graphLocation", "/tmp/tinkergraph.kryo")
 modern = TinkerFactory.createModern()
 blvp = BulkLoaderVertexProgram.build().
-           keepOriginalIds(false).
+           bulkLoader(OneTimeBulkLoader).
            writeGraph(writeGraphConf).create(modern)
 modern.compute().workers(1).program(blvp).submit().get()
 graph = GraphFactory.open(writeGraphConf)

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -366,7 +366,7 @@ It's recommended to tune this property for the target graph and not use the defa
 
 NOTE: `BulkLoaderVertexProgram` uses the `IncrementalBulkLoader` by default. The other option is the `OneTimeBulkLoader`,
 which doesn't store any temporary IDs in the `writeGraph` and thus should only be used for initial bulk loads. Both
-implementations should cover the mahority of use-cases, but have a limitation though: They don't support multi-valued
+implementations should cover the majority of use-cases, but have a limitation though: They don't support multi-valued
 properties. `OneTimeBulkLoader` and `IncrementalBulkLoader` will handle every property as a single-valued property. A
 custom `BulkLoader` implementation has to be used if the default behavior is not sufficient.
 

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -364,10 +364,11 @@ It's recommended to tune this property for the target graph and not use the defa
 |`writeGraph(String)` | Sets the path to a `GraphFactory` compatible configuration file for the target graph. | _none_
 |========================================
 
-NOTE: `BulkLoaderVertexProgram` comes with a default `BulkLoader` implementation, namely `IncrementalBulkLoader`. It
-will work for the most use-cases, but has one limitation though: It doesn't support multi-valued properties.
-`IncrementalBulkLoader` will handle every property as a single-valued property. A custom `BulkLoader` implementation
-has to be used if the default behavior is not sufficient.
+NOTE: `BulkLoaderVertexProgram` uses the `IncrementalBulkLoader` by default. The other option is the `OneTimeBulkLoader`,
+which doesn't store any temporary IDs in the `writeGraph` and thus should only be used for initial bulk loads. Both
+implementations should cover the mahority of use-cases, but have a limitation though: They don't support multi-valued
+properties. `OneTimeBulkLoader` and `IncrementalBulkLoader` will handle every property as a single-valued property. A
+custom `BulkLoader` implementation has to be used if the default behavior is not sufficient.
 
 NOTE: A custom `BulkLoader` implementation for incremental loading should use `GraphTraversal` methods to create/update
 elements (e.g. `g.addV()` instead of `graph.addVertex()`). This way the `BulkLoaderVertexProgram` is able to efficiently

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoader.java
@@ -117,7 +117,7 @@ public interface BulkLoader {
      * @return The vertex with the given ID.
      */
     public default Vertex getVertexById(final Object id, final Graph graph, final GraphTraversalSource g) {
-        return graph.vertices(id).next();
+        return g.V().hasId(id).next();
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoader.java
@@ -102,11 +102,7 @@ public interface BulkLoader {
      * @param g      A standard traversal source for the given graph.
      * @return The matched vertex.
      */
-    public default Vertex getVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
-        return useUserSuppliedIds()
-                ? getVertexById(vertex.id(), graph, g)
-                : g.V().has(getVertexIdProperty(), vertex.id()).next();
-    }
+    public Vertex getVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g);
 
     /**
      * Gets a vertex by its ID from the given graph.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -152,7 +152,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
             ConfigurationUtils.copy(config, configuration);
         }
         intermediateBatchSize = configuration.getLong(INTERMEDIATE_BATCH_SIZE_CFG_KEY, 0L);
-        elementComputeKeys.add(configuration.getString(BULK_LOADER_VERTEX_ID_CFG_KEY, DEFAULT_BULK_LOADER_VERTEX_ID));
+        elementComputeKeys.add(DEFAULT_BULK_LOADER_VERTEX_ID);
         bulkLoader = createBulkLoader();
     }
 
@@ -217,7 +217,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
             this.commit(false);
             if (!bulkLoader.useUserSuppliedIds()) {
                 // create an id pair and send it to all the vertex's incoming adjacent vertices
-                sourceVertex.property(bulkLoader.getVertexIdProperty(), targetVertex.id().toString());
+                sourceVertex.property(DEFAULT_BULK_LOADER_VERTEX_ID, targetVertex.id());
                 messenger.sendMessage(messageScope, Pair.with(sourceVertex.id(), targetVertex.id()));
             }
         } else if (memory.getIteration() == 1) {
@@ -242,7 +242,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
                     idPairs.put(idPair.getValue(0), idPair.getValue(1));
                 }
                 // get the vertex with given the dummy id property
-                final Object outVId = sourceVertex.value(bulkLoader.getVertexIdProperty());
+                final Object outVId = sourceVertex.value(DEFAULT_BULK_LOADER_VERTEX_ID);
                 final Vertex outV = bulkLoader.getVertexById(outVId, graph, g);
                 // for all the incoming edges of the vertex, get the incoming adjacent vertex and write the edge and its properties
                 sourceVertex.edges(Direction.OUT).forEachRemaining(edge -> {
@@ -253,7 +253,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
                 });
             }
         } else if (memory.getIteration() == 2) {
-            final Object vertexId = sourceVertex.value(bulkLoader.getVertexIdProperty());
+            final Object vertexId = sourceVertex.value(DEFAULT_BULK_LOADER_VERTEX_ID);
             bulkLoader.getVertexById(vertexId, graph, g)
                     .property(bulkLoader.getVertexIdProperty()).remove();
             this.commit(false);
@@ -264,7 +264,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
     public boolean terminate(final Memory memory) {
         switch (memory.getIteration()) {
             case 1:
-                return bulkLoader.keepOriginalIds();
+                return bulkLoader.keepOriginalIds() || bulkLoader.getVertexIdProperty() == null;
             case 2:
                 return true;
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -217,7 +217,7 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
             this.commit(false);
             if (!bulkLoader.useUserSuppliedIds()) {
                 // create an id pair and send it to all the vertex's incoming adjacent vertices
-                sourceVertex.property(bulkLoader.getVertexIdProperty(), targetVertex.id());
+                sourceVertex.property(bulkLoader.getVertexIdProperty(), targetVertex.id().toString());
                 messenger.sendMessage(messageScope, Pair.with(sourceVertex.id(), targetVertex.id()));
             }
         } else if (memory.getIteration() == 1) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/IncrementalBulkLoader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/IncrementalBulkLoader.java
@@ -46,15 +46,13 @@ public class IncrementalBulkLoader implements BulkLoader {
     @Override
     public Vertex getOrCreateVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
         final Iterator<Vertex> iterator = useUserSuppliedIds()
-                ? graph.vertices(vertex.id())
+                ? g.V().hasId(vertex.id())
                 : g.V().has(vertex.label(), getVertexIdProperty(), vertex.id());
         return iterator.hasNext()
                 ? iterator.next()
                 : useUserSuppliedIds()
                 ? g.addV(vertex.label()).property(T.id, vertex.id()).next()
                 : g.addV(vertex.label()).property(getVertexIdProperty(), vertex.id()).next();
-        //? graph.addVertex(T.id, vertex.id(), T.label, vertex.label())
-        //: graph.addVertex(T.label, vertex.label(), getVertexIdProperty(), vertex.id());
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/OneTimeBulkLoader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/OneTimeBulkLoader.java
@@ -19,20 +19,21 @@
 package org.apache.tinkerpop.gremlin.process.computer.bulkloading;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
-import java.util.Iterator;
-
 /**
+ * {@link org.apache.tinkerpop.gremlin.process.computer.bulkloading.OneTimeBulkLoader} is a
+ * {@link org.apache.tinkerpop.gremlin.process.computer.bulkloading.BulkLoader} implementation that should be used
+ * for initial bulk loads. In contrast to {@link org.apache.tinkerpop.gremlin.process.computer.bulkloading.IncrementalBulkLoader}
+ * it doesn't store temporary identifiers in the write graph nor does it attempt to find existing elements, instead it
+ * only clones each element from the source graph.
+ *
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
 public class OneTimeBulkLoader implements BulkLoader {
@@ -40,7 +41,7 @@ public class OneTimeBulkLoader implements BulkLoader {
     private boolean userSuppliedIds = false;
 
     /**
-     * {@inheritDoc}
+     * Creates a clone of the given vertex in the given graph.
      */
     @Override
     public Vertex getOrCreateVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
@@ -49,7 +50,7 @@ public class OneTimeBulkLoader implements BulkLoader {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a clone of the given edge between the given in- and out-vertices.
      */
     @Override
     public Edge getOrCreateEdge(final Edge edge, final Vertex outVertex, final Vertex inVertex, final Graph graph, final GraphTraversalSource g) {
@@ -57,7 +58,7 @@ public class OneTimeBulkLoader implements BulkLoader {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a clone of the given property for the given vertex.
      */
     @Override
     public VertexProperty getOrCreateVertexProperty(final VertexProperty<?> property, final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
@@ -81,7 +82,7 @@ public class OneTimeBulkLoader implements BulkLoader {
     }
 
     /**
-     * {@inheritDoc}
+     * Always returns false.
      */
     @Override
     public boolean keepOriginalIds() {
@@ -89,7 +90,7 @@ public class OneTimeBulkLoader implements BulkLoader {
     }
 
     /**
-     * {@inheritDoc}
+     * Always returns null.
      */
     @Override
     public String getVertexIdProperty() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/OneTimeBulkLoader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/OneTimeBulkLoader.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.computer.bulkloading;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -34,10 +35,8 @@ import java.util.Iterator;
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public class IncrementalBulkLoader implements BulkLoader {
+public class OneTimeBulkLoader implements BulkLoader {
 
-    private String bulkLoaderVertexId = BulkLoaderVertexProgram.DEFAULT_BULK_LOADER_VERTEX_ID;
-    private boolean keepOriginalIds = true;
     private boolean userSuppliedIds = false;
 
     /**
@@ -45,14 +44,8 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public Vertex getOrCreateVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
-        final Iterator<Vertex> iterator = useUserSuppliedIds()
-                ? g.V().hasId(vertex.id())
-                : g.V().has(vertex.label(), getVertexIdProperty(), vertex.id().toString());
-        return iterator.hasNext()
-                ? iterator.next()
-                : useUserSuppliedIds()
-                ? g.addV(vertex.label()).property(T.id, vertex.id()).next()
-                : g.addV(vertex.label()).property(getVertexIdProperty(), vertex.id().toString()).next();
+        final GraphTraversal<Vertex, Vertex> t = g.addV(vertex.label());
+        return (useUserSuppliedIds() ? t.property(T.id, vertex.id()) : t).next();
     }
 
     /**
@@ -60,20 +53,7 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public Edge getOrCreateEdge(final Edge edge, final Vertex outVertex, final Vertex inVertex, final Graph graph, final GraphTraversalSource g) {
-        final Edge e;
-        final Traversal<Vertex, Edge> t = g.V(outVertex).outE(edge.label()).filter(__.inV().is(inVertex));
-        if (t.hasNext()) {
-            e = t.next();
-            edge.properties().forEachRemaining(property -> {
-                final Property<?> existing = e.property(property.key());
-                if (!existing.isPresent() || !existing.value().equals(property.value())) {
-                    e.property(property.key(), property.value());
-                }
-            });
-        } else {
-            e = createEdge(edge, outVertex, inVertex, graph, g);
-        }
-        return e;
+        return createEdge(edge, outVertex, inVertex, graph, g);
     }
 
     /**
@@ -81,23 +61,7 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public VertexProperty getOrCreateVertexProperty(final VertexProperty<?> property, final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
-        final VertexProperty<?> vp;
-        final VertexProperty<?> existing = vertex.property(property.key());
-        if (!existing.isPresent()) {
-            return createVertexProperty(property, vertex, graph, g);
-        }
-        if (!existing.value().equals(property.value())) {
-            vp = vertex.property(property.key(), property.value());
-        } else {
-            vp = existing;
-        }
-        property.properties().forEachRemaining(metaProperty -> {
-            final Property<?> existing2 = vp.property(metaProperty.key());
-            if (!existing2.isPresent() || !existing2.value().equals(metaProperty.value())) {
-                vp.property(metaProperty.key(), metaProperty.value());
-            }
-        });
-        return vp;
+        return createVertexProperty(property, vertex, graph, g);
     }
 
     /**
@@ -105,9 +69,7 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public Vertex getVertex(final Vertex vertex, final Graph graph, final GraphTraversalSource g) {
-        return useUserSuppliedIds()
-                ? getVertexById(vertex.id(), graph, g)
-                : g.V().has(vertex.label(), bulkLoaderVertexId, vertex.id()).next();
+        return getVertexById(vertex.id(), graph, g);
     }
 
     /**
@@ -123,7 +85,7 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public boolean keepOriginalIds() {
-        return keepOriginalIds;
+        return false;
     }
 
     /**
@@ -131,7 +93,7 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public String getVertexIdProperty() {
-        return bulkLoaderVertexId;
+        return null;
     }
 
     /**
@@ -139,14 +101,8 @@ public class IncrementalBulkLoader implements BulkLoader {
      */
     @Override
     public void configure(final Configuration configuration) {
-        if (configuration.containsKey(BulkLoaderVertexProgram.BULK_LOADER_VERTEX_ID_CFG_KEY)) {
-            bulkLoaderVertexId = configuration.getString(BulkLoaderVertexProgram.BULK_LOADER_VERTEX_ID_CFG_KEY);
-        }
         if (configuration.containsKey(BulkLoaderVertexProgram.USER_SUPPLIED_IDS_CFG_KEY)) {
             userSuppliedIds = configuration.getBoolean(BulkLoaderVertexProgram.USER_SUPPLIED_IDS_CFG_KEY);
-        }
-        if (configuration.containsKey(BulkLoaderVertexProgram.KEEP_ORIGINAL_IDS_CFG_KEY)) {
-            keepOriginalIds = configuration.getBoolean(BulkLoaderVertexProgram.KEEP_ORIGINAL_IDS_CFG_KEY);
         }
     }
 }

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -104,7 +104,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
      * as needed to enforce tests upon implementations.
      */
     private static final Class<?>[] allTests = new Class<?>[]{
-
+/*
             //branch
             GroovyBranchTest.Traversals.class,
             GroovyChooseTest.Traversals.class,
@@ -170,7 +170,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
 
             // algorithms
             PageRankVertexProgramTest.class,
-            PeerPressureVertexProgramTest.class,
+            PeerPressureVertexProgramTest.class,*/
             BulkLoaderVertexProgramTest.class,
     };
 

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.groovy.loaders.SugarLoader;
 import org.apache.tinkerpop.gremlin.groovy.util.SugarTestHelper;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.bulkloading.BulkLoaderVertexProgramTest;
-import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.PeerPressureVertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.PeerPressureVertexProgramTest;
 import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.GroovyBranchTest;
@@ -104,7 +103,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
      * as needed to enforce tests upon implementations.
      */
     private static final Class<?>[] allTests = new Class<?>[]{
-/*
+
             //branch
             GroovyBranchTest.Traversals.class,
             GroovyChooseTest.Traversals.class,
@@ -170,7 +169,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
 
             // algorithms
             PageRankVertexProgramTest.class,
-            PeerPressureVertexProgramTest.class,*/
+            PeerPressureVertexProgramTest.class,
             BulkLoaderVertexProgramTest.class,
     };
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1026

BLVP (in particular `IncrementalBulkLoader`) now stores the `toString()` version of vertex IDs in the temporary `bulkLoader.vertex.id` property. I also added another `BulkLoader` implementation (`OneTimeBulkLoader`), to a) be able to add more test cases and b) verify that the `toString()` update doesn't interfere with something else.

Successfully ran `mvn clean install` and integration tests.

VOTE: +1