### PR TITLE
TINKERPOP-1055 Gremlin Console FileNotFoundException can be misleading

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Execute the `LifeCycle.beforeEval()` in the same thread that `eval()` is executed in for `GremlinExecutor`.
+* Improved error handling of Gremlin Console initialization scripts to better separate errors in initialization script I/O versus execution of the script itself.
 * Fixed a bug in `Graph.OptOut` when trying to opt-out of certain test cases with the `method` property set to "*".
 * Added another `BulkLoader` implementation (`OneTimeBulkLoader`) that doesn't store temporary properties in the target graph.
 * Fixed a `SparkGraphComputer` sorting bug in MapReduce that occurred when there was more than one partition.

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -282,19 +282,21 @@ class Console {
     }
 
     private void initializeShellWithScript(final String initScriptFile) {
-        String line = ""
         try {
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(
-                    new FileInputStream(initScriptFile), Charset.forName("UTF-8")))
-            while ((line = reader.readLine()) != null) {
-                groovy.execute(line)
+            final File file = new File(initScriptFile)
+            file.eachLine { line ->
+                try {
+                    groovy.execute(line)
+                } catch (Exception ex) {
+                    io.err.println("Bad line in Gremlin initialization file at [$line] - ${ex.message}")
+                    System.exit(1)
+                }
             }
-            reader.close()
         } catch (FileNotFoundException ignored) {
-            io.err.println(String.format("Gremlin initialization file not found at [%s].", initScriptFile))
+            io.err.println("Gremlin initialization file not found at [$initScriptFile].")
             System.exit(1)
-        } catch (IOException ignored) {
-            io.err.println(String.format("Bad line in Gremlin initialization file at [%s].", line))
+        } catch (Exception ex) {
+            io.err.println("Error starting Gremlin with initialization script at [$initScriptFile] - ${ex.message}")
             System.exit(1)
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1055

Some relatively minor refactoring required to get this working.  Tested manually only as I wasn't sure how to write tests around the console when it was calling `System.exit(1)` on error.  I first tested a "good" script:

```text
$ cat test.groovy
x=1
addItUp = {x,y -> x+y}

$ bin/gremlin.sh test.groovy

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
==>1
==>groovysh_evaluate$_run_closure1@5536379e
gremlin> addItUp(1,10)
==>11
```

Then I tested a script that wasn't present on the file system:

```text
$ bin/gremlin.sh test1.groovy

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
Gremlin initialization file not found at [test1.groovy].
```

Finally, I tested a script with an error in the script itself:

```text

$ cat test-fail.groovy
x = 1
y = x / 0

$ bin/gremlin.sh test-fail.groovy

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
==>1
Bad line in Gremlin initialization file at [y = x / 0] - Division by zero
```


VOTE: +1