### PR TITLE
Do not include TraversalMetrics cap in profile results.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileStep.java
@@ -134,6 +134,12 @@ public final class ProfileStep<S> extends AbstractStep<S, S> implements MapReduc
         final List<Step> steps = traversal.getSteps();
         for (int ii = 0; ii + 1 < steps.size(); ii = ii + 2) {
             Step step = steps.get(ii);
+
+            if (!(steps.get(ii+1) instanceof ProfileStep)) {
+                // If the next step is not a ProfileStep then we are done initializing.
+                return;
+            }
+
             ProfileStep profileStep = (ProfileStep) steps.get(ii + 1);
 
             // Create metrics

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ProfileStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/finalization/ProfileStrategy.java
@@ -23,8 +23,10 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ProfileStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SideEffectCapStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 
 import java.util.List;
 
@@ -62,6 +64,14 @@ public final class ProfileStrategy extends AbstractTraversalStrategy<TraversalSt
         for (int ii = 0; ii < numSteps; ii++) {
             // Get the original step
             Step step = steps.get(ii * 2);
+
+            if (step instanceof SideEffectCapStep && ii == numSteps - 1) {
+                SideEffectCapStep sideEffectCapStep = (SideEffectCapStep) step;
+                if (sideEffectCapStep.getSideEffectKeys().size() == 1 && sideEffectCapStep.getSideEffectKeys().get(0).equals(TraversalMetrics.METRICS_KEY)) {
+                    // Do not profile the last step if it is used to cap off the TraversalMetrics.
+                    continue;
+                }
+            }
 
             // Create and inject ProfileStep
             ProfileStep profileStep = new ProfileStep(traversal);

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyProfileTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyProfileTest.groovy
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -52,6 +53,11 @@ public abstract class GroovyProfileTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_b__b_in_count_isXeqX1XXX_selectXa_bX_byXnameX_profile() {
             TraversalScriptHelper.compute("g.V.match(__.as('a').out('created').as('b'), __.as('b').in.count.is(eq(1))).select('a', 'b').by('name').profile", g)
+        }
+
+        @Override
+        Traversal<Vertex, TraversalMetrics> get_g_V_profile_capXmetricsX() {
+            g.V.profile.cap(TraversalMetrics.METRICS_KEY)
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/ProfileTest.java
@@ -65,6 +65,8 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_b__b_in_count_isXeqX1XXX_selectXa_bX_byXnameX_profile();
 
+    public abstract Traversal<Vertex, TraversalMetrics>  get_g_V_profile_capXmetricsX();
+
     /**
      * Many of the tests in this class are coupled to not-totally-generic vendor behavior. However, this test is intended to provide
      * fully generic validation.
@@ -308,6 +310,16 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
         traversal.iterate();
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void testTraversalMetricsCapStepExclusion() {
+        // https://issues.apache.org/jira/browse/TINKERPOP-1078.
+        // Exclude '.cap(TraversalMetrics.METRICS_KEY)' step from profiling.
+        final Traversal<Vertex, TraversalMetrics> t = get_g_V_profile_capXmetricsX();
+        TraversalMetrics traversalMetrics = t.next();
+        assertEquals("There should be 1 top-level metrics.", 1, traversalMetrics.getMetrics().size());
+    }
+
     /**
      * Traversals
      */
@@ -348,6 +360,11 @@ public abstract class ProfileTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_b__b_in_count_isXeqX1XXX_selectXa_bX_byXnameX_profile() {
             return g.V().match(__.as("a").out("created").as("b"), __.as("b").in().count().is(P.eq(1))).<String>select("a", "b").by("name").profile();
+        }
+
+        @Override
+        public Traversal<Vertex, TraversalMetrics> get_g_V_profile_capXmetricsX() {
+            return g.V().profile().cap(TraversalMetrics.METRICS_KEY);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -341,7 +341,7 @@ public class SerializationTest {
             assertTrue(m.containsKey(GraphSONTokens.METRICS));
 
             final List<Map<String, Object>> metrics = (List<Map<String, Object>>) m.get(GraphSONTokens.METRICS);
-            assertEquals(3, metrics.size());
+            assertEquals(2, metrics.size());
 
             final Map<String, Object> metrics0 = metrics.get(0);
             assertTrue(metrics0.containsKey(GraphSONTokens.ID));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1078

If the last step in a Traversal that is being profiled is ```cap(TraversalMetrics.METRICS_KEY)``` then that step is not profiled and not included as a row in the TraversalMetrics results.

Includes tests.