### PR TITLE
TINKERPOP-997 - Feature and FeatureRequirement adjustments

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ TinkerPop 3.1.1 (NOT OFFICIALLY RELEASED YET)
 * `DefaultTraversal` has a well defined `hashCode()` and `equals()`.
 * Added serializers to Gryo for `java.time` related classes.
 * Integrated `NumberHelper` in `SackFunctions`.
+* Deprecated `VertexPropertyFeatures.supportsAddProperty()` which effectively was a duplicate of `VertexFeatures.supportsMetaProperties`.
 * The Spark persistence `StorageLevel` can now be set for both job graphs and `PersistedOutputRDD` data.
 * Added to the list of "invalid binding keys" allowed by Gremlin Server to cover the private fields of `T` which get exposed in the `ScriptEngine` on static imports.
 * Added `BulkDumperVertex` that allows to dump a whole graph in any of the supported IO formats (GraphSON, Gryo, Script).

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -212,6 +212,7 @@ These changes related to "Feature Consistency" open up a number of previously no
 not support meta-properties, so providers should be wary of potential test failure on previously non-executing tests.
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-985[TINKERPOP-985],
+link:https://issues.apache.org/jira/browse/TINKERPOP-997[TINKERPOP-997],
 link:https://issues.apache.org/jira/browse/TINKERPOP-998[TINKERPOP-998]
 
 Graph Processor Providers

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -148,6 +148,13 @@ the `AbsstractSandboxExtension` or extending directly from Groovy's `TypeCheckin
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-891[TINKERPOP-891],
 link:http://tinkerpop.apache.org/docs/3.1.0-incubating/#script-execution[Reference Documentation - Script Execution]
 
+Deprecated supportsAddProperty()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It was realized that `VertexPropertyFeatures.supportsAddProperty()` was effectively a duplicate of
+`VertexFeatures.supportsMetaProperties()`.  As a result, `supportsAddProperty()` was deprecated in favor of the other.
+If using `supportsAddProperty()`, simply modify that code to instead utilize `supportsMetaProperties()`.
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -198,13 +205,14 @@ Corrections fell into two groups of changes:
 
 . Bugs in the how `Features` were applied to certain tests.
 . Refactoring around the realization that `VertexFeatures.supportsMetaProperties()` is really just a duplicate of
-features already exposed as `VertexPropertyFeatures.supportsAddProperty()` and
-`VertexPropertyFeatures.supportsRemoveProperty()`.  `VertexFeatures.supportsMetaProperties()` has been deprecated.
+features already exposed as `VertexPropertyFeatures.supportsAddProperty()`.
+`VertexPropertyFeatures.supportsAddProperty()` has been deprecated.
 
 These changes related to "Feature Consistency" open up a number of previously non-executing tests for graphs that did
 not support meta-properties, so providers should be wary of potential test failure on previously non-executing tests.
 
-See: link:https://issues.apache.org/jira/browse/TINKERPOP-985[TINKERPOP-985]
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-985[TINKERPOP-985],
+link:https://issues.apache.org/jira/browse/TINKERPOP-998[TINKERPOP-998]
 
 Graph Processor Providers
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/Graph.java
@@ -718,6 +718,11 @@ public interface Graph extends AutoCloseable, Host {
          * Features that are related to {@link Vertex} {@link Property} objects.
          */
         public interface VertexPropertyFeatures extends PropertyFeatures {
+            /**
+             * @deprecated As of release 3.1.1-incubating, replaced by
+             * {@link org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures#FEATURE_META_PROPERTIES}
+             */
+            @Deprecated
             public static final String FEATURE_ADD_PROPERTY = "AddProperty";
             public static final String FEATURE_REMOVE_PROPERTY = "RemoveProperty";
             public static final String FEATURE_USER_SUPPLIED_IDS = "UserSuppliedIds";
@@ -729,7 +734,11 @@ public interface Graph extends AutoCloseable, Host {
 
             /**
              * Determines if a {@link VertexProperty} allows properties to be added.
+             *
+             * @deprecated As of release 3.1.1-incubating, replaced by
+             * {@link org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures#supportsMetaProperties()}
              */
+            @Deprecated
             @FeatureDescriptor(name = FEATURE_ADD_PROPERTY)
             public default boolean supportsAddProperty() {
                 return true;

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/FeatureRequirementSet.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/FeatureRequirementSet.java
@@ -54,7 +54,7 @@ public @interface FeatureRequirementSet {
         private static final List<FeatureRequirement> featuresRequiredBySimple = new ArrayList<FeatureRequirement>() {{
             add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES, Graph.Features.EdgeFeatures.class));
-            add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_ADD_PROPERTY, Graph.Features.VertexPropertyFeatures.class));
+            add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.VertexPropertyFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.EdgePropertyFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY, Graph.Features.EdgeFeatures.class));
@@ -63,7 +63,7 @@ public @interface FeatureRequirementSet {
         private static final List<FeatureRequirement> featuresRequiredByVerticesOnly = new ArrayList<FeatureRequirement>() {{
             add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.VertexPropertyFeatures.class));
-            add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_ADD_PROPERTY, Graph.Features.VertexPropertyFeatures.class));
+            add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES, Graph.Features.VertexFeatures.class));
         }};
 
         public List<FeatureRequirement> featuresRequired() {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/FeatureRequirementSet.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/FeatureRequirementSet.java
@@ -54,7 +54,7 @@ public @interface FeatureRequirementSet {
         private static final List<FeatureRequirement> featuresRequiredBySimple = new ArrayList<FeatureRequirement>() {{
             add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES, Graph.Features.EdgeFeatures.class));
-            add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES, Graph.Features.VertexFeatures.class));
+            add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.VertexPropertyFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.EdgePropertyFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.EdgeFeatures.FEATURE_ADD_PROPERTY, Graph.Features.EdgeFeatures.class));
@@ -63,7 +63,7 @@ public @interface FeatureRequirementSet {
         private static final List<FeatureRequirement> featuresRequiredByVerticesOnly = new ArrayList<FeatureRequirement>() {{
             add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES, Graph.Features.VertexFeatures.class));
             add(FeatureRequirement.Factory.create(Graph.Features.VertexPropertyFeatures.FEATURE_STRING_VALUES, Graph.Features.VertexPropertyFeatures.class));
-            add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES, Graph.Features.VertexFeatures.class));
+            add(FeatureRequirement.Factory.create(Graph.Features.VertexFeatures.FEATURE_ADD_PROPERTY, Graph.Features.VertexFeatures.class));
         }};
 
         public List<FeatureRequirement> featuresRequired() {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/FeatureSupportTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/FeatureSupportTest.java
@@ -890,7 +890,7 @@ public class FeatureSupportTest {
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = VertexFeatures.FEATURE_META_PROPERTIES, supported = false)
-        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = VertexPropertyFeatures.FEATURE_ADD_PROPERTY)
+        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = VertexFeatures.FEATURE_META_PROPERTIES)
         public void shouldSupportMetaPropertyIfPropertiesCanBePutOnProperties() throws Exception {
             try {
                 final Vertex v = graph.addVertex();
@@ -905,7 +905,7 @@ public class FeatureSupportTest {
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = VertexFeatures.FEATURE_META_PROPERTIES, supported = false)
-        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = VertexPropertyFeatures.FEATURE_ADD_PROPERTY)
+        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = VertexFeatures.FEATURE_META_PROPERTIES)
         public void shouldSupportMetaPropertyIfPropertiesCanBePutOnPropertiesViaVertexProperty() throws Exception {
             try {
                 final Vertex v = graph.addVertex("name", "stephen");
@@ -920,7 +920,7 @@ public class FeatureSupportTest {
         @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = VertexFeatures.FEATURE_META_PROPERTIES, supported = false)
-        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = VertexPropertyFeatures.FEATURE_ADD_PROPERTY)
+        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = VertexFeatures.FEATURE_META_PROPERTIES)
         public void shouldSupportMetaPropertyIfPropertiesHaveAnIteratorViaVertexProperty() throws Exception {
             try {
                 final Vertex v = graph.addVertex("name", "stephen");

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/PropertyTest.java
@@ -255,7 +255,7 @@ public class PropertyTest {
         @Test
         @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES)
         @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = FEATURE_PROPERTIES)
-        @FeatureRequirement(featureClass = Graph.Features.VertexPropertyFeatures.class, feature = VertexPropertyFeatures.FEATURE_ADD_PROPERTY)
+        @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = Graph.Features.VertexFeatures.FEATURE_META_PROPERTIES)
         public void testGraphVertexSetPropertyStandard() throws Exception {
             try {
                 final Vertex v = this.graph.addVertex();


### PR DESCRIPTION
As they were very closely related, this PR covers:

https://issues.apache.org/jira/browse/TINKERPOP-997
https://issues.apache.org/jira/browse/TINKERPOP-998

it deprecates a `Feature` that was basically a duplicate of another.  It also opens up a good number of test cases to graphs that don't support meta-properties as there was a mis-definition of the `SIMPLE` requirement set.

Tested with `mvn clean install -DincludeNeo4j` and all was good. Also temporarily modified the TinkerGraph feature for meta-property support and manually noted that the right test cases opened up and closed down based on this change.  Would be nice to get some verification from other graphs that this change is all good.  

@jdellithorpe please take a look at this change when you get a moment, as you were the one who noted the problem in the first place.  Looks like we get about 90 tests opened up as a result of this.

VOTE +1