### PR TITLE
TINKERPOP-983 - Provide a way to track open Graph instances in tests

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -133,8 +133,14 @@ public abstract class AbstractGremlinTest {
     public void tearDown() throws Exception {
         if (null != graphProvider) {
             graphProvider.clear(graph, config);
+
+            // All GraphProvider objects should be an instance of ManagedGraphProvider, as this is handled by GraphManager
+            // which wraps injected GraphProviders with a ManagedGraphProvider instance. If this doesn't happen, there
+            // is no way to trace open graphs.
             if(graphProvider instanceof GraphManager.ManagedGraphProvider)
                 ((GraphManager.ManagedGraphProvider)graphProvider).tryCloseGraphs();
+            else
+                logger.warn("The {} is not of type ManagedGraphProvider and therefore graph instances may leak between test cases.", graphProvider.getClass());
 
             g = null;
             config = null;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -133,6 +133,9 @@ public abstract class AbstractGremlinTest {
     public void tearDown() throws Exception {
         if (null != graphProvider) {
             graphProvider.clear(graph, config);
+            if(graphProvider instanceof GraphManager.ManagedGraphProvider)
+                ((GraphManager.ManagedGraphProvider)graphProvider).tryCloseGraphs();
+
             g = null;
             config = null;
             graphProvider = null;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
@@ -86,6 +86,11 @@ public class GraphManager {
         }
 
         @Override
+        public String getWorkingDirectory() {
+            return innerGraphProvider.getWorkingDirectory();
+        }
+
+        @Override
         public GraphTraversalSource traversal(final Graph graph) {
             return innerGraphProvider.traversal(graph);
         }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
@@ -18,7 +18,17 @@
  */
 package org.apache.tinkerpop.gremlin;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Holds objects specified by the test suites supplying them in a static manner to the test cases.
@@ -36,7 +46,7 @@ public class GraphManager {
     }
 
     public static GraphProvider getGraphProvider() {
-        return graphProvider;
+        return new ManagedGraphProvider(graphProvider);
     }
 
     public static TraversalEngine.Type setTraversalEngineType(final TraversalEngine.Type traversalEngine) {
@@ -48,4 +58,94 @@ public class GraphManager {
     public static TraversalEngine.Type getTraversalEngineType() {
         return traversalEngineType;
     }
+
+    public static class ManagedGraphProvider implements GraphProvider {
+        private final GraphProvider innerGraphProvider;
+        private final List<Graph> openGraphs = new ArrayList<>();
+
+        public ManagedGraphProvider(final GraphProvider innerGraphProvider){
+            this.innerGraphProvider = innerGraphProvider;
+        }
+
+        public void tryCloseGraphs(){
+            for(Graph graph : openGraphs) {
+                try {
+                    graph.close();
+                }catch (Exception e){
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        public GraphTraversalSource traversal(final Graph graph) {
+            return innerGraphProvider.traversal(graph);
+        }
+
+        @Override
+        public GraphTraversalSource traversal(final Graph graph, final TraversalStrategy... strategies) {
+            return innerGraphProvider.traversal(graph, strategies);
+        }
+
+        @Override
+        public Graph standardTestGraph(final Class<?> test, final String testMethodName, final LoadGraphWith.GraphData loadGraphWith) {
+            final Graph graph = innerGraphProvider.standardTestGraph(test, testMethodName, loadGraphWith);
+            openGraphs.add(graph);
+            return graph;
+        }
+
+        @Override
+        public Graph openTestGraph(final Configuration config) {
+            final Graph graph = innerGraphProvider.openTestGraph(config);
+            openGraphs.add(graph);
+            return graph;
+        }
+
+        @Override
+        public Configuration standardGraphConfiguration(final Class<?> test, final String testMethodName, final LoadGraphWith.GraphData loadGraphWith) {
+            return innerGraphProvider.standardGraphConfiguration(test, testMethodName, loadGraphWith);
+        }
+
+        @Override
+        public void clear(final Configuration configuration) throws Exception {
+            innerGraphProvider.clear(configuration);
+        }
+
+        @Override
+        public void clear(final Graph graph, final Configuration configuration) throws Exception {
+            innerGraphProvider.clear(graph, configuration);
+        }
+
+        @Override
+        public Object convertId(final Object id, final Class<? extends Element> c) {
+            return innerGraphProvider.convertId(id, c);
+        }
+
+        @Override
+        public String convertLabel(final String label) {
+            return innerGraphProvider.convertLabel(label);
+        }
+
+        @Override
+        public Configuration newGraphConfiguration(final String graphName, final Class<?> test, final String testMethodName,
+                                                   final Map<String, Object> configurationOverrides, final LoadGraphWith.GraphData loadGraphWith) {
+            return innerGraphProvider.newGraphConfiguration(graphName, test, testMethodName, configurationOverrides, loadGraphWith);
+        }
+
+        @Override
+        public Configuration newGraphConfiguration(final String graphName, final Class<?> test, final String testMethodName,final LoadGraphWith.GraphData loadGraphWith) {
+            return innerGraphProvider.newGraphConfiguration(graphName, test, testMethodName, loadGraphWith);
+        }
+
+        @Override
+        public void loadGraphData(final Graph graph, final LoadGraphWith loadGraphWith, final Class testClass, final String testName) {
+            innerGraphProvider.loadGraphData(graph, loadGraphWith, testClass, testName);
+        }
+
+        @Override
+        public Set<Class> getImplementations() {
+            return innerGraphProvider.getImplementations();
+        }
+    }
+
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphManager.java
@@ -45,6 +45,9 @@ public class GraphManager {
         return old;
     }
 
+    /**
+     * Gets the {@link GraphProvider} from the current test suite and wraps it in a {@link ManagedGraphProvider}.
+     */
     public static GraphProvider getGraphProvider() {
         return new ManagedGraphProvider(graphProvider);
     }
@@ -59,6 +62,11 @@ public class GraphManager {
         return traversalEngineType;
     }
 
+    /**
+     * This class provides a way to intercepts calls to {@link Graph} implementation's {@link GraphProvider} instances.
+     * When {@link #openTestGraph(Configuration)} is called the created object is stored in a list and when tests are
+     * complete the {@link #tryCloseGraphs()} is called. When this is called, an attempt is made to close all open graphs.
+     */
     public static class ManagedGraphProvider implements GraphProvider {
         private final GraphProvider innerGraphProvider;
         private final List<Graph> openGraphs = new ArrayList<>();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -874,7 +874,7 @@ public class GraphTest extends AbstractGremlinTest {
                 final Vertex a = vertices.get(random.nextInt(vertices.size()));
                 final Vertex b = vertices.get(random.nextInt(vertices.size()));
                 if (a != b) {
-                    edges.add(a.addEdge(GraphManager.getGraphProvider().convertLabel("a" + UUID.randomUUID()), b));
+                    edges.add(a.addEdge(graphProvider.convertLabel("a" + UUID.randomUUID()), b));
                     created = true;
                 }
             }
@@ -910,7 +910,7 @@ public class GraphTest extends AbstractGremlinTest {
         for (int i = 0; i < vertexCount; i = i + 2) {
             final Vertex a = vertices.get(i);
             final Vertex b = vertices.get(i + 1);
-            edges.add(a.addEdge(GraphManager.getGraphProvider().convertLabel("a" + UUID.randomUUID()), b));
+            edges.add(a.addEdge(graphProvider.convertLabel("a" + UUID.randomUUID()), b));
         }
 
         tryCommit(graph, assertVertexEdgeCounts(vertexCount, vertexCount / 2));
@@ -975,8 +975,6 @@ public class GraphTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     public void shouldEvaluateConnectivityPatterns() {
-        final GraphProvider graphProvider = GraphManager.getGraphProvider();
-
         final Vertex a;
         final Vertex b;
         final Vertex c;
@@ -1066,10 +1064,7 @@ public class GraphTest extends AbstractGremlinTest {
     @Test
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
-    public void shouldTraverseInOutFromVertexWithSingleEdgeLabelFilter() {
-        final GraphProvider graphProvider = GraphManager.getGraphProvider();
-
-        final Vertex a = graph.addVertex();
+    public void shouldTraverseInOutFromVertexWithSingleEdgeLabelFilter() {final Vertex a = graph.addVertex();
         final Vertex b = graph.addVertex();
         final Vertex c = graph.addVertex();
 
@@ -1117,7 +1112,6 @@ public class GraphTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     public void shouldTraverseInOutFromVertexWithMultipleEdgeLabelFilter() {
-        final GraphProvider graphProvider = GraphManager.getGraphProvider();
         final Vertex a = graph.addVertex();
         final Vertex b = graph.addVertex();
         final Vertex c = graph.addVertex();
@@ -1154,8 +1148,6 @@ public class GraphTest extends AbstractGremlinTest {
     @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
     public void shouldTestTreeConnectivity() {
-        final GraphProvider graphProvider = GraphManager.getGraphProvider();
-
         int branchSize = 11;
         final Vertex start = graph.addVertex();
         for (int i = 0; i < branchSize; i++) {
@@ -1201,8 +1193,6 @@ public class GraphTest extends AbstractGremlinTest {
     @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
     @FeatureRequirement(featureClass = Graph.Features.GraphFeatures.class, feature = Graph.Features.GraphFeatures.FEATURE_PERSISTENCE)
     public void shouldPersistDataOnClose() throws Exception {
-        final GraphProvider graphProvider = GraphManager.getGraphProvider();
-
         final Vertex v = graph.addVertex();
         final Vertex u = graph.addVertex();
         if (graph.features().vertex().properties().supportsStringValues()) {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
@@ -472,13 +472,13 @@ public class PropertyTest {
         private Edge createEdgeForPropertyFeatureTests() {
             final Vertex vertexA = graph.addVertex();
             final Vertex vertexB = graph.addVertex();
-            return vertexA.addEdge(GraphManager.getGraphProvider().convertLabel("knows"), vertexB);
+            return vertexA.addEdge(graphProvider.convertLabel("knows"), vertexB);
         }
 
         private Edge createEdgeForPropertyFeatureTests(final String k, Object v) {
             final Vertex vertexA = graph.addVertex();
             final Vertex vertexB = graph.addVertex();
-            return vertexA.addEdge(GraphManager.getGraphProvider().convertLabel("knows"), vertexB, k, v);
+            return vertexA.addEdge(graphProvider.convertLabel("knows"), vertexB, k, v);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexTest.java
@@ -259,7 +259,7 @@ public class VertexTest {
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_USER_SUPPLIED_IDS)
         public void shouldHaveExceptionConsistencyWhenAssigningSameIdOnEdge() {
             final Vertex v = graph.addVertex();
-            final Object o = GraphManager.getGraphProvider().convertId("1", Edge.class);
+            final Object o = graphProvider.convertId("1", Edge.class);
             v.addEdge("self", v, T.id, o);
 
             try {
@@ -359,8 +359,8 @@ public class VertexTest {
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = VertexFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
         public void shouldEvaluateVerticesEquivalentWithSuppliedIdsViaTraversal() {
-            final Vertex v = graph.addVertex(T.id, GraphManager.getGraphProvider().convertId("1", Vertex.class));
-            final Vertex u = graph.vertices(GraphManager.getGraphProvider().convertId("1", Vertex.class)).next();
+            final Vertex v = graph.addVertex(T.id, graphProvider.convertId("1", Vertex.class));
+            final Vertex u = graph.vertices(graphProvider.convertId("1", Vertex.class)).next();
             assertEquals(v, u);
         }
 
@@ -368,8 +368,8 @@ public class VertexTest {
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = VertexFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
         public void shouldEvaluateVerticesEquivalentWithSuppliedIdsViaIterators() {
-            final Vertex v = graph.addVertex(T.id, GraphManager.getGraphProvider().convertId("1", Vertex.class));
-            final Vertex u = graph.vertices(GraphManager.getGraphProvider().convertId("1", Vertex.class)).next();
+            final Vertex v = graph.addVertex(T.id, graphProvider.convertId("1", Vertex.class));
+            final Vertex u = graph.vertices(graphProvider.convertId("1", Vertex.class)).next();
             assertEquals(v, u);
         }
 
@@ -392,8 +392,8 @@ public class VertexTest {
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = VertexFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
         public void shouldEvaluateEquivalentVertexHashCodeWithSuppliedIds() {
-            final Vertex v = graph.addVertex(T.id, GraphManager.getGraphProvider().convertId("1", Vertex.class));
-            final Vertex u = graph.vertices(GraphManager.getGraphProvider().convertId("1", Vertex.class)).next();
+            final Vertex v = graph.addVertex(T.id, graphProvider.convertId("1", Vertex.class));
+            final Vertex u = graph.vertices(graphProvider.convertId("1", Vertex.class)).next();
             assertEquals(v, u);
 
             final Set<Vertex> set = new HashSet<>();
@@ -401,8 +401,8 @@ public class VertexTest {
             set.add(v);
             set.add(u);
             set.add(u);
-            set.add(graph.vertices(GraphManager.getGraphProvider().convertId("1", Vertex.class)).next());
-            set.add(graph.vertices(GraphManager.getGraphProvider().convertId("1", Vertex.class)).next());
+            set.add(graph.vertices(graphProvider.convertId("1", Vertex.class)).next());
+            set.add(graph.vertices(graphProvider.convertId("1", Vertex.class)).next());
 
             assertEquals(1, set.size());
             assertEquals(v.hashCode(), u.hashCode());


### PR DESCRIPTION
Doing a test PR to see if Travis will build, there might be something wrong with my local environment. If Travis doesn't pass, I will rescind my PR.

Refactor tests to use member variables for `graphProvider`
Added Java docs

https://issues.apache.org/jira/browse/TINKERPOP-983