### PR TITLE
TINKERPOP-1083: Traversal needs a hashCode() and equals() definition.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/DefaultGraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/DefaultGraphTraversal.java
@@ -46,20 +46,6 @@ public class DefaultGraphTraversal<S, E> extends DefaultTraversal<S, E> implemen
     }
 
     @Override
-    public boolean equals(final Object other) {
-        return other != null && other.getClass().equals(this.getClass()) && this.asAdmin().equals(((DefaultGraphTraversal) other).asAdmin());
-    }
-
-    @Override
-    public int hashCode() {
-        int result = this.getClass().hashCode();
-        for (final Step step : this.asAdmin().getSteps()) {
-            result ^= step.hashCode();
-        }
-        return result;
-    }
-
-    @Override
     public DefaultGraphTraversal<S, E> clone() {
         return (DefaultGraphTraversal<S, E>) super.clone();
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -1120,7 +1120,7 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     public default GraphTraversal<S, E> emit() {
-        return this.emit(new TrueTraversal<>());
+        return this.emit(TrueTraversal.instance());
     }
 
     public default GraphTraversal<S, E> until(final Traversal<?, ?> untilTraversal) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/AbstractLambdaTraversal.java
@@ -37,15 +37,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S, E> {
 
-    private TraversalStrategies traversalStrategies = EmptyTraversalStrategies.instance();
-    private TraversalParent traversalParent = (TraversalParent) EmptyStep.instance();
-    private transient Graph graph = null;
+    private static final Set<TraverserRequirement> REQUIREMENTS = Collections.singleton(TraverserRequirement.OBJECT);
 
     public List<Step> getSteps() {
         return Collections.emptyList();
@@ -68,7 +67,7 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
 
     @Override
     public void applyStrategies() throws IllegalStateException {
-        this.traversalStrategies.applyStrategies(this);
+
     }
 
     @Override
@@ -98,30 +97,28 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
 
     @Override
     public void setStrategies(final TraversalStrategies strategies) {
-        this.traversalStrategies = strategies.clone();
+
     }
 
     @Override
     public TraversalStrategies getStrategies() {
-        return this.traversalStrategies;
+        return EmptyTraversalStrategies.instance();
     }
 
     @Override
     public void setParent(final TraversalParent step) {
-        this.traversalParent = step;
+
     }
 
     @Override
     public TraversalParent getParent() {
-        return this.traversalParent;
+        return EmptyStep.instance();
     }
 
     @Override
     public Traversal.Admin<S, E> clone() {
         try {
-            final AbstractLambdaTraversal<S, E> clone = (AbstractLambdaTraversal<S, E>) super.clone();
-            clone.traversalStrategies = this.traversalStrategies.clone();
-            return clone;
+            return (AbstractLambdaTraversal<S, E>) super.clone();
         } catch (final CloneNotSupportedException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
@@ -153,12 +150,27 @@ public abstract class AbstractLambdaTraversal<S, E> implements Traversal.Admin<S
 
     @Override
     public Optional<Graph> getGraph() {
-        return Optional.ofNullable(this.graph);
+        return Optional.empty();
     }
 
     @Override
     public void setGraph(final Graph graph) {
-        this.graph = graph;
+
+    }
+
+    @Override
+    public Set<TraverserRequirement> getTraverserRequirements() {
+        return REQUIREMENTS;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getClass().hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        return this.getClass().equals(object.getClass()) && this.hashCode() == object.hashCode();
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/ConstantTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/ConstantTraversal.java
@@ -39,7 +39,6 @@ public final class ConstantTraversal<S, E> extends AbstractLambdaTraversal<S, E>
         return "(" + this.end.toString() + ")";
     }
 
-
     @Override
     public int hashCode() {
         return this.getClass().hashCode() ^ this.end.hashCode();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/IdentityTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/IdentityTraversal.java
@@ -23,15 +23,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class IdentityTraversal<S, E> extends AbstractLambdaTraversal<S, E> {
-
-    private static final String IDENTITY = "identity";
+public final class IdentityTraversal<S> extends AbstractLambdaTraversal<S, S> {
 
     private S s;
 
     @Override
-    public E next() {
-        return (E) this.s;
+    public S next() {
+        return this.s;
     }
 
     @Override
@@ -41,11 +39,6 @@ public final class IdentityTraversal<S, E> extends AbstractLambdaTraversal<S, E>
 
     @Override
     public String toString() {
-        return IDENTITY;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.getClass().hashCode();
+        return "identity";
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/LoopTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/LoopTraversal.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class LoopTraversal<S, E> extends AbstractLambdaTraversal<S, E> {
+public final class LoopTraversal<S> extends AbstractLambdaTraversal<S, S> {
 
     private final long maxLoops;
     private boolean allow = false;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/TrueTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/TrueTraversal.java
@@ -21,11 +21,12 @@ package org.apache.tinkerpop.gremlin.process.traversal.lambda;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TrueTraversal<S, E> extends AbstractLambdaTraversal<S, E> {
+public final class TrueTraversal<S> extends AbstractLambdaTraversal<S, S> {
 
-    @Override
-    public boolean hasNext() {
-        return true;
+    private static final TrueTraversal INSTANCE = new TrueTraversal();
+
+    private TrueTraversal() {
+
     }
 
     @Override
@@ -33,9 +34,13 @@ public final class TrueTraversal<S, E> extends AbstractLambdaTraversal<S, E> {
         return "true";
     }
 
-    @Override
-    public int hashCode() {
-        return this.getClass().hashCode();
+    public static <S> TrueTraversal<S> instance() {
+        return INSTANCE;
     }
 
+    @Override
+    @SuppressWarnings("CloneDoesntCallSuperClone")
+    public TrueTraversal<S> clone() {
+        return INSTANCE;
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/EmptyStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/EmptyStep.java
@@ -37,7 +37,7 @@ public final class EmptyStep<S, E> implements Step<S, E>, TraversalParent {
 
     private static final EmptyStep INSTANCE = new EmptyStep<>();
 
-    public static <S, E> Step<S, E> instance() {
+    public static <S, E> EmptyStep<S, E> instance() {
         return INSTANCE;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -54,7 +53,7 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     protected List<Step> steps = new ArrayList<>();
     // steps will be repeatedly retrieved from this traversal so wrap them once in an immutable list that can be reused
     protected List<Step> unmodifiableSteps = Collections.unmodifiableList(steps);
-    protected TraversalParent traversalParent = (TraversalParent) EmptyStep.instance();
+    protected TraversalParent traversalParent = EmptyStep.instance();
     protected TraversalSideEffects sideEffects = new DefaultTraversalSideEffects();
     protected TraversalStrategies strategies;
     protected TraversalEngine traversalEngine = StandardTraversalEngine.instance(); // necessary for strategies that need the engine in OLAP message passing (not so bueno)
@@ -295,6 +294,20 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
     @Override
     public void setGraph(final Graph graph) {
         this.graph = graph;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return other != null && other.getClass().equals(this.getClass()) && this.asAdmin().equals(((Traversal.Admin) other));
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.getClass().hashCode();
+        for (final Step step : this.asAdmin().getSteps()) {
+            result ^= step.hashCode();
+        }
+        return result;
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/EmptyTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/EmptyTraversal.java
@@ -145,7 +145,7 @@ public class EmptyTraversal<S, E> implements Traversal.Admin<S, E> {
 
     @Override
     public TraversalParent getParent() {
-        return (TraversalParent) EmptyStep.instance();
+        return EmptyStep.instance();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalRing.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public final class TraversalRing<A, B> implements Serializable, Cloneable {
 
-    private IdentityTraversal<A, B> identityTraversal = new IdentityTraversal<>();
+    private IdentityTraversal identityTraversal = new IdentityTraversal<>();
     private List<Traversal.Admin<A, B>> traversals = new ArrayList<>();
     private int currentTraversal = -1;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1083

We had a lot of inconsistencies around `hashCode()`/`equals()` for `Traversal`. Moreover, I pretty much gutted a crap load of pointless internals in `AbstractLambdaTraversal` (much simpler, safer, and more efficient).

`mvn clean install` as well as Spark integration tests (and the first 10 minutes of Giraph integration tests).

VOTE +1.