### PR TITLE
TINKERPOP-1089: Order.shuffle implementation is too fragile

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComparatorTraverser.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ComparatorTraverser.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.util;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class ComparatorTraverser<S> implements Comparator<Traverser<S>>, Serializable {
+
+    private final Comparator<S> comparator;
+
+    public ComparatorTraverser(final Comparator<S> comparator) {
+        this.comparator = comparator;
+    }
+
+    public Comparator<S> getComparator() {
+        return this.comparator;
+    }
+
+    @Override
+    public int compare(final Traverser<S> traverserA, final Traverser<S> traverserB) {
+        return this.comparator.compare(traverserA.get(), traverserB.get());
+    }
+
+    public static <S> List<ComparatorTraverser<S>> convertComparator(final List<Comparator<S>> comparators) {
+        return comparators.stream().map(comparator -> new ComparatorTraverser<>(comparator)).collect(Collectors.toList());
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/TraverserSet.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/traverser/util/TraverserSet.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.traverser.util;
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 
 import java.io.Serializable;
 import java.util.AbstractSet;
@@ -142,6 +142,13 @@ public class TraverserSet<S> extends AbstractSet<Traverser.Admin<S>> implements 
     public void sort(final Comparator<Traverser<S>> comparator) {
         final List<Traverser.Admin<S>> list = new ArrayList<>(this.map.values());
         Collections.sort(list, comparator);
+        this.map.clear();
+        list.forEach(traverser -> this.map.put(traverser, traverser));
+    }
+
+    public void shuffle() {
+        final List<Traverser.Admin<S>> list = new ArrayList<>(this.map.values());
+        Collections.shuffle(list);
         this.map.clear();
         list.forEach(traverser -> this.map.put(traverser, traverser));
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/ChainedComparator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/function/ChainedComparator.java
@@ -18,9 +18,15 @@
  */
 package org.apache.tinkerpop.gremlin.util.function;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.ComparatorTraverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.TraversalComparator;
+
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -29,11 +35,19 @@ public final class ChainedComparator<T> implements Comparator<T>, Serializable {
 
     private final List<Comparator<T>> comparators;
     private transient Comparator<T> chain;
+    private final boolean isShuffle;
 
     public ChainedComparator(final List<Comparator<T>> comparators) {
         if (comparators.isEmpty())
             throw new IllegalArgumentException("A chained comparator requires at least one comparator");
-        this.comparators = comparators;
+        this.comparators = new ArrayList<>(comparators);
+        this.isShuffle = ChainedComparator.testIsShuffle(this.comparators.get(this.comparators.size() - 1));
+        if (!this.isShuffle)
+            this.comparators.removeAll(this.comparators.stream().filter(ChainedComparator::testIsShuffle).collect(Collectors.toList()));
+    }
+
+    public boolean isShuffle() {
+        return this.isShuffle;
     }
 
     @Override
@@ -41,4 +55,16 @@ public final class ChainedComparator<T> implements Comparator<T>, Serializable {
         if (null == this.chain) this.chain = this.comparators.stream().reduce((a, b) -> a.thenComparing(b)).get();
         return this.chain.compare(objectA, objectB);
     }
+
+    private static boolean testIsShuffle(final Comparator comparator) {
+        if (comparator.equals(Order.shuffle))
+            return true;
+        else if (comparator instanceof ComparatorTraverser)
+            return testIsShuffle(((ComparatorTraverser) comparator).getComparator());
+        else if (comparator instanceof TraversalComparator)
+            return testIsShuffle(((TraversalComparator) comparator).getComparator());
+        else
+            return false;
+    }
+
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStepTest.java
@@ -23,7 +23,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 import org.junit.Ignore;
+import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -50,5 +52,21 @@ public class OrderGlobalStepTest extends StepTest {
                 __.order().by("age", Order.incr).by(outE().count(), Order.incr),
                 __.order().by(outE().count(), Order.incr).by("age", Order.incr)
         );
+    }
+
+    @Test
+    public void shouldNotThrowContractException() {
+        for (int x = 0; x < 1000; x++) {
+            final List<Integer> list = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                list.add(i);
+            }
+            __.inject(list).unfold().order().by(Order.shuffle).iterate();
+            __.inject(list).unfold().order().by().by(Order.shuffle).iterate();
+            __.inject(list).unfold().order().by(Order.shuffle).by().iterate();
+            __.inject(list).unfold().order().by(__.identity(), Order.shuffle).iterate();
+            __.inject(list).unfold().order().by().by(__.identity(), Order.shuffle).iterate();
+            __.inject(list).unfold().order().by(__.identity(), Order.shuffle).by().iterate();
+        }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStepTest.java
@@ -24,7 +24,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.StepTest;
 import org.junit.Ignore;
+import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -51,5 +53,21 @@ public class OrderLocalStepTest extends StepTest {
                 __.order(Scope.local).by("age", Order.incr).by(outE().count(), Order.incr),
                 __.order(Scope.local).by(outE().count(), Order.incr).by("age", Order.incr)
         );
+    }
+
+    @Test
+    public void shouldNotThrowContractException() {
+        for (int x = 0; x < 1000; x++) {
+            final List<Integer> list = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                list.add(i);
+            }
+            __.inject(list).order(Scope.local).by(Order.shuffle).iterate();
+            __.inject(list).order(Scope.local).by().by(Order.shuffle).iterate();
+            __.inject(list).order(Scope.local).by(Order.shuffle).by().iterate();
+            __.inject(list).order(Scope.local).by(__.identity(), Order.shuffle).iterate();
+            __.inject(list).order(Scope.local).by().by(__.identity(), Order.shuffle).iterate();
+            __.inject(list).order(Scope.local).by(__.identity(), Order.shuffle).by().iterate();
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1089

This required some refactoring. We have lots of `Comparator` wrappers everywhere so things get a little nasty. However, I added some solid test cases that ensure that the order violation doesn't happen with `Order.shuffle`.

VOTE +1.