### PR TITLE
TINKERPOP-938 Add a "clear SNAPSHOT jars" section to the process-docs.sh.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Added `--no-clean` option in `bin/process-docs.sh` to prevent the script from cleaning Grapes and HDFS.
+* Added `--noClean` option in `bin/process-docs.sh` to prevent the script from cleaning Grapes and HDFS.
 * Execute the `LifeCycle.beforeEval()` in the same thread that `eval()` is executed in for `GremlinExecutor`.
 * Improved error handling of Gremlin Console initialization scripts to better separate errors in initialization script I/O versus execution of the script itself.
 * Fixed a bug in `Graph.OptOut` when trying to opt-out of certain test cases with the `method` property set to "*".

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `--no-clean` option in `bin/process-docs.sh` to prevent the script from cleaning Grapes and HDFS.
 * Execute the `LifeCycle.beforeEval()` in the same thread that `eval()` is executed in for `GremlinExecutor`.
 * Improved error handling of Gremlin Console initialization scripts to better separate errors in initialization script I/O versus execution of the script itself.
 * Fixed a bug in `Graph.OptOut` when trying to opt-out of certain test cases with the `method` property set to "*".

--- a/bin/process-docs.sh
+++ b/bin/process-docs.sh
@@ -24,7 +24,7 @@ while [[ $# -gt 0 ]]
 do
   key="$1"
   case $key in
-    -n|--no-clean)
+    -n|--noClean)
       NOCLEAN=1
       ;;
     -d|--dryRun)

--- a/bin/process-docs.sh
+++ b/bin/process-docs.sh
@@ -20,7 +20,31 @@
 
 pushd "$(dirname $0)/.." > /dev/null
 
-if [ "$1" == "--dryRun" ]; then
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+  case $key in
+    -n|--no-clean)
+      NOCLEAN=1
+      ;;
+    -d|--dryRun)
+      DRYRUN=1
+      ;;
+    *)
+      # unknown option
+      ;;
+  esac
+  shift
+done
+
+if [ -z ${NOCLEAN} ]; then
+  rm -rf ~/.groovy/grapes/org.apache.tinkerpop/
+  if hash hadoop 2> /dev/null; then
+    hadoop fs -rm -r "hadoop-gremlin-*-libs" > /dev/null 2>&1
+  fi
+fi
+
+if [ ! -z ${DRYRUN} ]; then
 
   mkdir -p target/postprocess-asciidoc/tmp
   cp -R docs/{static,stylesheets} target/postprocess-asciidoc/

--- a/docs/src/dev/developer/contributing.asciidoc
+++ b/docs/src/dev/developer/contributing.asciidoc
@@ -44,8 +44,10 @@ Before issuing your pull request, please be sure of the following:
 . If the change requires modification to the documentation, which can be found in `docs/src`, please be sure to try to
 generate the docs.  If the changes are minimal and do not include code examples, it might be sufficient to test
 generate the docs to validate formatting by just doing `bin/process-docs.sh --dryRun`.  If there are code examples,
-please be sure to have Zookeeper and Hadoop running when doing a `bin/process-docs.sh`.  The documentation is
-generated to `/target/docs/htmlsingle`.
+please be sure to have Zookeeper and Hadoop running when doing a `bin/process-docs.sh`.  If no code changes were made,
+one can also use the `--noClean` option. This will prevent the processor from cleaning up the local Grapes directory and
+the Hadoop Gremlin Libs directory in HDFS, resulting in a slightly faster execution time. The documentation is generated
+to `/target/docs/htmlsingle`.
 . If necessary, run the integration tests.  For example, if the changes affect serialization or Gremlin Server/Driver
 operations then running the integration tests assures in addition to unit tests will definitely be necessary. After
 a successful `mvn clean install`, do `mvn verify -DskipIntegrationTests=false -pl gremlin-server`.


### PR DESCRIPTION
Clear the local Grapes directory and HDFS in `bin/process-docs.sh`.
Also added an option (`--no-clean`) to avoid the cleanup.

VOTE: +1