### PR TITLE
TINKERPOP-962: Provide "vertex query" selectivity when importing data in OLAP.

### DIFF
--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphGraphComputer.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphGraphComputer.java
@@ -146,7 +146,7 @@ public final class GiraphGraphComputer extends AbstractHadoopGraphComputer imple
         try {
             // store vertex and edge filters (will propagate down to native InputFormat or else GiraphVertexInputFormat will process)
             final Configuration apacheConfiguration = new BaseConfiguration();
-            GraphFilterAware.storeVertexAndEdgeFilters(apacheConfiguration, this.giraphConfiguration, this.vertexFilter, this.edgeFilter);
+            GraphFilterAware.storeGraphFilter(apacheConfiguration, this.giraphConfiguration, this.graphFilter);
 
             // it is possible to run graph computer without a vertex program (and thus, only map reduce jobs if they exist)
             if (null != this.vertexProgram) {

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphGraphComputer.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphGraphComputer.java
@@ -42,6 +42,7 @@ import org.apache.tinkerpop.gremlin.hadoop.process.computer.util.ComputerSubmiss
 import org.apache.tinkerpop.gremlin.hadoop.process.computer.util.MapReduceHelper;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.FileSystemStorage;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.InputOutputHelper;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritableIterator;
@@ -143,6 +144,10 @@ public final class GiraphGraphComputer extends AbstractHadoopGraphComputer imple
         storage.rm(this.giraphConfiguration.get(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION));
         this.giraphConfiguration.setBoolean(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES, this.persist.equals(Persist.EDGES));
         try {
+            // store vertex and edge filters (will propagate down to native InputFormat or else GiraphVertexInputFormat will process)
+            final Configuration apacheConfiguration = new BaseConfiguration();
+            GraphFilterAware.storeVertexAndEdgeFilters(apacheConfiguration, this.giraphConfiguration, this.vertexFilter, this.edgeFilter);
+
             // it is possible to run graph computer without a vertex program (and thus, only map reduce jobs if they exist)
             if (null != this.vertexProgram) {
                 // a way to verify in Giraph whether the traversal will go over the wire or not

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexInputFormat.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexInputFormat.java
@@ -21,18 +21,10 @@ package org.apache.tinkerpop.gremlin.giraph.structure.io;
 import org.apache.giraph.io.VertexInputFormat;
 import org.apache.giraph.io.VertexReader;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.tinkerpop.gremlin.hadoop.Constants;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
-import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
-import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
-import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
+import org.apache.tinkerpop.gremlin.hadoop.process.computer.GraphFilterInputFormat;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,11 +34,6 @@ import java.util.List;
  */
 public final class GiraphVertexInputFormat extends VertexInputFormat {
 
-    private InputFormat<NullWritable, VertexWritable> hadoopGraphInputFormat;
-    protected GraphFilter graphFilter = new GraphFilter();
-    private boolean graphFilterLoaded = false;
-    private boolean graphFilterAware = false;
-
     @Override
     public void checkInputSpecs(final Configuration configuration) {
 
@@ -54,29 +41,17 @@ public final class GiraphVertexInputFormat extends VertexInputFormat {
 
     @Override
     public List<InputSplit> getSplits(final JobContext context, final int minSplitCountHint) throws IOException, InterruptedException {
-        this.constructor(context.getConfiguration());
-        return this.hadoopGraphInputFormat.getSplits(context);
+        return new GraphFilterInputFormat().getSplits(context);
     }
 
     @Override
     public VertexReader createVertexReader(final InputSplit split, final TaskAttemptContext context) throws IOException {
-        this.constructor(context.getConfiguration());
         try {
-            return new GiraphVertexReader(this.hadoopGraphInputFormat.createRecordReader(split, context), this.graphFilterAware, this.graphFilter);
-        } catch (InterruptedException e) {
-            throw new IOException(e);
-        }
-    }
-
-    private final void constructor(final Configuration configuration) {
-        if (null == this.hadoopGraphInputFormat) {
-            this.hadoopGraphInputFormat = ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputFormat.class, InputFormat.class), configuration);
-            this.graphFilterAware = this.hadoopGraphInputFormat instanceof GraphFilterAware;
-            if (!this.graphFilterLoaded) {
-                if (configuration.get(Constants.GREMLIN_HADOOP_GRAPH_FILTER, null) != null)
-                    this.graphFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(configuration), Constants.GREMLIN_HADOOP_GRAPH_FILTER);
-                this.graphFilterLoaded = true;
-            }
+            final GiraphVertexReader reader = new GiraphVertexReader();
+            reader.initialize(split, context);
+            return reader;
+        } catch (final InterruptedException e) {
+            throw new IOException(e.getMessage(), e);
         }
     }
 

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexInputFormat.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexInputFormat.java
@@ -45,7 +45,7 @@ public final class GiraphVertexInputFormat extends VertexInputFormat {
     private InputFormat<NullWritable, VertexWritable> hadoopGraphInputFormat;
     protected GraphFilter graphFilter = new GraphFilter();
     private boolean graphFilterLoaded = false;
-    private boolean graphFilterAware;
+    private boolean graphFilterAware = false;
 
     @Override
     public void checkInputSpecs(final Configuration configuration) {

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexOutputFormat.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexOutputFormat.java
@@ -18,17 +18,15 @@
  */
 package org.apache.tinkerpop.gremlin.giraph.structure.io;
 
-import org.apache.tinkerpop.gremlin.hadoop.Constants;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.giraph.io.VertexOutputFormat;
 import org.apache.giraph.io.VertexWriter;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
 
 import java.io.IOException;
 
@@ -37,29 +35,21 @@ import java.io.IOException;
  */
 public final class GiraphVertexOutputFormat extends VertexOutputFormat {
 
-    private OutputFormat<NullWritable, VertexWritable> hadoopGraphOutputFormat;
-
     @Override
     public VertexWriter createVertexWriter(final TaskAttemptContext context) throws IOException, InterruptedException {
-        this.constructor(context.getConfiguration());
-        return new GiraphVertexWriter(this.hadoopGraphOutputFormat);
+        return new GiraphVertexWriter();
     }
 
     @Override
     public void checkOutputSpecs(final JobContext context) throws IOException, InterruptedException {
-        this.constructor(context.getConfiguration());
-        this.hadoopGraphOutputFormat.checkOutputSpecs(context);
+        final Configuration configuration = context.getConfiguration();
+        ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class, OutputFormat.class), configuration).checkOutputSpecs(context);
     }
 
     @Override
     public OutputCommitter getOutputCommitter(final TaskAttemptContext context) throws IOException, InterruptedException {
-        this.constructor(context.getConfiguration());
-        return this.hadoopGraphOutputFormat.getOutputCommitter(context);
+        final Configuration configuration = context.getConfiguration();
+        return ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class, OutputFormat.class), configuration).getOutputCommitter(context);
     }
 
-    private final void constructor(final Configuration configuration) {
-        if (null == this.hadoopGraphOutputFormat) {
-            this.hadoopGraphOutputFormat = ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class, OutputFormat.class), configuration);
-        }
-    }
 }

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
@@ -25,11 +25,9 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.tinkerpop.gremlin.giraph.process.computer.GiraphVertex;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 
 import java.io.IOException;
 
@@ -39,15 +37,13 @@ import java.io.IOException;
 public final class GiraphVertexReader extends VertexReader {
 
     private RecordReader<NullWritable, VertexWritable> recordReader;
-    private final Traversal.Admin<org.apache.tinkerpop.gremlin.structure.Vertex, org.apache.tinkerpop.gremlin.structure.Vertex> vertexFilter;
-    private final Traversal.Admin<Edge, Edge> edgeFilter;
+    private final GraphFilter graphFilter;
     private final boolean graphFilterAware;
 
-    public GiraphVertexReader(final RecordReader<NullWritable, VertexWritable> recordReader, final boolean graphFilterAware, final Traversal.Admin<org.apache.tinkerpop.gremlin.structure.Vertex, org.apache.tinkerpop.gremlin.structure.Vertex> vertexFilter, final Traversal.Admin<Edge, Edge> edgeFilter) {
+    public GiraphVertexReader(final RecordReader<NullWritable, VertexWritable> recordReader, final boolean graphFilterAware, final GraphFilter graphFilter) {
         this.recordReader = recordReader;
         this.graphFilterAware = graphFilterAware;
-        this.vertexFilter = null == vertexFilter ? null : vertexFilter.clone();
-        this.edgeFilter = null == edgeFilter ? null : edgeFilter.clone();
+        this.graphFilter = graphFilter.clone();
     }
 
     @Override
@@ -63,7 +59,7 @@ public final class GiraphVertexReader extends VertexReader {
             while (true) {
                 if (this.recordReader.nextKeyValue()) {
                     final VertexWritable vertexWritable = this.recordReader.getCurrentValue();
-                    final org.apache.tinkerpop.gremlin.structure.Vertex vertex = GraphFilterAware.applyVertexAndEdgeFilters(vertexWritable.get(), this.vertexFilter, this.edgeFilter);
+                    final org.apache.tinkerpop.gremlin.structure.Vertex vertex = GraphFilterAware.applyGraphFilter(vertexWritable.get(), this.graphFilter);
                     if (null != vertex) {
                         vertexWritable.set(vertex);
                         return true;

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
@@ -25,7 +25,11 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.tinkerpop.gremlin.giraph.process.computer.GiraphVertex;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 
 import java.io.IOException;
 
@@ -35,9 +39,15 @@ import java.io.IOException;
 public final class GiraphVertexReader extends VertexReader {
 
     private RecordReader<NullWritable, VertexWritable> recordReader;
+    private final Traversal.Admin<org.apache.tinkerpop.gremlin.structure.Vertex, org.apache.tinkerpop.gremlin.structure.Vertex> vertexFilter;
+    private final Traversal.Admin<Edge, Edge> edgeFilter;
+    private final boolean graphFilterAware;
 
-    public GiraphVertexReader(final RecordReader<NullWritable, VertexWritable> recordReader) {
+    public GiraphVertexReader(final RecordReader<NullWritable, VertexWritable> recordReader, final boolean graphFilterAware, final Traversal.Admin<org.apache.tinkerpop.gremlin.structure.Vertex, org.apache.tinkerpop.gremlin.structure.Vertex> vertexFilter, final Traversal.Admin<Edge, Edge> edgeFilter) {
         this.recordReader = recordReader;
+        this.graphFilterAware = graphFilterAware;
+        this.vertexFilter = null == vertexFilter ? null : vertexFilter.clone();
+        this.edgeFilter = null == edgeFilter ? null : edgeFilter.clone();
     }
 
     @Override
@@ -47,7 +57,22 @@ public final class GiraphVertexReader extends VertexReader {
 
     @Override
     public boolean nextVertex() throws IOException, InterruptedException {
-        return this.recordReader.nextKeyValue();
+        if (this.graphFilterAware) {
+            return this.recordReader.nextKeyValue();
+        } else {
+            while (true) {
+                if (this.recordReader.nextKeyValue()) {
+                    final VertexWritable vertexWritable = this.recordReader.getCurrentValue();
+                    final org.apache.tinkerpop.gremlin.structure.Vertex vertex = GraphFilterAware.applyVertexAndEdgeFilters(vertexWritable.get(), this.vertexFilter, this.edgeFilter);
+                    if (null != vertex) {
+                        vertexWritable.set(vertex);
+                        return true;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
     }
 
     @Override

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.tinkerpop.gremlin.giraph.process.computer.GiraphVertex;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 
@@ -59,7 +58,7 @@ public final class GiraphVertexReader extends VertexReader {
             while (true) {
                 if (this.recordReader.nextKeyValue()) {
                     final VertexWritable vertexWritable = this.recordReader.getCurrentValue();
-                    final org.apache.tinkerpop.gremlin.structure.Vertex vertex = GraphFilterAware.applyGraphFilter(vertexWritable.get(), this.graphFilter);
+                    final org.apache.tinkerpop.gremlin.structure.Vertex vertex = this.graphFilter.applyGraphFilter(vertexWritable.get());
                     if (null != vertex) {
                         vertexWritable.set(vertex);
                         return true;

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexReader.java
@@ -27,8 +27,10 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.tinkerpop.gremlin.giraph.process.computer.GiraphVertex;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
+import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -58,9 +60,9 @@ public final class GiraphVertexReader extends VertexReader {
             while (true) {
                 if (this.recordReader.nextKeyValue()) {
                     final VertexWritable vertexWritable = this.recordReader.getCurrentValue();
-                    final org.apache.tinkerpop.gremlin.structure.Vertex vertex = this.graphFilter.applyGraphFilter(vertexWritable.get());
-                    if (null != vertex) {
-                        vertexWritable.set(vertex);
+                    final Optional<StarGraph.StarVertex> vertex = this.graphFilter.applyGraphFilter(vertexWritable.get());
+                    if (vertex.isPresent()) {
+                        vertexWritable.set(vertex.get());
                         return true;
                     }
                 } else {

--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexWriter.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/structure/io/GiraphVertexWriter.java
@@ -20,11 +20,14 @@ package org.apache.tinkerpop.gremlin.giraph.structure.io;
 
 import org.apache.giraph.graph.Vertex;
 import org.apache.giraph.io.VertexWriter;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.tinkerpop.gremlin.giraph.process.computer.GiraphVertex;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 
 import java.io.IOException;
@@ -33,16 +36,16 @@ import java.io.IOException;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class GiraphVertexWriter extends VertexWriter {
-    private final OutputFormat<NullWritable, VertexWritable> outputFormat;
     private RecordWriter<NullWritable, VertexWritable> recordWriter;
 
-    public GiraphVertexWriter(final OutputFormat<NullWritable, VertexWritable> outputFormat) {
-        this.outputFormat = outputFormat;
+    public GiraphVertexWriter() {
+
     }
 
     @Override
     public void initialize(final TaskAttemptContext context) throws IOException, InterruptedException {
-        this.recordWriter = this.outputFormat.getRecordWriter(context);
+        final Configuration configuration = context.getConfiguration();
+        this.recordWriter = ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class, OutputFormat.class), configuration).getRecordWriter(context);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
@@ -107,9 +107,28 @@ public interface GraphComputer {
      */
     public GraphComputer workers(final int workers);
 
-    public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter);
+    /**
+     * Add a filter that will limit which vertices are loaded from the graph source.
+     * The provided {@link Traversal} can only check the vertex, its vertex properties, and the vertex property properties.
+     * The loaded graph will only have those vertices that pass through the provided filter.
+     *
+     * @param vertexFilter the traversal to verify whether or not to load the current vertex
+     * @return the updated GraphComputer with newly set vertex filter
+     * @throws IllegalArgumentException if the provided traversal attempts to access vertex edges
+     */
+    public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter) throws IllegalArgumentException;
 
-    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter);
+    /**
+     * Add a filter that will limit which edges of the vertices are loaded from the graph source.
+     * The provided {@link Traversal} can only check the local star graph of the vertex and thus,
+     * can not access properties/labels of the adjacent vertices.
+     * The vertices of the loaded graph will only have those edges that pass through the provided filter.
+     *
+     * @param edgeFilter the traversal that determines which edges are loaded for each vertex
+     * @return the updated GraphComputer with newly set edge filter
+     * @throws IllegalArgumentException if the provided traversal goes attempts to access adjacent vertices
+     */
+    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) throws IllegalArgumentException;
 
     /**
      * Set an arbitrary configuration key/value for the underlying {@link org.apache.commons.configuration.Configuration} in the {@link GraphComputer}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.process.computer;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
 import java.util.concurrent.Future;
 
 /**
@@ -102,6 +106,10 @@ public interface GraphComputer {
      * @return the updated GraphComputer with newly set worker count
      */
     public GraphComputer workers(final int workers);
+
+    public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter);
+
+    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter);
 
     /**
      * Set an arbitrary configuration key/value for the underlying {@link org.apache.commons.configuration.Configuration} in the {@link GraphComputer}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
@@ -109,7 +109,7 @@ public interface GraphComputer {
 
     public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter);
 
-    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter);
+    public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter);
 
     /**
      * Set an arbitrary configuration key/value for the underlying {@link org.apache.commons.configuration.Configuration} in the {@link GraphComputer}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
@@ -109,7 +109,7 @@ public interface GraphComputer {
 
     public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter);
 
-    public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter);
+    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter);
 
     /**
      * Set an arbitrary configuration key/value for the underlying {@link org.apache.commons.configuration.Configuration} in the {@link GraphComputer}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputer.java
@@ -126,7 +126,7 @@ public interface GraphComputer {
      *
      * @param edgeFilter the traversal that determines which edges are loaded for each vertex
      * @return the updated GraphComputer with newly set edge filter
-     * @throws IllegalArgumentException if the provided traversal goes attempts to access adjacent vertices
+     * @throws IllegalArgumentException if the provided traversal attempts to access adjacent vertices
      */
     public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) throws IllegalArgumentException;
 
@@ -263,6 +263,14 @@ public interface GraphComputer {
 
         public static IllegalArgumentException computerRequiresMoreWorkersThanSupported(final int workers, final int maxWorkers) {
             return new IllegalArgumentException("The computer requires more workers than supported: " + workers + " [max:" + maxWorkers + "]");
+        }
+
+        public static IllegalArgumentException vertexFilterAccessesIncidentEdges(final Traversal<Vertex, Vertex> vertexFilter) {
+            return new IllegalArgumentException("The provided vertex filter traversal accesses incident edges: " + vertexFilter);
+        }
+
+        public static IllegalArgumentException edgeFilterAccessesAdjacentVertices(final Traversal<Vertex, Edge> edgeFilter) {
+            return new IllegalArgumentException("The provided edge filter traversal accesses data on adjacent vertices: " + edgeFilter);
         }
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -41,6 +41,13 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
+ * GraphFilter is used by {@link GraphComputer} implementations to prune the source graph data being loaded into the OLAP system.
+ * There are two types of filters: a {@link Vertex} filter and an {@link Edge} filter.
+ * The vertex filter is a {@link Traversal} that can only check the id, label, and properties of the vertex.
+ * The edge filter is a {@link Traversal} that starts at the vertex are emits all legal incident edges.
+ * The use of GraphFilter can greatly reduce the amount of data processed by the {@link GraphComputer}.
+ * For instance, for {@code g.V().count()}, there is no reason to load edges, and thus, the edge filter can be {@code bothE().limit(0)}.
+ *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class GraphFilter implements Cloneable, Serializable {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -45,9 +45,10 @@ public final class GraphFilter implements Cloneable, Serializable {
     private Traversal.Admin<Vertex, Vertex> vertexFilter = null;
     private Traversal.Admin<Vertex, Edge> edgeFilter = null;
 
-    private Direction allowedEdgeDirection = Direction.BOTH;
-    private Set<String> allowedEdgeLabels = new HashSet<>();
-    private boolean allowAllRemainingEdges = false;
+    // private boolean dropAllEdges (make this a fast one if the end is limit(0)?)
+    protected Direction allowedEdgeDirection = Direction.BOTH;
+    protected Set<String> allowedEdgeLabels = new HashSet<>();
+    protected boolean allowAllRemainingEdges = false;
 
     public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter) {
         this.vertexFilter = vertexFilter.asAdmin().clone();
@@ -127,7 +128,7 @@ public final class GraphFilter implements Cloneable, Serializable {
             return vertex;
         else if (null == vertex)
             return null;
-        else if (!this.hasVertexFilter() || TraversalUtil.test(vertex, this.vertexFilter)) {
+        else if (this.legalVertex(vertex)) {
             if (this.hasEdgeFilter()) {
                 if (!this.allowedEdgeDirection.equals(Direction.BOTH))
                     vertex.dropEdges(this.allowedEdgeDirection.opposite());
@@ -137,7 +138,7 @@ public final class GraphFilter implements Cloneable, Serializable {
                 if (!this.allowAllRemainingEdges) {
                     final Map<String, List<Edge>> outEdges = new HashMap<>();
                     final Map<String, List<Edge>> inEdges = new HashMap<>();
-                    TraversalUtil.applyAll(vertex, this.edgeFilter).forEachRemaining(edge -> {
+                    this.legalEdges(vertex).forEachRemaining(edge -> {
                         if (edge instanceof StarGraph.StarOutEdge) {
                             List<Edge> edges = outEdges.get(edge.label());
                             if (null == edges) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.io.Serializable;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class GraphFilter implements Cloneable, Serializable {
+
+    private Traversal.Admin<Vertex, Vertex> vertexFilter = null;
+    private Traversal.Admin<Edge, Edge> edgeFilter = null;
+
+    public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter) {
+        this.vertexFilter = vertexFilter.asAdmin().clone();
+    }
+
+    public void setEdgeFilter(final Traversal<Edge, Edge> edgeFilter) {
+        this.edgeFilter = edgeFilter.asAdmin().clone();
+    }
+
+    public boolean hasVertexFilter() {
+        return this.vertexFilter != null;
+    }
+
+    public final Traversal.Admin<Vertex, Vertex> getVertexFilter() {
+        return this.vertexFilter;
+    }
+
+    public final Traversal.Admin<Edge, Edge> getEdgeFilter() {
+        return this.edgeFilter;
+    }
+
+    public boolean hasEdgeFilter() {
+        return this.edgeFilter != null;
+    }
+
+    public boolean hasFilter() {
+        return this.vertexFilter != null || this.edgeFilter != null;
+    }
+
+    @Override
+    public GraphFilter clone() {
+        try {
+            final GraphFilter clone = (GraphFilter) super.clone();
+            if (null != this.vertexFilter)
+                clone.vertexFilter = this.vertexFilter.clone();
+            if (null != this.edgeFilter)
+                clone.edgeFilter = this.edgeFilter.clone();
+            return clone;
+        } catch (final CloneNotSupportedException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (!this.hasFilter())
+            return "graphfilter[none]";
+        else if (this.hasVertexFilter() && this.hasEdgeFilter())
+            return "graphfilter[" + this.vertexFilter + "," + this.edgeFilter + "]";
+        else if (this.hasVertexFilter())
+            return "graphfilter[" + this.vertexFilter + "]";
+        else
+            return "graphfilter[" + this.edgeFilter + "]";
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -53,13 +53,13 @@ public final class GraphFilter implements Cloneable, Serializable {
 
     public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter) {
         if (!TraversalHelper.isLocalVertex(vertexFilter.asAdmin()))
-            throw new IllegalArgumentException("The provided vertex filter must not leave the local vertex: " + edgeFilter);
+            throw GraphComputer.Exceptions.vertexFilterAccessesIncidentEdges(vertexFilter);
         this.vertexFilter = vertexFilter.asAdmin().clone();
     }
 
     public void setEdgeFilter(final Traversal<Vertex, Edge> edgeFilter) {
         if (!TraversalHelper.isLocalStarGraph(edgeFilter.asAdmin()))
-            throw new IllegalArgumentException("The provided edge filter must not leave the local star graph: " + edgeFilter);
+            throw GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(edgeFilter);
         this.edgeFilter = edgeFilter.asAdmin().clone();
         if (this.edgeFilter.getStartStep() instanceof VertexStep) {
             this.allowedEdgeLabels.addAll(Arrays.asList(((VertexStep) this.edgeFilter.getStartStep()).getEdgeLabels()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,12 +62,22 @@ public final class GraphFilter implements Cloneable, Serializable {
         }
     }
 
+    public boolean legalVertex(final Vertex vertex) {
+        return null == this.vertexFilter || TraversalUtil.test(vertex, this.vertexFilter);
+    }
+
+    public Iterator<Edge> legalEdges(final Vertex vertex) {
+        return null == this.edgeFilter ?
+                vertex.edges(Direction.BOTH) :
+                TraversalUtil.applyAll(vertex, this.edgeFilter);
+    }
+
     public final Traversal.Admin<Vertex, Vertex> getVertexFilter() {
-        return this.vertexFilter.clone();
+        return this.vertexFilter;
     }
 
     public final Traversal.Admin<Vertex, Edge> getEdgeFilter() {
-        return this.edgeFilter.clone();
+        return this.edgeFilter;
     }
 
     public boolean hasFilter() {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -123,7 +123,7 @@ public final class GraphFilter implements Cloneable, Serializable {
             return Legal.YES;
         else if (this.allowNoEdges)
             return Legal.NO;
-        else if (!direction.equals(Direction.BOTH) && !this.allowedEdgeDirection.equals(direction))
+        else if (!this.allowedEdgeDirection.equals(Direction.BOTH) && !this.allowedEdgeDirection.equals(direction))
             return Legal.NO;
         else if (!this.allowedEdgeLabels.isEmpty() && !this.allowedEdgeLabels.contains(label))
             return Legal.NO;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilter.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.computer;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -51,10 +52,14 @@ public final class GraphFilter implements Cloneable, Serializable {
     protected boolean allowAllRemainingEdges = false;
 
     public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter) {
+        if (!TraversalHelper.isLocalVertex(vertexFilter.asAdmin()))
+            throw new IllegalArgumentException("The provided vertex filter must not leave the local vertex: " + edgeFilter);
         this.vertexFilter = vertexFilter.asAdmin().clone();
     }
 
     public void setEdgeFilter(final Traversal<Vertex, Edge> edgeFilter) {
+        if (!TraversalHelper.isLocalStarGraph(edgeFilter.asAdmin()))
+            throw new IllegalArgumentException("The provided edge filter must not leave the local star graph: " + edgeFilter);
         this.edgeFilter = edgeFilter.asAdmin().clone();
         if (this.edgeFilter.getStartStep() instanceof VertexStep) {
             this.allowedEdgeLabels.addAll(Arrays.asList(((VertexStep) this.edgeFilter.getStartStep()).getEdgeLabels()));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/engine/ComputerTraversalEngine.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/engine/ComputerTraversalEngine.java
@@ -26,7 +26,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.ProfileStrategy;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.Collections;
@@ -70,7 +72,8 @@ public final class ComputerTraversalEngine implements TraversalEngine {
         private Class<? extends GraphComputer> graphComputerClass;
         private int workers = -1;
         private static final List<TraversalStrategy> WITH_STRATEGIES = Collections.singletonList(ComputerResultStrategy.instance());
-
+        private Traversal<Vertex, Vertex> vertexFilter = null;
+        private Traversal<Vertex, Edge> edgeFilter = null;
 
         @Override
         public List<TraversalStrategy> getWithStrategies() {
@@ -87,11 +90,25 @@ public final class ComputerTraversalEngine implements TraversalEngine {
             return this;
         }
 
+        public Builder vertices(final Traversal<Vertex, Vertex> vertexFilter) {
+            this.vertexFilter = vertexFilter;
+            return this;
+        }
+
+        public Builder edges(final Traversal<Vertex, Edge> edgeFilter) {
+            this.edgeFilter = edgeFilter;
+            return this;
+        }
+
 
         public ComputerTraversalEngine create(final Graph graph) {
-            final GraphComputer graphComputer = null == this.graphComputerClass ? graph.compute() : graph.compute(this.graphComputerClass);
+            GraphComputer graphComputer = null == this.graphComputerClass ? graph.compute() : graph.compute(this.graphComputerClass);
             if (-1 != this.workers)
-                graphComputer.workers(this.workers);
+                graphComputer = graphComputer.workers(this.workers);
+            if (null != this.vertexFilter)
+                graphComputer = graphComputer.vertices(this.vertexFilter);
+            if (null != this.edgeFilter)
+                graphComputer = graphComputer.edges(this.edgeFilter);
             return new ComputerTraversalEngine(graphComputer);
         }
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalUtil.java
@@ -96,6 +96,12 @@ public final class TraversalUtil {
         }
     }
 
+    public static final <S, E> Iterator<E> applyAll(final S start, final Traversal.Admin<S, E> traversal) {
+        traversal.reset();
+        traversal.addStart(traversal.getTraverserGenerator().generate(start, traversal.getStartStep(), 1l));
+        return traversal; // flatMap
+    }
+
     public static final <S, E> boolean test(final S start, final Traversal.Admin<S, E> traversal, final E end) {
         if (null == end) return TraversalUtil.test(start, traversal);
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoReader.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.io.gryo;
 
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -34,6 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedProperty;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
+import org.apache.tinkerpop.gremlin.structure.util.star.StarGraphGryoSerializer;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.io.Input;
@@ -45,6 +47,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
@@ -60,6 +63,7 @@ import java.util.function.Function;
  */
 public final class GryoReader implements GraphReader {
     private final Kryo kryo;
+    private final Map<GraphFilter, StarGraphGryoSerializer> graphFilterCache = new HashMap<>();
 
     private final long batchSize;
 
@@ -106,6 +110,21 @@ public final class GryoReader implements GraphReader {
         }));
 
         if (supportsTx) graphToWriteTo.tx().commit();
+    }
+
+    @Override
+    public Optional<Vertex> readVertex(final InputStream inputStream, final GraphFilter graphFilter) throws IOException {
+        StarGraphGryoSerializer serializer = this.graphFilterCache.get(graphFilter);
+        if (null == serializer) {
+            serializer = StarGraphGryoSerializer.withGraphFilter(graphFilter);
+            this.graphFilterCache.put(graphFilter, serializer);
+        }
+        final Input input = new Input(inputStream);
+        this.readHeader(input);
+        final StarGraph starGraph = this.kryo.readObject(input, StarGraph.class, serializer);
+        // read the terminator
+        this.kryo.readClassAndObject(input);
+        return Optional.ofNullable(starGraph == null ? null : starGraph.getStarVertex());
     }
 
     /**

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -39,10 +39,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -273,11 +275,57 @@ public final class StarGraph implements Graph, Serializable {
             super(id, label);
         }
 
-        public void dropEdges() {
-            if (null != this.outEdges) this.outEdges.clear();
-            if (null != this.inEdges) this.inEdges.clear();
-            this.outEdges = null;
-            this.inEdges = null;
+        public void setEdges(final Direction direction, final Map<String, List<Edge>> edges) {
+            if (direction.equals(Direction.OUT))
+                this.outEdges = edges;
+            else if (direction.equals(Direction.IN))
+                this.inEdges = edges;
+            else
+                throw new IllegalArgumentException("The following direction is not supported: " + direction);
+        }
+
+        public void keepEdges(final Direction direction, final Set<String> edgeLabels) {
+            final Set<String> dropLabels = new HashSet<>();
+            if ((direction.equals(Direction.OUT) || direction.equals(Direction.BOTH)) && null != this.outEdges)
+                dropLabels.addAll(this.outEdges.keySet());
+            if ((direction.equals(Direction.IN) || direction.equals(Direction.BOTH)) && null != this.inEdges)
+                dropLabels.addAll(this.inEdges.keySet());
+            //
+            for (final String label : edgeLabels) {
+                dropLabels.remove(label);
+            }
+            if (dropLabels.size() > 0) {
+                this.dropEdges(direction, dropLabels);
+            }
+        }
+
+        public void dropEdges(final Direction direction) {
+            if ((direction.equals(Direction.OUT) || direction.equals(Direction.BOTH)) && null != this.outEdges) {
+                this.outEdges.clear();
+                this.outEdges = null;
+            }
+            if ((direction.equals(Direction.IN) || direction.equals(Direction.BOTH)) && null != this.inEdges) {
+                this.inEdges.clear();
+                this.inEdges = null;
+            }
+        }
+
+        public void dropEdges(final Direction direction, final Set<String> edgeLabels) {
+            if ((direction.equals(Direction.OUT) || direction.equals(Direction.BOTH)) && null != this.outEdges) {
+                for (final String edgeLabel : edgeLabels) {
+                    this.outEdges.remove(edgeLabel);
+                }
+                if (this.outEdges.isEmpty())
+                    this.outEdges = null;
+            }
+            if ((direction.equals(Direction.IN) || direction.equals(Direction.BOTH)) && null != this.inEdges) {
+                for (final String edgeLabel : edgeLabels) {
+                    this.inEdges.remove(edgeLabel);
+                }
+
+                if (this.inEdges.isEmpty())
+                    this.inEdges = null;
+            }
         }
 
         public void dropVertexProperties(final String... propertyKeys) {
@@ -441,7 +489,7 @@ public final class StarGraph implements Graph, Serializable {
         @Override
         public void remove() {
             if (null != StarGraph.this.starVertex.vertexProperties)
-                StarGraph.this.starVertex.vertexProperties.get(this.label()).remove(this);
+                StarGraph.this.starVertex.vertexProperties.get(this.label).remove(this);
         }
 
         @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
@@ -123,7 +123,7 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
                 }
             }
         }
-        return this.graphFilter.hasFilter() ? this.graphFilter.applyGraphFilter(starGraph).orElse(null) : starGraph;
+        return this.graphFilter.hasFilter() ? starGraph.applyGraphFilter(this.graphFilter).orElse(null) : starGraph;
     }
 
     private void writeEdges(final Kryo kryo, final Output output, final StarGraph starGraph, final Direction direction) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
@@ -99,6 +99,9 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
         }
     }
 
+    /**
+     * If the returned {@link StarGraph} is null, that means that the {@link GraphFilter} filtered the vertex.
+     */
     @Override
     public StarGraph read(final Kryo kryo, final Input input, final Class<StarGraph> aClass) {
         final StarGraph starGraph = StarGraph.open();
@@ -120,7 +123,7 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
                 }
             }
         }
-        return this.graphFilter.applyGraphFilter(starGraph);
+        return this.graphFilter.hasFilter() ? this.graphFilter.applyGraphFilter(starGraph).orElse(null) : starGraph;
     }
 
     private void writeEdges(final Kryo kryo, final Output output, final StarGraph starGraph, final Direction direction) {
@@ -152,7 +155,7 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
                 for (int j = 0; j < numberOfEdgesWithLabel; j++) {
                     final Object edgeId = kryo.readClassAndObject(input);
                     final Object adjacentVertexId = kryo.readClassAndObject(input);
-                    if (this.graphFilter.maybeLegalEdge(direction, edgeLabel)) {
+                    if (this.graphFilter.checkEdgeLegality(direction, edgeLabel).positive()) {
                         if (direction.equals(Direction.OUT))
                             starGraph.starVertex.addOutEdge(edgeLabel, starGraph.addVertex(T.id, adjacentVertexId), T.id, edgeId);
                         else

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphGryoSerializer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.util.star;
 
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -46,6 +47,7 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
     private static final Map<Direction, StarGraphGryoSerializer> CACHE = new HashMap<>();
 
     private final Direction edgeDirectionToSerialize;
+    private GraphFilter graphFilter = new GraphFilter(); // will allow all vertices/edges
 
     private final static byte VERSION_1 = Byte.MIN_VALUE;
 
@@ -66,6 +68,12 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
      */
     public static StarGraphGryoSerializer with(final Direction direction) {
         return CACHE.get(direction);
+    }
+
+    public static StarGraphGryoSerializer withGraphFilter(final GraphFilter graphFilter) {
+        final StarGraphGryoSerializer serializer = new StarGraphGryoSerializer(Direction.BOTH);
+        serializer.graphFilter = graphFilter.clone();
+        return serializer;
     }
 
     @Override
@@ -112,7 +120,7 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
                 }
             }
         }
-        return starGraph;
+        return this.graphFilter.applyGraphFilter(starGraph);
     }
 
     private void writeEdges(final Kryo kryo, final Output output, final StarGraph starGraph, final Direction direction) {
@@ -135,7 +143,7 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
         }
     }
 
-    private static void readEdges(final Kryo kryo, final Input input, final StarGraph starGraph, final Direction direction) {
+    private void readEdges(final Kryo kryo, final Input input, final StarGraph starGraph, final Direction direction) {
         if (kryo.readObject(input, Boolean.class)) {
             final int numberOfUniqueLabels = kryo.readObject(input, Integer.class);
             for (int i = 0; i < numberOfUniqueLabels; i++) {
@@ -144,10 +152,14 @@ public final class StarGraphGryoSerializer extends Serializer<StarGraph> {
                 for (int j = 0; j < numberOfEdgesWithLabel; j++) {
                     final Object edgeId = kryo.readClassAndObject(input);
                     final Object adjacentVertexId = kryo.readClassAndObject(input);
-                    if (direction.equals(Direction.OUT))
-                        starGraph.starVertex.addOutEdge(edgeLabel, starGraph.addVertex(T.id, adjacentVertexId), T.id, edgeId);
-                    else
-                        starGraph.starVertex.addInEdge(edgeLabel, starGraph.addVertex(T.id, adjacentVertexId), T.id, edgeId);
+                    if (this.graphFilter.maybeLegalEdge(direction, edgeLabel)) {
+                        if (direction.equals(Direction.OUT))
+                            starGraph.starVertex.addOutEdge(edgeLabel, starGraph.addVertex(T.id, adjacentVertexId), T.id, edgeId);
+                        else
+                            starGraph.starVertex.addInEdge(edgeLabel, starGraph.addVertex(T.id, adjacentVertexId), T.id, edgeId);
+                    } else if (null != starGraph.edgeProperties) {
+                        starGraph.edgeProperties.remove(edgeId);
+                    }
                 }
             }
         }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java
@@ -231,6 +231,11 @@ public final class IteratorUtils {
             public E next() {
                 return function.apply(iterator.next());
             }
+
+            @Override
+            public void remove() {
+                iterator.remove();
+            }
         };
     }
 
@@ -254,6 +259,11 @@ public final class IteratorUtils {
                     advance();
                     return null != this.nextResult;
                 }
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
             }
 
             @Override
@@ -309,6 +319,11 @@ public final class IteratorUtils {
                     }
                 }
                 return false;
+            }
+
+            @Override
+            public void remove() {
+                this.currentIterator.remove();
             }
 
             @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
@@ -58,6 +58,11 @@ public final class MultiIterator<T> implements Iterator<T>, Serializable {
     }
 
     @Override
+    public void remove() {
+        this.iterators.get(this.current).remove();
+    }
+
+    @Override
     public T next() {
         if (this.iterators.isEmpty()) throw FastNoSuchElementException.instance();
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilterTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilterTest.java
@@ -77,18 +77,18 @@ public class GraphFilterTest {
         //
         graphFilter = new GraphFilter();
         try {
-            graphFilter.setEdgeFilter(__.<Vertex>inE("likes").inV().outE().has("weight", 1));    // cannot leave local star graph
+            graphFilter.setVertexFilter(__.out("likes"));    // cannot leave local vertex
             fail();
         } catch (final IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("local star graph"));
+            assertEquals(e.getMessage(), GraphComputer.Exceptions.vertexFilterAccessesIncidentEdges(__.out("likes")).getMessage());
         }
         //
         graphFilter = new GraphFilter();
         try {
-            graphFilter.setVertexFilter(__.out("likes"));    // cannot leave local vertex
+            graphFilter.setEdgeFilter(__.<Vertex>inE("likes").inV().outE().has("weight", 1));    // cannot leave local star graph
             fail();
         } catch (final IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("local vertex"));
+            assertEquals(e.getMessage(), GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(__.<Vertex>inE("likes").inV().outE().has("weight", 1)).getMessage());
         }
     }
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilterTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilterTest.java
@@ -19,78 +19,10 @@
 
 package org.apache.tinkerpop.gremlin.process.computer;
 
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class GraphFilterTest {
-
-    @Test
-    public void shouldHandlePreFilterCorrectly() {
-        GraphFilter graphFilter = new GraphFilter();
-        graphFilter.setEdgeFilter(__.<Vertex>bothE().limit(0));
-        assertTrue(graphFilter.allowedEdgeLabels.isEmpty());
-        assertEquals(Direction.BOTH, graphFilter.allowedEdgeDirection);
-        assertFalse(graphFilter.allowAllRemainingEdges);
-        //
-        graphFilter = new GraphFilter();
-        graphFilter.setEdgeFilter(__.<Vertex>bothE("knows").limit(0));
-        assertEquals(1, graphFilter.allowedEdgeLabels.size());
-        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
-        assertEquals(Direction.BOTH, graphFilter.allowedEdgeDirection);
-        assertFalse(graphFilter.allowAllRemainingEdges);
-        //
-        graphFilter = new GraphFilter();
-        graphFilter.setEdgeFilter(__.<Vertex>outE("knows", "created"));
-        assertEquals(2, graphFilter.allowedEdgeLabels.size());
-        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
-        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
-        assertEquals(Direction.OUT, graphFilter.allowedEdgeDirection);
-        assertTrue(graphFilter.allowAllRemainingEdges);
-        //
-        graphFilter = new GraphFilter();
-        graphFilter.setEdgeFilter(__.<Vertex>inE("knows", "created", "likes"));
-        assertEquals(3, graphFilter.allowedEdgeLabels.size());
-        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
-        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
-        assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
-        assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
-        assertTrue(graphFilter.allowAllRemainingEdges);
-        //
-        graphFilter = new GraphFilter();
-        graphFilter.setEdgeFilter(__.<Vertex>inE("knows", "created", "likes"));
-        assertEquals(3, graphFilter.allowedEdgeLabels.size());
-        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
-        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
-        assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
-        assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
-        assertTrue(graphFilter.allowAllRemainingEdges);
-        //
-        graphFilter = new GraphFilter();
-        try {
-            graphFilter.setVertexFilter(__.out("likes"));    // cannot leave local vertex
-            fail();
-        } catch (final IllegalArgumentException e) {
-            assertEquals(e.getMessage(), GraphComputer.Exceptions.vertexFilterAccessesIncidentEdges(__.out("likes")).getMessage());
-        }
-        //
-        graphFilter = new GraphFilter();
-        try {
-            graphFilter.setEdgeFilter(__.<Vertex>inE("likes").inV().outE().has("weight", 1));    // cannot leave local star graph
-            fail();
-        } catch (final IllegalArgumentException e) {
-            assertEquals(e.getMessage(), GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(__.<Vertex>inE("likes").inV().outE().has("weight", 1)).getMessage());
-        }
-    }
 
     /*@Test
     public void shouldHandleStarGraph() {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilterTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/computer/GraphFilterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class GraphFilterTest {
+
+    @Test
+    public void shouldHandlePreFilterCorrectly() {
+        final GraphFilter graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex>bothE().limit(0));
+        assertTrue(graphFilter.allowedEdgeLabels.isEmpty());
+        assertEquals(Direction.BOTH, graphFilter.allowedEdgeDirection);
+        assertFalse(graphFilter.allowAllRemainingEdges);
+        //
+        graphFilter.setEdgeFilter(__.<Vertex>bothE("knows").limit(0));
+        assertEquals(1, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertEquals(Direction.BOTH, graphFilter.allowedEdgeDirection);
+        assertFalse(graphFilter.allowAllRemainingEdges);
+        //
+        graphFilter.setEdgeFilter(__.<Vertex>outE("knows", "created"));
+        assertEquals(2, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
+        assertEquals(Direction.OUT, graphFilter.allowedEdgeDirection);
+        assertTrue(graphFilter.allowAllRemainingEdges);
+        //
+        graphFilter.setEdgeFilter(__.<Vertex>inE("knows", "created", "likes"));
+        assertEquals(3, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
+        assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
+        assertTrue(graphFilter.allowAllRemainingEdges);
+        //
+        graphFilter.setEdgeFilter(__.<Vertex>inE("knows", "created", "likes").has("weight", 1));
+        assertEquals(3, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
+        assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
+        assertFalse(graphFilter.allowAllRemainingEdges);
+    }
+
+    /*@Test
+    public void shouldHandleStarGraph() {
+        final StarGraph graph = StarGraph.open();
+        final Vertex vertex = graph.addVertex("person");
+        for (int i = 0; i < 10; i++) {
+            vertex.addEdge("created", graph.addVertex(i < 5 ? "software" : "hardware"), "weight", 1);
+        }
+        final GraphFilter graphFilter = new GraphFilter();
+    }*/
+}

--- a/gremlin-groovy/src/test/groovy/org/apache/tinkerpop/gremlin/process/computer/GroovyGraphFilterTest.groovy
+++ b/gremlin-groovy/src/test/groovy/org/apache/tinkerpop/gremlin/process/computer/GroovyGraphFilterTest.groovy
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
+import org.apache.tinkerpop.gremlin.structure.Direction
+import org.apache.tinkerpop.gremlin.structure.Vertex
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class GroovyGraphFilterTest {
+
+    @Test
+    public void shouldHandlePreFilterCorrectly() {
+        GraphFilter graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex> bothE().limit(0));
+        assertTrue(graphFilter.allowNoEdges);
+        //
+        graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex> bothE("knows").limit(0));
+        assertTrue(graphFilter.allowNoEdges);
+        //
+        graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex> bothE("knows").select("a"));
+        assertEquals(1, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertEquals(Direction.BOTH, graphFilter.allowedEdgeDirection);
+        assertFalse(graphFilter.allowAllRemainingEdges);
+        assertFalse(graphFilter.allowNoEdges);
+        //
+        graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex> outE("knows", "created"));
+        assertEquals(2, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
+        assertEquals(Direction.OUT, graphFilter.allowedEdgeDirection);
+        assertTrue(graphFilter.allowAllRemainingEdges);
+        assertFalse(graphFilter.allowNoEdges);
+        //
+        graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex> inE("knows", "created", "likes"));
+        assertEquals(3, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
+        assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
+        assertTrue(graphFilter.allowAllRemainingEdges);
+        assertFalse(graphFilter.allowNoEdges);
+        //
+        graphFilter = new GraphFilter();
+        graphFilter.setEdgeFilter(__.<Vertex> inE("knows", "created", "likes"));
+        assertEquals(3, graphFilter.allowedEdgeLabels.size());
+        assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
+        assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
+        assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
+        assertTrue(graphFilter.allowAllRemainingEdges);
+        assertFalse(graphFilter.allowNoEdges);
+        //
+        graphFilter = new GraphFilter();
+        try {
+            graphFilter.setVertexFilter(__.out("likes"));    // cannot leave local vertex
+            fail();
+        } catch (final IllegalArgumentException e) {
+            assertEquals(e.getMessage(), GraphComputer.Exceptions.vertexFilterAccessesIncidentEdges(__.out("likes")).getMessage());
+        }
+        //
+        graphFilter = new GraphFilter();
+        try {
+            graphFilter.setEdgeFilter(__.<Vertex> inE("likes").inV().outE().has("weight", 1));
+            // cannot leave local star graph
+            fail();
+        } catch (final IllegalArgumentException e) {
+            assertEquals(e.getMessage(), GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(__.<Vertex> inE("likes").inV().outE().has("weight", 1)).getMessage());
+        }
+    }
+}

--- a/gremlin-groovy/src/test/groovy/org/apache/tinkerpop/gremlin/process/computer/GroovyGraphFilterTest.groovy
+++ b/gremlin-groovy/src/test/groovy/org/apache/tinkerpop/gremlin/process/computer/GroovyGraphFilterTest.groovy
@@ -46,7 +46,7 @@ public class GroovyGraphFilterTest {
         assertEquals(1, graphFilter.allowedEdgeLabels.size());
         assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
         assertEquals(Direction.BOTH, graphFilter.allowedEdgeDirection);
-        assertFalse(graphFilter.allowAllRemainingEdges);
+        //assertFalse(graphFilter.allowAllRemainingEdges);
         assertFalse(graphFilter.allowNoEdges);
         //
         graphFilter = new GraphFilter();
@@ -55,7 +55,7 @@ public class GroovyGraphFilterTest {
         assertTrue(graphFilter.allowedEdgeLabels.contains("knows"));
         assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
         assertEquals(Direction.OUT, graphFilter.allowedEdgeDirection);
-        assertTrue(graphFilter.allowAllRemainingEdges);
+        //assertTrue(graphFilter.allowAllRemainingEdges);
         assertFalse(graphFilter.allowNoEdges);
         //
         graphFilter = new GraphFilter();
@@ -65,7 +65,7 @@ public class GroovyGraphFilterTest {
         assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
         assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
         assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
-        assertTrue(graphFilter.allowAllRemainingEdges);
+        //assertTrue(graphFilter.allowAllRemainingEdges);
         assertFalse(graphFilter.allowNoEdges);
         //
         graphFilter = new GraphFilter();
@@ -75,7 +75,7 @@ public class GroovyGraphFilterTest {
         assertTrue(graphFilter.allowedEdgeLabels.contains("created"));
         assertTrue(graphFilter.allowedEdgeLabels.contains("likes"));
         assertEquals(Direction.IN, graphFilter.allowedEdgeDirection);
-        assertTrue(graphFilter.allowAllRemainingEdges);
+        //assertTrue(graphFilter.allowAllRemainingEdges);
         assertFalse(graphFilter.allowNoEdges);
         //
         graphFilter = new GraphFilter();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -34,7 +34,6 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -1394,7 +1393,6 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
     /////////////////////////////////////////////
 
     @Test
-    @Ignore
     @LoadGraphWith(GRATEFUL)
     public void shouldSupportWorkerCount() throws Exception {
         int maxWorkers = graph.compute(graphComputerClass.get()).features().getMaxWorkers();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -69,7 +69,9 @@ import static org.junit.Assert.fail;
         "adjacentVertexEdgesAndVerticesCanNotBeReadOrUpdated",
         "resultGraphPersistCombinationNotSupported",
         "vertexPropertiesCanNotBeUpdatedInMapReduce",
-        "computerRequiresMoreWorkersThanSupported"
+        "computerRequiresMoreWorkersThanSupported",
+        "vertexFilterAccessesIncidentEdges",
+        "edgeFilterAccessesAdjacentVertices"
 })
 @ExceptionCoverage(exceptionClass = Graph.Exceptions.class, methods = {
         "graphDoesNotSupportProvidedGraphComputer"
@@ -1505,6 +1507,20 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
         graph.compute(graphComputerClass.get()).edges(__.<Vertex>bothE().limit(0)).mapReduce(new MapReduceJ(VertexProgramM.VERTICES_ONLY)).submit().get();
         graph.compute(graphComputerClass.get()).edges(__.<Vertex>outE().limit(1)).mapReduce(new MapReduceJ(VertexProgramM.ONE_OUT_EDGE_ONLY)).submit().get();
         graph.compute(graphComputerClass.get()).edges(__.outE()).mapReduce(new MapReduceJ(VertexProgramM.OUT_EDGES_ONLY)).submit().get();
+
+        // EXCEPTION HANDLING
+        try {
+            graph.compute(graphComputerClass.get()).vertices(__.out());
+            fail();
+        } catch (final IllegalArgumentException e) {
+            assertEquals(e.getMessage(), GraphComputer.Exceptions.vertexFilterAccessesIncidentEdges(__.out()).getMessage());
+        }
+        try {
+            graph.compute(graphComputerClass.get()).edges(__.<Vertex>out().outE());
+            fail();
+        } catch (final IllegalArgumentException e) {
+            assertEquals(e.getMessage(), GraphComputer.Exceptions.edgeFilterAccessesAdjacentVertices(__.<Vertex>out().outE()).getMessage());
+        }
     }
 
     public static class VertexProgramM implements VertexProgram {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -1488,6 +1488,16 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void shouldSupportGraphFilter() throws Exception {
+        /// VERTEX PROGRAM
+        graph.compute(graphComputerClass.get()).vertices(__.hasLabel("software")).program(new VertexProgramM(VertexProgramM.SOFTWARE_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).vertices(__.hasLabel("person")).program(new VertexProgramM(VertexProgramM.PEOPLE_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).edges(__.bothE("knows")).program(new VertexProgramM(VertexProgramM.KNOWS_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).vertices(__.hasLabel("person")).edges(__.bothE("knows")).program(new VertexProgramM(VertexProgramM.PEOPLE_KNOWS_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).vertices(__.hasLabel("person")).edges(__.<Vertex>bothE("knows").has("weight", P.gt(0.5f))).program(new VertexProgramM(VertexProgramM.PEOPLE_KNOWS_WELL_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).edges(__.<Vertex>bothE().limit(0)).program(new VertexProgramM(VertexProgramM.VERTICES_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).edges(__.<Vertex>outE().limit(1)).program(new VertexProgramM(VertexProgramM.ONE_OUT_EDGE_ONLY)).submit().get();
+        graph.compute(graphComputerClass.get()).edges(__.outE()).program(new VertexProgramM(VertexProgramM.OUT_EDGES_ONLY)).submit().get();
+
         /// VERTEX PROGRAM + MAP REDUCE
         graph.compute(graphComputerClass.get()).vertices(__.hasLabel("software")).program(new VertexProgramM(VertexProgramM.SOFTWARE_ONLY)).mapReduce(new MapReduceJ(VertexProgramM.SOFTWARE_ONLY)).submit().get();
         graph.compute(graphComputerClass.get()).vertices(__.hasLabel("person")).program(new VertexProgramM(VertexProgramM.PEOPLE_ONLY)).mapReduce(new MapReduceJ(VertexProgramM.PEOPLE_ONLY)).submit().get();

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -34,6 +34,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
@@ -38,8 +38,7 @@ public final class Constants {
     public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphInputFormat.hasEdges";
     public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphOutputFormat.hasEdges";
 
-    public static final String GREMLIN_HADOOP_VERTEX_FILTER = "gremlin.hadoop.vertexFilter";
-    public static final String GREMLIN_HADOOP_EDGE_FILTER = "gremlin.hadoop.edgeFilter";
+    public static final String GREMLIN_HADOOP_GRAPH_FILTER = "gremlin.hadoop.graphFilter";
 
     public static final String GREMLIN_HADOOP_JARS_IN_DISTRIBUTED_CACHE = "gremlin.hadoop.jarsInDistributedCache";
     public static final String HIDDEN_G = Graph.Hidden.hide("g");

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
@@ -38,6 +38,9 @@ public final class Constants {
     public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphOutputFormat.hasEdges";
     public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphInputFormat.hasEdges";
 
+    public static final String GREMLIN_HADOOP_VERTEX_FILTER = "gremlin.hadoop.vertexFilter";
+    public static final String GREMLIN_HADOOP_EDGE_FILTER = "gremlin.hadoop.edgeFilter";
+
     public static final String GREMLIN_HADOOP_JARS_IN_DISTRIBUTED_CACHE = "gremlin.hadoop.jarsInDistributedCache";
     public static final String HIDDEN_G = Graph.Hidden.hide("g");
     public static final String GREMLIN_HADOOP_JOB_PREFIX = "HadoopGremlin: ";

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/Constants.java
@@ -35,8 +35,8 @@ public final class Constants {
     public static final String GREMLIN_HADOOP_OUTPUT_LOCATION = "gremlin.hadoop.outputLocation";
     public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT = "gremlin.hadoop.graphInputFormat";
     public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT = "gremlin.hadoop.graphOutputFormat";
-    public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphOutputFormat.hasEdges";
-    public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphInputFormat.hasEdges";
+    public static final String GREMLIN_HADOOP_GRAPH_INPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphInputFormat.hasEdges";
+    public static final String GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES = "gremlin.hadoop.graphOutputFormat.hasEdges";
 
     public static final String GREMLIN_HADOOP_VERTEX_FILTER = "gremlin.hadoop.vertexFilter";
     public static final String GREMLIN_HADOOP_EDGE_FILTER = "gremlin.hadoop.edgeFilter";

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -29,6 +29,9 @@ import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.GraphComputerHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,9 +55,24 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
     protected ResultGraph resultGraph = null;
     protected Persist persist = null;
 
+    protected Traversal.Admin<Vertex, Vertex> vertexFilter = null;
+    protected Traversal.Admin<Vertex, Edge> edgeFilter = null;
+
     public AbstractHadoopGraphComputer(final HadoopGraph hadoopGraph) {
         this.hadoopGraph = hadoopGraph;
         this.logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @Override
+    public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter) {
+        this.vertexFilter = vertexFilter.asAdmin();
+        return this;
+    }
+
+    @Override
+    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
+        this.edgeFilter = edgeFilter.asAdmin();
+        return this;
     }
 
     @Override

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -56,7 +56,7 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
     protected Persist persist = null;
 
     protected Traversal.Admin<Vertex, Vertex> vertexFilter = null;
-    protected Traversal.Admin<Vertex, Edge> edgeFilter = null;
+    protected Traversal.Admin<Edge, Edge> edgeFilter = null;
 
     public AbstractHadoopGraphComputer(final HadoopGraph hadoopGraph) {
         this.hadoopGraph = hadoopGraph;
@@ -70,7 +70,7 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
     }
 
     @Override
-    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
+    public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter) {
         this.edgeFilter = edgeFilter.asAdmin();
         return this;
     }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -70,7 +70,7 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
     }
 
     @Override
-    public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter) {
+    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
         this.graphFilter.setEdgeFilter(edgeFilter);
         return this;
     }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.GraphComputerHelper;
@@ -55,8 +56,7 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
     protected ResultGraph resultGraph = null;
     protected Persist persist = null;
 
-    protected Traversal.Admin<Vertex, Vertex> vertexFilter = null;
-    protected Traversal.Admin<Edge, Edge> edgeFilter = null;
+    protected GraphFilter graphFilter = new GraphFilter();
 
     public AbstractHadoopGraphComputer(final HadoopGraph hadoopGraph) {
         this.hadoopGraph = hadoopGraph;
@@ -65,13 +65,13 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
 
     @Override
     public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter) {
-        this.vertexFilter = vertexFilter.asAdmin();
+        this.graphFilter.setVertexFilter(vertexFilter);
         return this;
     }
 
     @Override
     public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter) {
-        this.edgeFilter = edgeFilter.asAdmin();
+        this.graphFilter.setEdgeFilter(edgeFilter);
         return this;
     }
 

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterInputFormat.java
@@ -16,28 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.tinkerpop.gremlin.hadoop.structure.io.script;
 
+package org.apache.tinkerpop.gremlin.hadoop.process.computer;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
- * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class ScriptInputFormat extends CommonFileInputFormat {
+public final class GraphFilterInputFormat extends InputFormat<NullWritable, VertexWritable> {
 
     @Override
-    public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException {
-        RecordReader<NullWritable, VertexWritable> reader = new ScriptRecordReader();
-        reader.initialize(split, context);
-        return reader;
+    public List<InputSplit> getSplits(final JobContext jobContext) throws IOException, InterruptedException {
+        final Configuration configuration = jobContext.getConfiguration();
+        return ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputFormat.class, InputFormat.class), configuration).getSplits(jobContext);
+    }
+
+    @Override
+    public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+        final GraphFilterRecordReader recordReader = new GraphFilterRecordReader();
+        recordReader.initialize(inputSplit, taskAttemptContext);
+        return recordReader;
     }
 
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterInputFormat.java
@@ -28,15 +28,22 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.tinkerpop.gremlin.hadoop.Constants;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 
 import java.io.IOException;
 import java.util.List;
 
 /**
+ * GraphFilterInputFormat is a utility {@link InputFormat} that is useful if the underlying InputFormat is not {@link GraphFilterAware}.
+ * If the underlying InputFormat is GraphFilterAware, then GraphFilterInputFormat acts as an identity mapping.
+ * If the underlying InputFormat is not GraphFilterAware, then GraphFilterInputFormat will apply the respective {@link GraphFilter}
+ * and prune the loaded source graph data accordingly.
+ *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GraphFilterInputFormat extends InputFormat<NullWritable, VertexWritable> {
+public final class GraphFilterInputFormat extends InputFormat<NullWritable, VertexWritable> implements GraphFilterAware {
 
     @Override
     public List<InputSplit> getSplits(final JobContext jobContext) throws IOException, InterruptedException {
@@ -46,9 +53,11 @@ public final class GraphFilterInputFormat extends InputFormat<NullWritable, Vert
 
     @Override
     public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
-        final GraphFilterRecordReader recordReader = new GraphFilterRecordReader();
-        recordReader.initialize(inputSplit, taskAttemptContext);
-        return recordReader;
+        return new GraphFilterRecordReader();
     }
 
+    @Override
+    public void setGraphFilter(final GraphFilter graphFilter) {
+        // do nothing -- loaded via configuration
+    }
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterRecordReader.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.hadoop.process.computer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
+import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
+import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
+import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class GraphFilterRecordReader extends RecordReader<NullWritable, VertexWritable> {
+
+    private GraphFilter graphFilter = null;
+    private RecordReader<NullWritable, VertexWritable> recordReader;
+
+    public GraphFilterRecordReader() {
+    }
+
+    @Override
+    public void initialize(final InputSplit inputSplit, final TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+        final Configuration configuration = taskAttemptContext.getConfiguration();
+        final InputFormat<NullWritable, VertexWritable> inputFormat = ReflectionUtils.newInstance(configuration.getClass(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputFormat.class, InputFormat.class), configuration);
+        if (!(inputFormat instanceof GraphFilterAware) && configuration.get(Constants.GREMLIN_HADOOP_GRAPH_FILTER, null) != null)
+            this.graphFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(configuration), Constants.GREMLIN_HADOOP_GRAPH_FILTER);
+        this.recordReader = inputFormat.createRecordReader(inputSplit, taskAttemptContext);
+        this.recordReader.initialize(inputSplit, taskAttemptContext);
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+        if (null == this.graphFilter) {
+            return this.recordReader.nextKeyValue();
+        } else {
+            while (true) {
+                if (this.recordReader.nextKeyValue()) {
+                    final VertexWritable vertexWritable = this.recordReader.getCurrentValue();
+                    final Optional<StarGraph.StarVertex> vertex = this.graphFilter.applyGraphFilter(vertexWritable.get());
+                    if (vertex.isPresent()) {
+                        vertexWritable.set(vertex.get());
+                        return true;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+
+    @Override
+    public NullWritable getCurrentKey() throws IOException, InterruptedException {
+        return NullWritable.get();
+    }
+
+    @Override
+    public VertexWritable getCurrentValue() throws IOException, InterruptedException {
+        return this.recordReader.getCurrentValue();
+    }
+
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+        return this.recordReader.getProgress();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.recordReader.close();
+    }
+}

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/GraphFilterRecordReader.java
@@ -66,7 +66,7 @@ public final class GraphFilterRecordReader extends RecordReader<NullWritable, Ve
             while (true) {
                 if (this.recordReader.nextKeyValue()) {
                     final VertexWritable vertexWritable = this.recordReader.getCurrentValue();
-                    final Optional<StarGraph.StarVertex> vertex = this.graphFilter.applyGraphFilter(vertexWritable.get());
+                    final Optional<StarGraph.StarVertex> vertex = vertexWritable.get().applyGraphFilter(this.graphFilter);
                     if (vertex.isPresent()) {
                         vertexWritable.set(vertex.get());
                         return true;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/util/MapReduceHelper.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/util/MapReduceHelper.java
@@ -22,7 +22,6 @@ import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.OutputFormat;
@@ -32,6 +31,7 @@ import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
 import org.apache.tinkerpop.gremlin.hadoop.Constants;
+import org.apache.tinkerpop.gremlin.hadoop.process.computer.GraphFilterInputFormat;
 import org.apache.tinkerpop.gremlin.hadoop.process.computer.HadoopCombine;
 import org.apache.tinkerpop.gremlin.hadoop.process.computer.HadoopMap;
 import org.apache.tinkerpop.gremlin.hadoop.process.computer.HadoopReduce;
@@ -72,6 +72,8 @@ public final class MapReduceHelper {
             final Optional<Comparator<?>> reduceSort = mapReduce.getReduceKeySort();
 
             newConfiguration.setClass(Constants.GREMLIN_HADOOP_MAP_REDUCE_CLASS, mapReduce.getClass(), MapReduce.class);
+            if (vertexProgramExists)
+                newConfiguration.set(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputOutputHelper.getInputFormat((Class) newConfiguration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class)).getCanonicalName());
             final Job job = Job.getInstance(newConfiguration, mapReduce.toString());
             HadoopGraph.LOGGER.info(Constants.GREMLIN_HADOOP_JOB_PREFIX + mapReduce.toString());
             job.setJarByClass(HadoopGraph.class);
@@ -94,9 +96,7 @@ public final class MapReduceHelper {
             job.setMapOutputValueClass(ObjectWritable.class);
             job.setOutputKeyClass(ObjectWritable.class);
             job.setOutputValueClass(ObjectWritable.class);
-            job.setInputFormatClass(vertexProgramExists ?
-                    InputOutputHelper.getInputFormat((Class) newConfiguration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class)) :
-                    (Class) newConfiguration.getClass(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputFormat.class));
+            job.setInputFormatClass(GraphFilterInputFormat.class);
             job.setOutputFormatClass(SequenceFileOutputFormat.class);
             // if there is no vertex program, then grab the graph from the input location
             final Path graphPath = vertexProgramExists ?
@@ -130,7 +130,7 @@ public final class MapReduceHelper {
                 FileSystem.get(newConfiguration).delete(memoryPath, true); // delete the temporary memory path
                 memoryPath = sortedMemoryPath;
             }
-            mapReduce.addResultToMemory(memory, new ObjectWritableIterator(configuration, memoryPath));
+            mapReduce.addResultToMemory(memory, new ObjectWritableIterator(newConfiguration, memoryPath));
         }
     }
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/util/MapReduceHelper.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/util/MapReduceHelper.java
@@ -72,8 +72,10 @@ public final class MapReduceHelper {
             final Optional<Comparator<?>> reduceSort = mapReduce.getReduceKeySort();
 
             newConfiguration.setClass(Constants.GREMLIN_HADOOP_MAP_REDUCE_CLASS, mapReduce.getClass(), MapReduce.class);
-            if (vertexProgramExists)
+            if (vertexProgramExists) {
                 newConfiguration.set(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputOutputHelper.getInputFormat((Class) newConfiguration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, OutputFormat.class)).getCanonicalName());
+                newConfiguration.unset(Constants.GREMLIN_HADOOP_GRAPH_FILTER);
+            }
             final Job job = Job.getInstance(newConfiguration, mapReduce.toString());
             HadoopGraph.LOGGER.info(Constants.GREMLIN_HADOOP_JOB_PREFIX + mapReduce.toString());
             job.setJarByClass(HadoopGraph.class);

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.hadoop.structure.io;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.tinkerpop.gremlin.hadoop.Constants;
+import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
+import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.Iterator;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class CommonFileInputFormat extends FileInputFormat<NullWritable, VertexWritable> implements HadoopPoolsConfigurable, GraphFilterAware {
+
+    protected Traversal.Admin<Vertex, Vertex> vertexFilter = null;
+    protected Traversal.Admin<Edge, Edge> edgeFilter = null;
+    private boolean filtersLoader = false;
+
+    protected void loadVertexAndEdgeFilters(final TaskAttemptContext context) {
+        if (!this.filtersLoader) {
+            if (context.getConfiguration().get(Constants.GREMLIN_HADOOP_VERTEX_FILTER, null) != null)
+                this.vertexFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(context.getConfiguration()), Constants.GREMLIN_HADOOP_VERTEX_FILTER);
+            if (context.getConfiguration().get(Constants.GREMLIN_HADOOP_EDGE_FILTER, null) != null)
+                this.edgeFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(context.getConfiguration()), Constants.GREMLIN_HADOOP_EDGE_FILTER);
+            this.filtersLoader = true;
+        }
+    }
+
+    @Override
+    protected boolean isSplitable(final JobContext context, final Path file) {
+        return null == new CompressionCodecFactory(context.getConfiguration()).getCodec(file);
+    }
+
+    @Override
+    public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter) {
+        // do nothing. loaded through configuration.
+    }
+
+    @Override
+    public void setEdgeFilter(final Traversal<Edge, Edge> edgeFilter) {
+        // do nothing. loaded through configuration.
+    }
+
+    public static final Vertex applyVertexAndEdgeFilters(final Vertex vertex, final Traversal.Admin<Vertex, Vertex> vertexFilter, final Traversal.Admin<Edge, Edge> edgeFilter) {
+        if (null == vertex)
+            return null;
+        else if (vertexFilter == null || TraversalUtil.test(vertex, vertexFilter)) {
+            if (edgeFilter != null) {
+                final Iterator<Edge> edgeIterator = vertex.edges(Direction.BOTH);
+                while (edgeIterator.hasNext()) {
+                    if (!TraversalUtil.test(edgeIterator.next(), edgeFilter))
+                        edgeIterator.remove();
+                }
+            }
+            return vertex;
+        } else {
+            return null;
+        }
+    }
+}

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
@@ -23,28 +23,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.tinkerpop.gremlin.hadoop.Constants;
-import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
-import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public abstract class CommonFileInputFormat extends FileInputFormat<NullWritable, VertexWritable> implements HadoopPoolsConfigurable, GraphFilterAware {
-
-    protected GraphFilter graphFilter = new GraphFilter();
-    private boolean graphFilterLoaded = false;
-
-    protected void loadVertexAndEdgeFilters(final TaskAttemptContext context) {
-        if (!this.graphFilterLoaded) {
-            if (context.getConfiguration().get(Constants.GREMLIN_HADOOP_GRAPH_FILTER, null) != null)
-                this.graphFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(context.getConfiguration()), Constants.GREMLIN_HADOOP_GRAPH_FILTER);
-            this.graphFilterLoaded = true;
-        }
-    }
 
     @Override
     protected boolean isSplitable(final JobContext context, final Path file) {

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
@@ -29,12 +29,8 @@ import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
 import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-
-import java.util.Iterator;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -68,22 +64,5 @@ public abstract class CommonFileInputFormat extends FileInputFormat<NullWritable
     @Override
     public void setEdgeFilter(final Traversal<Edge, Edge> edgeFilter) {
         // do nothing. loaded through configuration.
-    }
-
-    public static final Vertex applyVertexAndEdgeFilters(final Vertex vertex, final Traversal.Admin<Vertex, Vertex> vertexFilter, final Traversal.Admin<Edge, Edge> edgeFilter) {
-        if (null == vertex)
-            return null;
-        else if (vertexFilter == null || TraversalUtil.test(vertex, vertexFilter)) {
-            if (edgeFilter != null) {
-                final Iterator<Edge> edgeIterator = vertex.edges(Direction.BOTH);
-                while (edgeIterator.hasNext()) {
-                    if (!TraversalUtil.test(edgeIterator.next(), edgeFilter))
-                        edgeIterator.remove();
-                }
-            }
-            return vertex;
-        } else {
-            return null;
-        }
     }
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileInputFormat.java
@@ -27,27 +27,22 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public abstract class CommonFileInputFormat extends FileInputFormat<NullWritable, VertexWritable> implements HadoopPoolsConfigurable, GraphFilterAware {
 
-    protected Traversal.Admin<Vertex, Vertex> vertexFilter = null;
-    protected Traversal.Admin<Edge, Edge> edgeFilter = null;
-    private boolean filtersLoader = false;
+    protected GraphFilter graphFilter = new GraphFilter();
+    private boolean graphFilterLoaded = false;
 
     protected void loadVertexAndEdgeFilters(final TaskAttemptContext context) {
-        if (!this.filtersLoader) {
-            if (context.getConfiguration().get(Constants.GREMLIN_HADOOP_VERTEX_FILTER, null) != null)
-                this.vertexFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(context.getConfiguration()), Constants.GREMLIN_HADOOP_VERTEX_FILTER);
-            if (context.getConfiguration().get(Constants.GREMLIN_HADOOP_EDGE_FILTER, null) != null)
-                this.edgeFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(context.getConfiguration()), Constants.GREMLIN_HADOOP_EDGE_FILTER);
-            this.filtersLoader = true;
+        if (!this.graphFilterLoaded) {
+            if (context.getConfiguration().get(Constants.GREMLIN_HADOOP_GRAPH_FILTER, null) != null)
+                this.graphFilter = VertexProgramHelper.deserialize(ConfUtil.makeApacheConfiguration(context.getConfiguration()), Constants.GREMLIN_HADOOP_GRAPH_FILTER);
+            this.graphFilterLoaded = true;
         }
     }
 
@@ -57,12 +52,7 @@ public abstract class CommonFileInputFormat extends FileInputFormat<NullWritable
     }
 
     @Override
-    public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter) {
-        // do nothing. loaded through configuration.
-    }
-
-    @Override
-    public void setEdgeFilter(final Traversal<Edge, Edge> edgeFilter) {
+    public void setGraphFilter(final GraphFilter graphFilter) {
         // do nothing. loaded through configuration.
     }
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileOutputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/CommonFileOutputFormat.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  */
 public abstract class CommonFileOutputFormat extends FileOutputFormat<NullWritable, VertexWritable> implements PersistResultGraphAware {
 
-    protected DataOutputStream getDataOuputStream(final TaskAttemptContext job) throws IOException, InterruptedException {
+    protected DataOutputStream getDataOutputStream(final TaskAttemptContext job) throws IOException, InterruptedException {
         final Configuration conf = job.getConfiguration();
         boolean isCompressed = getCompressOutput(job);
         CompressionCodec codec = null;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/GraphFilterAware.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/GraphFilterAware.java
@@ -23,12 +23,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
-import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-
-import java.util.Iterator;
 
 /**
  * An input graph class is {@code GraphFilterAware} if it can filter out vertices and edges as its loading the graph from the

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/GraphFilterAware.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/GraphFilterAware.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.hadoop.structure.io;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+/**
+ * An input graph class is {@code GraphFilterAware} if it can filter out vertices and edges as its loading the graph from the
+ * source data. Any input class that is {@code GraphFilterAware} must be able to fully handle both vertex and edge filtering.
+ * It is assumed that if the input class is {@code GraphFilterAware}, then the respective
+ * {@link org.apache.tinkerpop.gremlin.process.computer.GraphComputer} will not perform any filtering on the loaded graph.
+ *
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public interface GraphFilterAware {
+
+    public void setVertexFilter(final Traversal<Vertex, Vertex> vertexFilter);
+
+    public void setEdgeFilter(final Traversal<Edge, Edge> edgeFilter);
+}

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/GraphFilterAware.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/GraphFilterAware.java
@@ -42,23 +42,6 @@ public interface GraphFilterAware {
 
     public void setGraphFilter(final GraphFilter graphFilter);
 
-    public static Vertex applyGraphFilter(final Vertex vertex, final GraphFilter graphFilter) {
-        if (null == vertex)
-            return null;
-        else if (!graphFilter.hasVertexFilter() || TraversalUtil.test(vertex, graphFilter.getVertexFilter())) {
-            if (graphFilter.hasEdgeFilter()) {
-                final Iterator<Edge> edgeIterator = vertex.edges(Direction.BOTH);
-                while (edgeIterator.hasNext()) {
-                    if (!TraversalUtil.test(edgeIterator.next(), graphFilter.getEdgeFilter()))
-                        edgeIterator.remove();
-                }
-            }
-            return vertex;
-        } else {
-            return null;
-        }
-    }
-
     public static void storeGraphFilter(final Configuration apacheConfiguration, final org.apache.hadoop.conf.Configuration hadoopConfiguration, final GraphFilter graphFilter) {
         if (graphFilter.hasFilter()) {
             VertexProgramHelper.serialize(graphFilter, apacheConfiguration, Constants.GREMLIN_HADOOP_GRAPH_FILTER);

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritableIterator.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/ObjectWritableIterator.java
@@ -24,11 +24,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.tinkerpop.gremlin.process.computer.KeyValue;
-import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 
 /**
@@ -77,7 +77,7 @@ public final class ObjectWritableIterator implements Iterator<KeyValue> {
             } else {
                 while (true) {
                     if (this.readers.isEmpty())
-                        throw FastNoSuchElementException.instance();
+                        throw new NoSuchElementException();
                     if (this.readers.peek().next(this.key, this.value)) {
                         return new KeyValue<>(this.key.get(), this.value.get());
                     } else

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/VertexWritableIterator.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/VertexWritableIterator.java
@@ -23,12 +23,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
-import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 
 /**
@@ -76,7 +76,7 @@ public final class VertexWritableIterator implements Iterator<Vertex> {
             } else {
                 while (true) {
                     if (this.readers.isEmpty())
-                        throw FastNoSuchElementException.instance();
+                        throw new NoSuchElementException();
                     if (this.readers.peek().next(this.value)) {
                         return this.value.get();
                     } else

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/graphson/GraphSONOutputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/graphson/GraphSONOutputFormat.java
@@ -34,7 +34,7 @@ public final class GraphSONOutputFormat extends CommonFileOutputFormat implement
 
     @Override
     public RecordWriter<NullWritable, VertexWritable> getRecordWriter(final TaskAttemptContext job) throws IOException, InterruptedException {
-        return new GraphSONRecordWriter(getDataOuputStream(job), job.getConfiguration());
+        return new GraphSONRecordWriter(getDataOutputStream(job), job.getConfiguration());
     }
 
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoInputFormat.java
@@ -34,8 +34,7 @@ public final class GryoInputFormat extends CommonFileInputFormat {
 
     @Override
     public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException {
-        super.loadVertexAndEdgeFilters(context);
-        final RecordReader<NullWritable, VertexWritable> reader = new GryoRecordReader(this.graphFilter);
+        final RecordReader<NullWritable, VertexWritable> reader = new GryoRecordReader();
         reader.initialize(split, context);
         return reader;
     }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoInputFormat.java
@@ -35,7 +35,7 @@ public final class GryoInputFormat extends CommonFileInputFormat {
     @Override
     public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException {
         super.loadVertexAndEdgeFilters(context);
-        final RecordReader<NullWritable, VertexWritable> reader = new GryoRecordReader(this.vertexFilter, this.edgeFilter);
+        final RecordReader<NullWritable, VertexWritable> reader = new GryoRecordReader(this.graphFilter);
         reader.initialize(split, context);
         return reader;
     }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoInputFormat.java
@@ -22,8 +22,7 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPoolsConfigurable;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 
 import java.io.IOException;
@@ -31,11 +30,12 @@ import java.io.IOException;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GryoInputFormat extends FileInputFormat<NullWritable, VertexWritable> implements HadoopPoolsConfigurable {
+public final class GryoInputFormat extends CommonFileInputFormat {
 
     @Override
     public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException {
-        final RecordReader<NullWritable, VertexWritable> reader = new GryoRecordReader();
+        super.loadVertexAndEdgeFilters(context);
+        final RecordReader<NullWritable, VertexWritable> reader = new GryoRecordReader(this.vertexFilter, this.edgeFilter);
         reader.initialize(split, context);
         return reader;
     }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoOutputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoOutputFormat.java
@@ -34,7 +34,7 @@ public final class GryoOutputFormat extends CommonFileOutputFormat implements Ha
 
     @Override
     public RecordWriter<NullWritable, VertexWritable> getRecordWriter(final TaskAttemptContext job) throws IOException, InterruptedException {
-        return new GryoRecordWriter(getDataOuputStream(job), job.getConfiguration());
+        return new GryoRecordWriter(getDataOutputStream(job), job.getConfiguration());
     }
 
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReader.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPools;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
@@ -36,6 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoMapper;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoReader;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.VertexTerminator;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
+import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -128,7 +128,7 @@ public final class GryoRecordReader extends RecordReader<NullWritable, VertexWri
             terminatorLocation = ((byte) currentByte) == TERMINATOR[terminatorLocation] ? terminatorLocation + 1 : 0;
             if (terminatorLocation >= TERMINATOR.length) {
                 try (InputStream in = new ByteArrayInputStream(output.toByteArray())) {
-                    final Vertex vertex = GraphFilterAware.applyGraphFilter(this.gryoReader.readVertex(in, Attachable::get), this.graphFilter); // I know how GryoReader works, so I'm cheating here
+                    final Vertex vertex = this.graphFilter.applyGraphFilter((StarGraph.StarVertex) this.gryoReader.readVertex(in, Attachable::get)); // I know how GryoReader works, so I'm cheating here
                     if (null != vertex) {
                         this.vertexWritable.set(vertex);
                         return true;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReader.java
@@ -60,7 +60,7 @@ public final class GryoRecordReader extends RecordReader<NullWritable, VertexWri
 
     public GryoRecordReader(final GraphFilter graphFilter) {
         this.graphFilter = graphFilter.clone();
-        this.graphFilter.applyStrategies();
+        this.graphFilter.compileFilters();
     }
 
     @Override

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/gryo/GryoRecordReader.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPools;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -131,7 +131,7 @@ public final class GryoRecordReader extends RecordReader<NullWritable, VertexWri
             terminatorLocation = ((byte) currentByte) == TERMINATOR[terminatorLocation] ? terminatorLocation + 1 : 0;
             if (terminatorLocation >= TERMINATOR.length) {
                 try (InputStream in = new ByteArrayInputStream(output.toByteArray())) {
-                    final Vertex vertex = CommonFileInputFormat.applyVertexAndEdgeFilters(this.gryoReader.readVertex(in, Attachable::get), this.vertexFilter, this.edgeFilter); // I know how GryoReader works, so I'm cheating here
+                    final Vertex vertex = GraphFilterAware.applyVertexAndEdgeFilters(this.gryoReader.readVertex(in, Attachable::get), this.vertexFilter, this.edgeFilter); // I know how GryoReader works, so I'm cheating here
                     if (null != vertex) {
                         this.vertexWritable.set(vertex);
                         return true;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptInputFormat.java
@@ -39,7 +39,7 @@ public final class ScriptInputFormat extends CommonFileInputFormat {
     @Override
     public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException {
         super.loadVertexAndEdgeFilters(context);
-        RecordReader<NullWritable, VertexWritable> reader = new ScriptRecordReader(this.vertexFilter, this.edgeFilter);
+        RecordReader<NullWritable, VertexWritable> reader = new ScriptRecordReader(this.graphFilter);
         reader.initialize(split, context);
         return reader;
     }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptInputFormat.java
@@ -25,8 +25,7 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPoolsConfigurable;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 
 import java.io.IOException;
@@ -35,19 +34,14 @@ import java.io.IOException;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
-public final class ScriptInputFormat extends FileInputFormat<NullWritable, VertexWritable> implements HadoopPoolsConfigurable {
+public final class ScriptInputFormat extends CommonFileInputFormat {
 
     @Override
-    public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context)
-            throws IOException, InterruptedException {
-
-        RecordReader<NullWritable, VertexWritable> reader = new ScriptRecordReader();
+    public RecordReader<NullWritable, VertexWritable> createRecordReader(final InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException {
+        super.loadVertexAndEdgeFilters(context);
+        RecordReader<NullWritable, VertexWritable> reader = new ScriptRecordReader(this.vertexFilter, this.edgeFilter);
         reader.initialize(split, context);
         return reader;
     }
 
-    @Override
-    protected boolean isSplitable(final JobContext context, final Path file) {
-        return null == new CompressionCodecFactory(context.getConfiguration()).getCodec(file);
-    }
 }

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptOutputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptOutputFormat.java
@@ -35,7 +35,7 @@ public final class ScriptOutputFormat extends CommonFileOutputFormat implements 
 
     @Override
     public RecordWriter<NullWritable, VertexWritable> getRecordWriter(final TaskAttemptContext job) throws IOException, InterruptedException {
-        return getRecordWriter(job, getDataOuputStream(job));
+        return getRecordWriter(job, getDataOutputStream(job));
     }
 
     public RecordWriter<NullWritable, VertexWritable> getRecordWriter(final TaskAttemptContext job, final DataOutputStream outputStream) throws IOException, InterruptedException {

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
 import org.apache.tinkerpop.gremlin.groovy.CompilerCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.DefaultImportCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -88,7 +87,7 @@ public final class ScriptRecordReader extends RecordReader<NullWritable, VertexW
                 final Bindings bindings = this.engine.createBindings();
                 bindings.put(LINE, this.lineRecordReader.getCurrentValue().toString());
                 bindings.put(FACTORY, new ScriptElementFactory());
-                final Vertex vertex = GraphFilterAware.applyGraphFilter((Vertex) engine.eval(READ_CALL, bindings), this.graphFilter);
+                final Vertex vertex = this.graphFilter.applyGraphFilter((StarGraph.StarVertex) engine.eval(READ_CALL, bindings));
                 if (vertex != null) {
                     this.vertexWritable.set(vertex);
                     return true;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
@@ -42,6 +42,7 @@ import javax.script.ScriptException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Iterator;
+import java.util.Optional;
 
 /**
  * @author Daniel Kuppitz (http://gremlin.guru)
@@ -87,9 +88,9 @@ public final class ScriptRecordReader extends RecordReader<NullWritable, VertexW
                 final Bindings bindings = this.engine.createBindings();
                 bindings.put(LINE, this.lineRecordReader.getCurrentValue().toString());
                 bindings.put(FACTORY, new ScriptElementFactory());
-                final Vertex vertex = this.graphFilter.applyGraphFilter((StarGraph.StarVertex) engine.eval(READ_CALL, bindings));
-                if (vertex != null) {
-                    this.vertexWritable.set(vertex);
+                final Optional<StarGraph.StarVertex> vertex = this.graphFilter.applyGraphFilter((StarGraph.StarVertex) engine.eval(READ_CALL, bindings));
+                if (vertex.isPresent()) {
+                    this.vertexWritable.set(vertex.get());
                     return true;
                 }
             } catch (final ScriptException e) {

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
 import org.apache.tinkerpop.gremlin.groovy.CompilerCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.DefaultImportCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.CommonFileInputFormat;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -90,7 +90,7 @@ public final class ScriptRecordReader extends RecordReader<NullWritable, VertexW
                 final Bindings bindings = this.engine.createBindings();
                 bindings.put(LINE, this.lineRecordReader.getCurrentValue().toString());
                 bindings.put(FACTORY, new ScriptElementFactory());
-                final Vertex vertex = CommonFileInputFormat.applyVertexAndEdgeFilters((Vertex) engine.eval(READ_CALL, bindings), this.vertexFilter, this.edgeFilter);
+                final Vertex vertex = GraphFilterAware.applyVertexAndEdgeFilters((Vertex) engine.eval(READ_CALL, bindings), this.vertexFilter, this.edgeFilter);
                 if (vertex != null) {
                     this.vertexWritable.set(vertex);
                     return true;

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
@@ -92,7 +92,7 @@ public final class ScriptRecordReader extends RecordReader<NullWritable, VertexW
                 final Bindings bindings = this.engine.createBindings();
                 bindings.put(LINE, this.lineRecordReader.getCurrentValue().toString());
                 bindings.put(FACTORY, new ScriptElementFactory());
-                final Optional<StarGraph.StarVertex> vertex = this.graphFilter.applyGraphFilter((StarGraph.StarVertex) engine.eval(READ_CALL, bindings));
+                final Optional<StarGraph.StarVertex> vertex = ((StarGraph.StarVertex) engine.eval(READ_CALL, bindings)).applyGraphFilter(this.graphFilter);
                 if (vertex.isPresent()) {
                     this.vertexWritable.set(vertex.get());
                     return true;

--- a/spark-gremlin/src/main/groovy/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/CompactBufferSerializer.groovy
+++ b/spark-gremlin/src/main/groovy/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/CompactBufferSerializer.groovy
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.spark.structure.io.gryo
+
+import org.apache.spark.util.collection.CompactBuffer
+import org.apache.tinkerpop.shaded.kryo.Kryo
+import org.apache.tinkerpop.shaded.kryo.Serializer
+import org.apache.tinkerpop.shaded.kryo.io.Input
+import org.apache.tinkerpop.shaded.kryo.io.Output
+import scala.reflect.ClassTag
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class CompactBufferSerializer<T> extends Serializer<CompactBuffer<T>> {
+
+    /*
+    private final ClassTag<T> evidence$1;
+    private T element0;
+    private T element1;
+    private int org$apache$spark$util$collection$CompactBuffer$$curSize;
+    private Object otherElements;
+     */
+
+    @Override
+    public void write(final Kryo kryo, final Output output, final CompactBuffer<T> compactBuffer) {
+        kryo.writeClassAndObject(output, compactBuffer.evidence$1);
+        kryo.writeClassAndObject(output, compactBuffer.element0);
+        kryo.writeClassAndObject(output, compactBuffer.element1);
+        output.flush();
+        output.writeVarInt(compactBuffer.org$apache$spark$util$collection$CompactBuffer$$curSize, true);
+        kryo.writeClassAndObject(output, compactBuffer.otherElements);
+        output.flush();
+    }
+
+    @Override
+    public CompactBuffer<T> read(Kryo kryo, Input input, Class<CompactBuffer<T>> aClass) {
+        final ClassTag<T> classTag = kryo.readClassAndObject(input);
+        final CompactBuffer<T> compactBuffer = new CompactBuffer<>(classTag);
+        compactBuffer.element0 = kryo.readClassAndObject(input);
+        compactBuffer.element1 = kryo.readClassAndObject(input);
+        compactBuffer.org$apache$spark$util$collection$CompactBuffer$$curSize = input.readVarInt(true);
+        compactBuffer.otherElements = kryo.readClassAndObject(input);
+        return compactBuffer;
+    }
+}

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -62,7 +62,7 @@ public final class SparkExecutor {
     public static JavaPairRDD<Object, VertexWritable> applyGraphFilter(JavaPairRDD<Object, VertexWritable> graphRDD, final GraphFilter graphFilter) {
         return graphRDD.mapPartitionsToPair(partitionIterator -> {
             final GraphFilter gFilter = graphFilter.clone();
-            return () -> IteratorUtils.filter(partitionIterator, tuple -> gFilter.applyGraphFilter(tuple._2().get()).isPresent());
+            return () -> IteratorUtils.filter(partitionIterator, tuple -> (tuple._2().get().applyGraphFilter(gFilter)).isPresent());
         }, true);
     }
 

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -22,7 +22,6 @@ import com.google.common.base.Optional;
 import org.apache.commons.configuration.Configuration;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
-import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.HadoopPools;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
@@ -63,7 +62,7 @@ public final class SparkExecutor {
     public static JavaPairRDD<Object, VertexWritable> filterLoadedGraph(JavaPairRDD<Object, VertexWritable> graphRDD, final GraphFilter graphFilter) {
         return graphRDD.mapPartitionsToPair(partitionIterator -> {
             final GraphFilter gFilter = graphFilter.clone();
-            return () -> IteratorUtils.filter(partitionIterator, tuple -> GraphFilterAware.applyGraphFilter(tuple._2().get(), gFilter) != null);
+            return () -> IteratorUtils.filter(partitionIterator, tuple -> gFilter.applyGraphFilter(tuple._2().get()) != null);
         }, true);
     }
 

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -62,7 +62,7 @@ public final class SparkExecutor {
     public static JavaPairRDD<Object, VertexWritable> filterLoadedGraph(JavaPairRDD<Object, VertexWritable> graphRDD, final GraphFilter graphFilter) {
         return graphRDD.mapPartitionsToPair(partitionIterator -> {
             final GraphFilter gFilter = graphFilter.clone();
-            return () -> IteratorUtils.filter(partitionIterator, tuple -> gFilter.applyGraphFilter(tuple._2().get()) != null);
+            return () -> IteratorUtils.filter(partitionIterator, tuple -> gFilter.applyGraphFilter(tuple._2().get()).isPresent());
         }, true);
     }
 

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -59,7 +59,7 @@ public final class SparkExecutor {
     // DATA LOADING //
     //////////////////
 
-    public static JavaPairRDD<Object, VertexWritable> filterLoadedGraph(JavaPairRDD<Object, VertexWritable> graphRDD, final GraphFilter graphFilter) {
+    public static JavaPairRDD<Object, VertexWritable> applyGraphFilter(JavaPairRDD<Object, VertexWritable> graphRDD, final GraphFilter graphFilter) {
         return graphRDD.mapPartitionsToPair(partitionIterator -> {
             final GraphFilter gFilter = graphFilter.clone();
             return () -> IteratorUtils.filter(partitionIterator, tuple -> gFilter.applyGraphFilter(tuple._2().get()).isPresent());

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -176,7 +176,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
             }
 
             // the Spark application name will always be set by SparkContextStorage, thus, INFO the name to make it easier to debug
-            logger.info(Constants.GREMLIN_HADOOP_SPARK_JOB_PREFIX + (null == this.vertexProgram ? "No VertexProgram" : this.vertexProgram) + "[" + this.mapReducers + "]");
+            logger.debug(Constants.GREMLIN_HADOOP_SPARK_JOB_PREFIX + (null == this.vertexProgram ? "No VertexProgram" : this.vertexProgram) + "[" + this.mapReducers + "]");
 
             // create the spark configuration from the graph computer configuration
             final SparkConf sparkConfiguration = new SparkConf();
@@ -193,15 +193,15 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                 JavaPairRDD<Object, VertexWritable> loadedGraphRDD = inputRDD.readGraphRDD(apacheConfiguration, sparkContext);
                 // if there are vertex or edge filters, filter the loaded graph rdd prior to partitioning and persisting
                 if (filtered) {
-                    this.logger.info("Filtering the loaded graphRDD: " + this.graphFilter);
+                    this.logger.debug("Filtering the loaded graphRDD: " + this.graphFilter);
                     loadedGraphRDD = SparkExecutor.filterLoadedGraph(loadedGraphRDD, this.graphFilter);
                 }
                 // if the loaded graph RDD is already partitioned use that partitioner, else partition it with HashPartitioner
                 if (loadedGraphRDD.partitioner().isPresent())
-                    this.logger.info("Using the existing partitioner associated with the loaded graphRDD: " + loadedGraphRDD.partitioner().get());
+                    this.logger.debug("Using the existing partitioner associated with the loaded graphRDD: " + loadedGraphRDD.partitioner().get());
                 else {
                     final Partitioner partitioner = new HashPartitioner(this.workersSet ? this.workers : loadedGraphRDD.partitions().size());
-                    this.logger.info("Partitioning the loaded graphRDD: " + partitioner);
+                    this.logger.debug("Partitioning the loaded graphRDD: " + partitioner);
                     loadedGraphRDD = loadedGraphRDD.partitionBy(partitioner);
                     partitioned = true;
                 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.spark.HashPartitioner;
+import org.apache.spark.Partitioner;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -40,6 +41,7 @@ import org.apache.tinkerpop.gremlin.hadoop.process.computer.util.ComputerSubmiss
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopConfiguration;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.FileSystemStorage;
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.GraphFilterAware;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
@@ -131,7 +133,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
             }
         }
 
-        // create the completable future
+        // create the completable future                                                    
         return CompletableFuture.<ComputerResult>supplyAsync(() -> {
             final long startTime = System.currentTimeMillis();
             final Storage fileSystemStorage = FileSystemStorage.open(hadoopConfiguration);
@@ -140,6 +142,21 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
             final boolean inputFromSpark = PersistedInputRDD.class.isAssignableFrom(hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD, Object.class));
             final boolean outputToHDFS = FileOutputFormat.class.isAssignableFrom(hadoopConfiguration.getClass(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, Object.class));
             final boolean outputToSpark = PersistedOutputRDD.class.isAssignableFrom(hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, Object.class));
+            final InputRDD inputRDD;
+            final OutputRDD outputRDD;
+            try {
+                inputRDD = hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD, InputFormatRDD.class, InputRDD.class).newInstance();
+                outputRDD = hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, OutputFormatRDD.class, OutputRDD.class).newInstance();
+                if (inputRDD instanceof GraphFilterAware) { // if the input class can filter on load, then set the filters
+                    if (null != this.vertexFilter)
+                        ((GraphFilterAware) inputRDD).setVertexFilter(this.vertexFilter);
+                    if (null != edgeFilter)
+                        ((GraphFilterAware) inputRDD).setEdgeFilter(this.edgeFilter);
+                }
+            } catch (final InstantiationException | IllegalAccessException e) {
+                throw new IllegalStateException(e.getMessage(), e);
+            }
+            final boolean filtered = (this.vertexFilter != null || this.edgeFilter != null) && !(inputRDD instanceof GraphFilterAware);
             SparkMemory memory = null;
             // delete output location
             final String outputLocation = hadoopConfiguration.get(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION, null);
@@ -149,11 +166,12 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                 if (outputToSpark && sparkContextStorage.exists(outputLocation))
                     sparkContextStorage.rm(outputLocation);
             }
-            // wire up a spark context
-            final SparkConf sparkConfiguration = new SparkConf();
-            sparkConfiguration.setAppName(Constants.GREMLIN_HADOOP_SPARK_JOB_PREFIX + (null == this.vertexProgram ? "No VertexProgram" : this.vertexProgram) + "[" + this.mapReducers + "]");
+
+            // the Spark application name will always be set by SparkContextStorage, thus, INFO the name to make it easier to debug
+            logger.info(Constants.GREMLIN_HADOOP_SPARK_JOB_PREFIX + (null == this.vertexProgram ? "No VertexProgram" : this.vertexProgram) + "[" + this.mapReducers + "]");
 
             // create the spark configuration from the graph computer configuration
+            final SparkConf sparkConfiguration = new SparkConf();
             hadoopConfiguration.forEach(entry -> sparkConfiguration.set(entry.getKey(), entry.getValue()));
             // execute the vertex program and map reducers and if there is a failure, auto-close the spark context
             try {
@@ -162,44 +180,42 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                 Spark.create(sparkContext.sc()); // this is the context RDD holder that prevents GC
                 updateLocalConfiguration(sparkContext, sparkConfiguration);
                 // create a message-passing friendly rdd from the input rdd
-                JavaPairRDD<Object, VertexWritable> loadedGraphRDD;
                 JavaPairRDD<Object, VertexWritable> computedGraphRDD = null;
                 boolean partitioned = false;
-                try {
-                    loadedGraphRDD = hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_INPUT_RDD, InputFormatRDD.class, InputRDD.class)
-                            .newInstance()
-                            .readGraphRDD(apacheConfiguration, sparkContext);
-
+                JavaPairRDD<Object, VertexWritable> loadedGraphRDD = inputRDD.readGraphRDD(apacheConfiguration, sparkContext);
+                // if there are vertex or edge filters, filter the loaded graph rdd prior to partitioning and persisting
+                if (filtered) {
+                    this.logger.info("Filtering the loaded graphRDD: " + this.vertexFilter + " and " + this.edgeFilter);
                     loadedGraphRDD = SparkExecutor.filterLoadedGraph(loadedGraphRDD, this.vertexFilter, this.edgeFilter);
-
-                    if (loadedGraphRDD.partitioner().isPresent())
-                        this.logger.info("Using the existing partitioner associated with the loaded graphRDD: " + loadedGraphRDD.partitioner().get());
-                    else {
-                        loadedGraphRDD = loadedGraphRDD.partitionBy(new HashPartitioner(this.workersSet ? this.workers : loadedGraphRDD.partitions().size()));
-                        partitioned = true;
-                    }
-                    assert loadedGraphRDD.partitioner().isPresent();
-                    // if the loaded graphRDD was already partitioned previous, then this coalesce/repartition will not take place
-                    if (this.workersSet) {
-                        if (loadedGraphRDD.partitions().size() > this.workers) // ensures that the loaded graphRDD does not have more partitions than workers
-                            loadedGraphRDD = loadedGraphRDD.coalesce(this.workers);
-                        else if (loadedGraphRDD.partitions().size() < this.workers) // ensures that the loaded graphRDD does not have less partitions than workers
-                            loadedGraphRDD = loadedGraphRDD.repartition(this.workers);
-                    }
-                    // persist the vertex program loaded graph as specified by configuration or else use default cache() which is MEMORY_ONLY
-                    if (!inputFromSpark || partitioned)
-                        loadedGraphRDD = loadedGraphRDD.persist(StorageLevel.fromString(hadoopConfiguration.get(Constants.GREMLIN_SPARK_GRAPH_STORAGE_LEVEL, "MEMORY_ONLY")));
-                } catch (final InstantiationException | IllegalAccessException e) {
-                    throw new IllegalStateException(e.getMessage(), e);
                 }
+                // if the loaded graph RDD is already partitioned use that partitioner, else partition it with HashPartitioner
+                if (loadedGraphRDD.partitioner().isPresent())
+                    this.logger.info("Using the existing partitioner associated with the loaded graphRDD: " + loadedGraphRDD.partitioner().get());
+                else {
+                    final Partitioner partitioner = new HashPartitioner(this.workersSet ? this.workers : loadedGraphRDD.partitions().size());
+                    this.logger.info("Partitioning the loaded graphRDD: " + partitioner);
+                    loadedGraphRDD = loadedGraphRDD.partitionBy(partitioner);
+                    partitioned = true;
+                }
+                assert loadedGraphRDD.partitioner().isPresent();
+                // if the loaded graphRDD was already partitioned previous, then this coalesce/repartition will not take place
+                if (this.workersSet) {
+                    if (loadedGraphRDD.partitions().size() > this.workers) // ensures that the loaded graphRDD does not have more partitions than workers
+                        loadedGraphRDD = loadedGraphRDD.coalesce(this.workers);
+                    else if (loadedGraphRDD.partitions().size() < this.workers) // ensures that the loaded graphRDD does not have less partitions than workers
+                        loadedGraphRDD = loadedGraphRDD.repartition(this.workers);
+                }
+                // persist the vertex program loaded graph as specified by configuration or else use default cache() which is MEMORY_ONLY
+                if (!inputFromSpark || partitioned || filtered)
+                    loadedGraphRDD = loadedGraphRDD.persist(StorageLevel.fromString(hadoopConfiguration.get(Constants.GREMLIN_SPARK_GRAPH_STORAGE_LEVEL, "MEMORY_ONLY")));
 
-                JavaPairRDD<Object, ViewIncomingPayload<Object>> viewIncomingRDD = null;
 
                 ////////////////////////////////
                 // process the vertex program //
                 ////////////////////////////////
                 if (null != this.vertexProgram) {
                     // set up the vertex program and wire up configurations
+                    JavaPairRDD<Object, ViewIncomingPayload<Object>> viewIncomingRDD = null;
                     memory = new SparkMemory(this.vertexProgram, this.mapReducers, sparkContext);
                     this.vertexProgram.setup(memory);
                     memory.broadcastMemory(sparkContext);
@@ -224,13 +240,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                     computedGraphRDD = SparkExecutor.prepareFinalGraphRDD(loadedGraphRDD, viewIncomingRDD, elementComputeKeys);
                     if ((hadoopConfiguration.get(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT, null) != null ||
                             hadoopConfiguration.get(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, null) != null) && !this.persist.equals(Persist.NOTHING)) {
-                        try {
-                            hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, OutputFormatRDD.class, OutputRDD.class)
-                                    .newInstance()
-                                    .writeGraphRDD(apacheConfiguration, computedGraphRDD);
-                        } catch (final InstantiationException | IllegalAccessException e) {
-                            throw new IllegalStateException(e.getMessage(), e);
-                        }
+                        outputRDD.writeGraphRDD(apacheConfiguration, computedGraphRDD);
                     }
                 }
 
@@ -279,7 +289,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
 
                 // unpersist the loaded graph if it will not be used again (no PersistedInputRDD)
                 // if the graphRDD was loaded from Spark, but then partitioned, its a different RDD
-                if ((!inputFromSpark || partitioned) && computedGraphCreated)
+                if ((!inputFromSpark || partitioned || filtered) && computedGraphCreated)
                     loadedGraphRDD.unpersist();
                 // unpersist the computed graph if it will not be used again (no PersistedOutputRDD)
                 if (!outputToSpark || this.persist.equals(GraphComputer.Persist.NOTHING))

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -61,6 +61,7 @@ import org.apache.tinkerpop.gremlin.spark.structure.io.OutputRDD;
 import org.apache.tinkerpop.gremlin.spark.structure.io.PersistedInputRDD;
 import org.apache.tinkerpop.gremlin.spark.structure.io.PersistedOutputRDD;
 import org.apache.tinkerpop.gremlin.spark.structure.io.SparkContextStorage;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
 
 import java.io.File;
@@ -264,7 +265,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                     if (computedGraphCreated && !outputToSpark) {
                         // drop all the edges of the graph as they are not used in mapReduce processing
                         computedGraphRDD = computedGraphRDD.mapValues(vertexWritable -> {
-                            vertexWritable.get().dropEdges();
+                            vertexWritable.get().dropEdges(Direction.BOTH);
                             return vertexWritable;
                         });
                         // if there is only one MapReduce to execute, don't bother wasting the clock cycles.

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -150,7 +150,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                 outputRDD = hadoopConfiguration.getClass(Constants.GREMLIN_SPARK_GRAPH_OUTPUT_RDD, OutputFormatRDD.class, OutputRDD.class).newInstance();
                 // if the input class can filter on load, then set the filters
                 if (inputRDD instanceof InputFormatRDD && GraphFilterAware.class.isAssignableFrom(hadoopConfiguration.getClass(Constants.GREMLIN_HADOOP_GRAPH_INPUT_FORMAT, InputFormat.class, InputFormat.class))) {
-                    InputFormatRDD.storeVertexAndEdgeFilters(apacheConfiguration, hadoopConfiguration, this.vertexFilter, this.edgeFilter);
+                    GraphFilterAware.storeVertexAndEdgeFilters(apacheConfiguration, hadoopConfiguration, this.vertexFilter, this.edgeFilter);
                     filtered = false;
                 } else if (inputRDD instanceof GraphFilterAware) {
                     if (null != this.vertexFilter)

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -194,7 +194,7 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                 // if there are vertex or edge filters, filter the loaded graph rdd prior to partitioning and persisting
                 if (filtered) {
                     this.logger.debug("Filtering the loaded graphRDD: " + this.graphFilter);
-                    loadedGraphRDD = SparkExecutor.filterLoadedGraph(loadedGraphRDD, this.graphFilter);
+                    loadedGraphRDD = SparkExecutor.applyGraphFilter(loadedGraphRDD, this.graphFilter);
                 }
                 // if the loaded graph RDD is already partitioned use that partitioner, else partition it with HashPartitioner
                 if (loadedGraphRDD.partitioner().isPresent())

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -170,6 +170,8 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                             .newInstance()
                             .readGraphRDD(apacheConfiguration, sparkContext);
 
+                    loadedGraphRDD = SparkExecutor.filterLoadedGraph(loadedGraphRDD, this.vertexFilter, this.edgeFilter);
+
                     if (loadedGraphRDD.partitioner().isPresent())
                         this.logger.info("Using the existing partitioner associated with the loaded graphRDD: " + loadedGraphRDD.partitioner().get());
                     else {

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -158,8 +158,10 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
                     if (null != edgeFilter)
                         ((GraphFilterAware) inputRDD).setEdgeFilter(this.edgeFilter);
                     filtered = false;
-                } else {
+                } else if (null != this.vertexFilter || null != this.edgeFilter) {
                     filtered = true;
+                } else {
+                    filtered = false;
                 }
             } catch (final InstantiationException | IllegalAccessException e) {
                 throw new IllegalStateException(e.getMessage(), e);

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/InputFormatRDD.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/InputFormatRDD.java
@@ -30,10 +30,6 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.io.FileSystemStorage;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
-import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import scala.Tuple2;
 
 /**
@@ -61,16 +57,5 @@ public final class InputFormatRDD implements InputRDD {
                 ObjectWritable.class,
                 ObjectWritable.class)
                 .mapToPair(tuple -> new Tuple2<>((K) ((Tuple2<ObjectWritable, ObjectWritable>) tuple)._1().get(), (V) ((Tuple2<ObjectWritable, ObjectWritable>) tuple)._2().get()));
-    }
-
-    public static void storeVertexAndEdgeFilters(final Configuration apacheConfiguration, final org.apache.hadoop.conf.Configuration hadoopConfiguration, final Traversal.Admin<Vertex, Vertex> vertexFilter, final Traversal.Admin<Edge, Edge> edgeFilter) {
-        if (null != vertexFilter) {
-            VertexProgramHelper.serialize(vertexFilter, apacheConfiguration, Constants.GREMLIN_HADOOP_VERTEX_FILTER);
-            hadoopConfiguration.set(Constants.GREMLIN_HADOOP_VERTEX_FILTER, apacheConfiguration.getString(Constants.GREMLIN_HADOOP_VERTEX_FILTER));
-        }
-        if (null != edgeFilter) {
-            VertexProgramHelper.serialize(edgeFilter, apacheConfiguration, Constants.GREMLIN_HADOOP_EDGE_FILTER);
-            hadoopConfiguration.set(Constants.GREMLIN_HADOOP_VERTEX_FILTER, apacheConfiguration.getString(Constants.GREMLIN_HADOOP_EDGE_FILTER));
-        }
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/InputFormatRDD.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/InputFormatRDD.java
@@ -30,6 +30,10 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.io.FileSystemStorage;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
+import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import scala.Tuple2;
 
 /**
@@ -57,5 +61,16 @@ public final class InputFormatRDD implements InputRDD {
                 ObjectWritable.class,
                 ObjectWritable.class)
                 .mapToPair(tuple -> new Tuple2<>((K) ((Tuple2<ObjectWritable, ObjectWritable>) tuple)._1().get(), (V) ((Tuple2<ObjectWritable, ObjectWritable>) tuple)._2().get()));
+    }
+
+    public static void storeVertexAndEdgeFilters(final Configuration apacheConfiguration, final org.apache.hadoop.conf.Configuration hadoopConfiguration, final Traversal.Admin<Vertex, Vertex> vertexFilter, final Traversal.Admin<Edge, Edge> edgeFilter) {
+        if (null != vertexFilter) {
+            VertexProgramHelper.serialize(vertexFilter, apacheConfiguration, Constants.GREMLIN_HADOOP_VERTEX_FILTER);
+            hadoopConfiguration.set(Constants.GREMLIN_HADOOP_VERTEX_FILTER, apacheConfiguration.getString(Constants.GREMLIN_HADOOP_VERTEX_FILTER));
+        }
+        if (null != edgeFilter) {
+            VertexProgramHelper.serialize(edgeFilter, apacheConfiguration, Constants.GREMLIN_HADOOP_EDGE_FILTER);
+            hadoopConfiguration.set(Constants.GREMLIN_HADOOP_VERTEX_FILTER, apacheConfiguration.getString(Constants.GREMLIN_HADOOP_EDGE_FILTER));
+        }
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/PersistedOutputRDD.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/PersistedOutputRDD.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.KeyValue;
 import org.apache.tinkerpop.gremlin.spark.structure.Spark;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ public final class PersistedOutputRDD implements OutputRDD {
         final StorageLevel storageLevel = StorageLevel.fromString(configuration.getString(Constants.GREMLIN_SPARK_PERSIST_STORAGE_LEVEL, "MEMORY_ONLY"));
         if (!configuration.getBoolean(Constants.GREMLIN_HADOOP_GRAPH_OUTPUT_FORMAT_HAS_EDGES, true))
             graphRDD.mapValues(vertex -> {
-                vertex.get().dropEdges();
+                vertex.get().dropEdges(Direction.BOTH);
                 return vertex;
             }).setName(Constants.getGraphLocation(configuration.getString(Constants.GREMLIN_HADOOP_OUTPUT_LOCATION))).persist(storageLevel);
         else

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
@@ -30,7 +30,6 @@ import org.apache.spark.scheduler.CompressedMapStatus;
 import org.apache.spark.scheduler.HighlyCompressedMapStatus;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.serializer.SerializerInstance;
-import org.apache.spark.storage.BlockManagerId;
 import org.apache.spark.util.SerializableConfiguration;
 import org.apache.spark.util.collection.CompactBuffer;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
@@ -41,6 +40,7 @@ import org.apache.tinkerpop.gremlin.spark.process.computer.payload.ViewOutgoingP
 import org.apache.tinkerpop.gremlin.spark.process.computer.payload.ViewPayload;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoPool;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
+import org.apache.tinkerpop.shaded.kryo.serializers.ExternalizableSerializer;
 import org.apache.tinkerpop.shaded.kryo.serializers.JavaSerializer;
 import scala.Tuple2;
 import scala.Tuple3;
@@ -87,12 +87,11 @@ public final class GryoSerializer extends Serializer {
                                 .addCustom(Tuple3[].class)
                                 .addCustom(CompactBuffer.class, new CompactBufferSerializer())
                                 .addCustom(CompactBuffer[].class)
-                                .addCustom(CompressedMapStatus.class)
-                                .addCustom(HighlyCompressedMapStatus.class)
+                                .addCustom(CompressedMapStatus.class, new ExternalizableSerializer())  // externalizable implemented so its okay
+                                .addCustom(HighlyCompressedMapStatus.class, new ExternalizableSerializer())   // externalizable implemented so its okay
                                 .addCustom(HttpBroadcast.class)
                                 .addCustom(PythonBroadcast.class)
                                 .addCustom(BoxedUnit.class)
-                                .addCustom(BlockManagerId.class)
                                 .addCustom(Class.forName("scala.reflect.ClassTag$$anon$1"), new JavaSerializer())
                                 .addCustom(Class.forName("scala.reflect.ManifestFactory$$anon$1"), new JavaSerializer())
                                 .addCustom(WrappedArray.ofRef.class, new WrappedArraySerializer())

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
@@ -30,6 +30,7 @@ import org.apache.spark.scheduler.CompressedMapStatus;
 import org.apache.spark.scheduler.HighlyCompressedMapStatus;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.serializer.SerializerInstance;
+import org.apache.spark.storage.BlockManagerId;
 import org.apache.spark.util.SerializableConfiguration;
 import org.apache.spark.util.collection.CompactBuffer;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
@@ -87,7 +88,8 @@ public final class GryoSerializer extends Serializer {
                                 .addCustom(Tuple3[].class)
                                 .addCustom(CompactBuffer.class, new CompactBufferSerializer())
                                 .addCustom(CompactBuffer[].class)
-                                .addCustom(CompressedMapStatus.class, new ExternalizableSerializer())  // externalizable implemented so its okay
+                                .addCustom(CompressedMapStatus.class)
+                                .addCustom(BlockManagerId.class)
                                 .addCustom(HighlyCompressedMapStatus.class, new ExternalizableSerializer())   // externalizable implemented so its okay
                                 .addCustom(HttpBroadcast.class)
                                 .addCustom(PythonBroadcast.class)

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
@@ -100,7 +100,7 @@ public final class GryoSerializer extends Serializer {
                                 .addCustom(ViewIncomingPayload.class)
                                 .addCustom(ViewOutgoingPayload.class)
                                 .addCustom(ViewPayload.class)
-                                .addCustom(SerializableConfiguration.class)
+                                .addCustom(SerializableConfiguration.class, new JavaSerializer())
                                 .addCustom(VertexWritable.class, new VertexWritableSerializer())
                                 .addCustom(ObjectWritable.class, new ObjectWritableSerializer())
                                 .referenceTracking(referenceTracking)

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/GryoSerializer.java
@@ -22,7 +22,6 @@ package org.apache.tinkerpop.gremlin.spark.structure.io.gryo;
 
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.spark.SerializableWritable;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.python.PythonBroadcast;
 import org.apache.spark.broadcast.HttpBroadcast;
@@ -31,6 +30,7 @@ import org.apache.spark.scheduler.CompressedMapStatus;
 import org.apache.spark.scheduler.HighlyCompressedMapStatus;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.serializer.SerializerInstance;
+import org.apache.spark.storage.BlockManagerId;
 import org.apache.spark.util.SerializableConfiguration;
 import org.apache.spark.util.collection.CompactBuffer;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
@@ -81,27 +81,28 @@ public final class GryoSerializer extends Serializer {
                 ioRegistries(makeApacheConfiguration(sparkConfiguration).getList(GryoPool.CONFIG_IO_REGISTRY, Collections.emptyList())).
                 initializeMapper(builder -> {
                     try {
-                        builder.addCustom(SerializableWritable.class, new JavaSerializer())
-                                .addCustom(Tuple2.class, new JavaSerializer())
-                                .addCustom(Tuple2[].class, new JavaSerializer())
-                                .addCustom(Tuple3.class, new JavaSerializer())
-                                .addCustom(Tuple3[].class, new JavaSerializer())
-                                .addCustom(CompactBuffer.class, new JavaSerializer())
-                                .addCustom(CompactBuffer[].class, new JavaSerializer())
-                                .addCustom(CompressedMapStatus.class, new JavaSerializer())
-                                .addCustom(HighlyCompressedMapStatus.class, new JavaSerializer())
-                                .addCustom(HttpBroadcast.class, new JavaSerializer())
-                                .addCustom(PythonBroadcast.class, new JavaSerializer())
-                                .addCustom(BoxedUnit.class, new JavaSerializer())
+                        builder.addCustom(Tuple2.class, new Tuple2Serializer())
+                                .addCustom(Tuple2[].class)
+                                .addCustom(Tuple3.class, new Tuple3Serializer())
+                                .addCustom(Tuple3[].class)
+                                .addCustom(CompactBuffer.class, new CompactBufferSerializer())
+                                .addCustom(CompactBuffer[].class)
+                                .addCustom(CompressedMapStatus.class)
+                                .addCustom(HighlyCompressedMapStatus.class)
+                                .addCustom(HttpBroadcast.class)
+                                .addCustom(PythonBroadcast.class)
+                                .addCustom(BoxedUnit.class)
+                                .addCustom(BlockManagerId.class)
                                 .addCustom(Class.forName("scala.reflect.ClassTag$$anon$1"), new JavaSerializer())
+                                .addCustom(Class.forName("scala.reflect.ManifestFactory$$anon$1"), new JavaSerializer())
                                 .addCustom(WrappedArray.ofRef.class, new WrappedArraySerializer())
                                 .addCustom(MessagePayload.class)
                                 .addCustom(ViewIncomingPayload.class)
                                 .addCustom(ViewOutgoingPayload.class)
                                 .addCustom(ViewPayload.class)
-                                .addCustom(SerializableConfiguration.class, new JavaSerializer())
-                                .addCustom(VertexWritable.class, new JavaSerializer())
-                                .addCustom(ObjectWritable.class, new JavaSerializer())
+                                .addCustom(SerializableConfiguration.class)
+                                .addCustom(VertexWritable.class, new VertexWritableSerializer())
+                                .addCustom(ObjectWritable.class, new ObjectWritableSerializer())
                                 .referenceTracking(referenceTracking)
                                 .registrationRequired(registrationRequired);
                         // add these as we find ClassNotFoundExceptions

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/ObjectWritableSerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/ObjectWritableSerializer.java
@@ -19,34 +19,25 @@
 
 package org.apache.tinkerpop.gremlin.spark.structure.io.gryo;
 
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
 import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.Serializer;
 import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
-import scala.collection.JavaConversions;
-import scala.collection.mutable.WrappedArray;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class WrappedArraySerializer<T> extends Serializer<WrappedArray<T>> {
+public final class ObjectWritableSerializer<T> extends Serializer<ObjectWritable<T>> {
 
     @Override
-    public void write(final Kryo kryo, final Output output, final WrappedArray<T> iterable) {
-        output.writeVarInt(iterable.size(), true);
-        JavaConversions.asJavaList(iterable).forEach(t -> {
-            kryo.writeClassAndObject(output, t);
-            output.flush();
-        });
+    public void write(final Kryo kryo, final Output output, final ObjectWritable<T> objectWritable) {
+        kryo.writeClassAndObject(output, objectWritable.get());
+        output.flush();
     }
 
     @Override
-    public WrappedArray<T> read(final Kryo kryo, final Input input, final Class<WrappedArray<T>> aClass) {
-        final int size = input.readVarInt(true);
-        final Object[] array = new Object[size];
-        for (int i = 0; i < size; i++) {
-            array[i] = kryo.readClassAndObject(input);
-        }
-        return new WrappedArray.ofRef<>((T[]) array);
+    public ObjectWritable<T> read(final Kryo kryo, final Input input, final Class<ObjectWritable<T>> clazz) {
+        return new ObjectWritable(kryo.readClassAndObject(input));
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/Tuple2Serializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/Tuple2Serializer.java
@@ -19,34 +19,28 @@
 
 package org.apache.tinkerpop.gremlin.spark.structure.io.gryo;
 
+
 import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.Serializer;
 import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
-import scala.collection.JavaConversions;
-import scala.collection.mutable.WrappedArray;
+import scala.Tuple2;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class WrappedArraySerializer<T> extends Serializer<WrappedArray<T>> {
+public final class Tuple2Serializer<A, B> extends Serializer<Tuple2<A, B>> {
 
     @Override
-    public void write(final Kryo kryo, final Output output, final WrappedArray<T> iterable) {
-        output.writeVarInt(iterable.size(), true);
-        JavaConversions.asJavaList(iterable).forEach(t -> {
-            kryo.writeClassAndObject(output, t);
-            output.flush();
-        });
+    public void write(final Kryo kryo, final Output output, final Tuple2<A, B> tuple2) {
+        kryo.writeClassAndObject(output, tuple2._1());
+        output.flush();
+        kryo.writeClassAndObject(output, tuple2._2());
+        output.flush();
     }
 
     @Override
-    public WrappedArray<T> read(final Kryo kryo, final Input input, final Class<WrappedArray<T>> aClass) {
-        final int size = input.readVarInt(true);
-        final Object[] array = new Object[size];
-        for (int i = 0; i < size; i++) {
-            array[i] = kryo.readClassAndObject(input);
-        }
-        return new WrappedArray.ofRef<>((T[]) array);
+    public Tuple2<A, B> read(final Kryo kryo, final Input input, final Class<Tuple2<A, B>> clazz) {
+        return new Tuple2(kryo.readClassAndObject(input), kryo.readClassAndObject(input));
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/Tuple3Serializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/Tuple3Serializer.java
@@ -23,30 +23,25 @@ import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.Serializer;
 import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
-import scala.collection.JavaConversions;
-import scala.collection.mutable.WrappedArray;
+import scala.Tuple3;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class WrappedArraySerializer<T> extends Serializer<WrappedArray<T>> {
+public final class Tuple3Serializer<A, B, C> extends Serializer<Tuple3<A, B, C>> {
 
     @Override
-    public void write(final Kryo kryo, final Output output, final WrappedArray<T> iterable) {
-        output.writeVarInt(iterable.size(), true);
-        JavaConversions.asJavaList(iterable).forEach(t -> {
-            kryo.writeClassAndObject(output, t);
-            output.flush();
-        });
+    public void write(final Kryo kryo, final Output output, final Tuple3<A, B, C> tuple3) {
+        kryo.writeClassAndObject(output, tuple3._1());
+        output.flush();
+        kryo.writeClassAndObject(output, tuple3._2());
+        output.flush();
+        kryo.writeClassAndObject(output, tuple3._3());
+        output.flush();
     }
 
     @Override
-    public WrappedArray<T> read(final Kryo kryo, final Input input, final Class<WrappedArray<T>> aClass) {
-        final int size = input.readVarInt(true);
-        final Object[] array = new Object[size];
-        for (int i = 0; i < size; i++) {
-            array[i] = kryo.readClassAndObject(input);
-        }
-        return new WrappedArray.ofRef<>((T[]) array);
+    public Tuple3<A, B, C> read(final Kryo kryo, final Input input, final Class<Tuple3<A, B, C>> clazz) {
+        return new Tuple3(kryo.readClassAndObject(input), kryo.readClassAndObject(input), kryo.readClassAndObject(input));
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/VertexWritableSerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/VertexWritableSerializer.java
@@ -19,34 +19,24 @@
 
 package org.apache.tinkerpop.gremlin.spark.structure.io.gryo;
 
+import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
+import org.apache.tinkerpop.gremlin.structure.util.star.StarGraph;
 import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.Serializer;
 import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
-import scala.collection.JavaConversions;
-import scala.collection.mutable.WrappedArray;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class WrappedArraySerializer<T> extends Serializer<WrappedArray<T>> {
-
+public final class VertexWritableSerializer extends Serializer<VertexWritable> {
     @Override
-    public void write(final Kryo kryo, final Output output, final WrappedArray<T> iterable) {
-        output.writeVarInt(iterable.size(), true);
-        JavaConversions.asJavaList(iterable).forEach(t -> {
-            kryo.writeClassAndObject(output, t);
-            output.flush();
-        });
+    public void write(final Kryo kryo, final Output output, final VertexWritable vertexWritable) {
+        kryo.writeObject(output, vertexWritable.get().graph());
     }
 
     @Override
-    public WrappedArray<T> read(final Kryo kryo, final Input input, final Class<WrappedArray<T>> aClass) {
-        final int size = input.readVarInt(true);
-        final Object[] array = new Object[size];
-        for (int i = 0; i < size; i++) {
-            array[i] = kryo.readClassAndObject(input);
-        }
-        return new WrappedArray.ofRef<>((T[]) array);
+    public VertexWritable read(final Kryo kryo, final Input input, final Class<VertexWritable> aClass) {
+        return new VertexWritable(kryo.readObject(input, StarGraph.class).getStarVertex());
     }
 }

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/io/SparkContextStorageCheck.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/structure/io/SparkContextStorageCheck.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.hadoop.Constants;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.AbstractStorageCheck;
 import org.apache.tinkerpop.gremlin.spark.structure.Spark;
 import org.apache.tinkerpop.gremlin.structure.io.Storage;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,6 +39,13 @@ public class SparkContextStorageCheck extends AbstractStorageCheck {
     public void setup() throws Exception {
         super.setup();
         SparkContextStorage.open("local[4]");
+        Spark.close();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        Spark.create("local[4]");
         Spark.close();
     }
 

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
@@ -99,7 +99,7 @@ public final class TinkerGraphComputer implements GraphComputer {
     }
 
     @Override
-    public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter) {
+    public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
         throw new UnsupportedOperationException();
     }
 

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
@@ -25,6 +25,8 @@ import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.ComputerGraph;
 import org.apache.tinkerpop.gremlin.process.computer.util.DefaultComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.util.GraphComputerHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
@@ -89,6 +91,16 @@ public final class TinkerGraphComputer implements GraphComputer {
     public GraphComputer workers(final int workers) {
         this.workers = workers;
         return this;
+    }
+
+    @Override
+    public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GraphComputer edges(final Traversal<Edge, Edge> edgeFilter) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.tinkergraph.process.computer;
 
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.ComputerGraph;
@@ -58,6 +59,7 @@ public final class TinkerGraphComputer implements GraphComputer {
     private boolean executed = false;
     private final Set<MapReduce> mapReducers = new HashSet<>();
     private int workers = Runtime.getRuntime().availableProcessors();
+    private final GraphFilter graphFilter = new GraphFilter();
 
     public TinkerGraphComputer(final TinkerGraph graph) {
         this.graph = graph;
@@ -95,12 +97,14 @@ public final class TinkerGraphComputer implements GraphComputer {
 
     @Override
     public GraphComputer vertices(final Traversal<Vertex, Vertex> vertexFilter) {
-        throw new UnsupportedOperationException();
+        this.graphFilter.setVertexFilter(vertexFilter);
+        return this;
     }
 
     @Override
     public GraphComputer edges(final Traversal<Vertex, Edge> edgeFilter) {
-        throw new UnsupportedOperationException();
+        this.graphFilter.setEdgeFilter(edgeFilter);
+        return this;
     }
 
     @Override
@@ -134,7 +138,7 @@ public final class TinkerGraphComputer implements GraphComputer {
             final long time = System.currentTimeMillis();
             try (final TinkerWorkerPool workers = new TinkerWorkerPool(this.workers)) {
                 if (null != this.vertexProgram) {
-                    TinkerHelper.createGraphComputerView(this.graph, this.vertexProgram.getElementComputeKeys());
+                    TinkerHelper.createGraphComputerView(this.graph, this.graphFilter, this.vertexProgram.getElementComputeKeys());
                     // execute the vertex program
                     this.vertexProgram.setup(this.memory);
                     this.memory.completeSubRound();

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputer.java
@@ -34,6 +34,7 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerHelper;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -169,6 +170,9 @@ public final class TinkerGraphComputer implements GraphComputer {
                             this.memory.completeSubRound();
                         }
                     }
+                } else {
+                    // MapReduce only
+                    TinkerHelper.createGraphComputerView(this.graph, this.graphFilter, Collections.emptySet());
                 }
 
                 // execute mapreduce jobs

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
@@ -19,6 +19,8 @@
 package org.apache.tinkerpop.gremlin.tinkergraph.process.computer;
 
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -35,6 +37,8 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerVertexProperty;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,11 +54,29 @@ public final class TinkerGraphComputerView {
     private final TinkerGraph graph;
     protected final Set<String> computeKeys;
     private Map<Element, Map<String, List<VertexProperty<?>>>> computeProperties;
+    private final Set<Object> legalVertices = new HashSet<>();
+    private final Map<Object, Set<Object>> legalEdges = new HashMap<>();
+    private final GraphFilter graphFilter;
 
-    public TinkerGraphComputerView(final TinkerGraph graph, final Set<String> computeKeys) {
+    public TinkerGraphComputerView(final TinkerGraph graph, final GraphFilter graphFilter, final Set<String> computeKeys) {
         this.graph = graph;
         this.computeKeys = computeKeys;
         this.computeProperties = new ConcurrentHashMap<>();
+        this.graphFilter = graphFilter;
+        if (this.graphFilter.hasFilter()) {
+            graph.vertices().forEachRemaining(vertex -> {
+                boolean legalVertex = false;
+                if (this.graphFilter.hasVertexFilter() && TraversalUtil.applyAll(vertex, this.graphFilter.getVertexFilter()).hasNext()) {
+                    this.legalVertices.add(vertex.id());
+                    legalVertex = true;
+                }
+                if ((legalVertex || !this.graphFilter.hasVertexFilter()) && this.graphFilter.hasEdgeFilter()) {
+                    final Set<Object> edges = new HashSet<>();
+                    this.legalEdges.put(vertex.id(), edges);
+                    TraversalUtil.applyAll(vertex, this.graphFilter.getEdgeFilter()).forEachRemaining(edge -> edges.add(edge.id()));
+                }
+            });
+        }
     }
 
     public <V> Property<V> addProperty(final TinkerVertex vertex, final String key, final V value) {
@@ -93,9 +115,18 @@ public final class TinkerGraphComputerView {
         }
     }
 
+    public boolean legalVertex(final Vertex vertex) {
+        return !this.graphFilter.hasVertexFilter() || this.legalVertices.contains(vertex.id());
+    }
+
+    public boolean legalEdge(final Vertex vertex, final Edge edge) {
+        return !this.graphFilter.hasEdgeFilter() || this.legalEdges.get(vertex.id()).contains(edge.id());
+    }
+
     //////////////////////
 
-    public Graph processResultGraphPersist(final GraphComputer.ResultGraph resultGraph, final GraphComputer.Persist persist) {
+    public Graph processResultGraphPersist(final GraphComputer.ResultGraph resultGraph,
+                                           final GraphComputer.Persist persist) {
         if (GraphComputer.Persist.NOTHING == persist) {
             if (GraphComputer.ResultGraph.ORIGINAL == resultGraph)
                 return this.graph;

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
@@ -20,7 +20,6 @@ package org.apache.tinkerpop.gremlin.tinkergraph.process.computer;
 
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -66,14 +65,14 @@ public final class TinkerGraphComputerView {
         if (this.graphFilter.hasFilter()) {
             graph.vertices().forEachRemaining(vertex -> {
                 boolean legalVertex = false;
-                if (this.graphFilter.hasVertexFilter() && TraversalUtil.applyAll(vertex, this.graphFilter.getVertexFilter()).hasNext()) {
+                if (this.graphFilter.hasVertexFilter() && this.graphFilter.legalVertex(vertex)) {
                     this.legalVertices.add(vertex.id());
                     legalVertex = true;
                 }
                 if ((legalVertex || !this.graphFilter.hasVertexFilter()) && this.graphFilter.hasEdgeFilter()) {
                     final Set<Object> edges = new HashSet<>();
                     this.legalEdges.put(vertex.id(), edges);
-                    TraversalUtil.applyAll(vertex, this.graphFilter.getEdgeFilter()).forEachRemaining(edge -> edges.add(edge.id()));
+                    this.graphFilter.legalEdges(vertex).forEachRemaining(edge -> edges.add(edge.id()));
                 }
             });
         }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerHelper.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerHelper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
+import org.apache.tinkerpop.gremlin.process.computer.GraphFilter;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -100,8 +101,8 @@ public final class TinkerHelper {
         return null != graph.graphComputerView;
     }
 
-    public static TinkerGraphComputerView createGraphComputerView(final TinkerGraph graph, final Set<String> computeKeys) {
-        return graph.graphComputerView = new TinkerGraphComputerView(graph, computeKeys);
+    public static TinkerGraphComputerView createGraphComputerView(final TinkerGraph graph, final GraphFilter graphFilter, final Set<String> computeKeys) {
+        return graph.graphComputerView = new TinkerGraphComputerView(graph, graphFilter, computeKeys);
     }
 
     public static TinkerGraphComputerView getGraphComputerView(final TinkerGraph graph) {

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerVertex.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerVertex.java
@@ -143,12 +143,21 @@ public final class TinkerVertex extends TinkerElement implements Vertex {
 
     @Override
     public Iterator<Edge> edges(final Direction direction, final String... edgeLabels) {
-        return (Iterator) TinkerHelper.getEdges(this, direction, edgeLabels);
+        final Iterator<Edge> edgeIterator = (Iterator) TinkerHelper.getEdges(this, direction, edgeLabels);
+        return TinkerHelper.inComputerMode(this.graph) ?
+                IteratorUtils.filter(edgeIterator, edge -> this.graph.graphComputerView.legalEdge(this, edge)) :
+                edgeIterator;
     }
 
     @Override
     public Iterator<Vertex> vertices(final Direction direction, final String... edgeLabels) {
-        return (Iterator) TinkerHelper.getVertices(this, direction, edgeLabels);
+        return TinkerHelper.inComputerMode(this.graph) ?
+                direction.equals(Direction.BOTH) ?
+                        IteratorUtils.concat(
+                                IteratorUtils.map(this.edges(Direction.OUT, edgeLabels), Edge::inVertex),
+                                IteratorUtils.map(this.edges(Direction.IN, edgeLabels), Edge::outVertex)) :
+                        IteratorUtils.map(this.edges(direction, edgeLabels), edge -> edge.vertices(direction.opposite()).next()) :
+                (Iterator) TinkerHelper.getVertices(this, direction, edgeLabels);
     }
 
     @Override


### PR DESCRIPTION
TINKERPOP-962: Provide "vertex query" selectivity when importing data in OLAP.

https://issues.apache.org/jira/browse/TINKERPOP-962

(For TinkerPop 3.2.0 -- Breaking Change for GraphComputer Implementations)

This feature enables us to push down a `GraphFilter` predicate to the underlying OLAP graph system. For instance, if `g.V().count()` is executed by `SparkGraphComputer`, then there is no reason to load all the edges, simply push down a `GraphFilter`-predicate that filters out edges. For graph database providers like Titan, they can simply only send up the subset of the graph that is required for the OLAP job instead of filtering on the OLAP cluster machines. In the future, we will provide `GraphFilterTraversalStrategy` which will analyze the traversal and automatically generate a `GraphFilter` so the user is blind to which subsets of the full graph are actually being accessed by the OLAP engine.

This pull request yields a breaking change for graph system providers that have their own `GraphComputer` implementation. There are two new methods on `GraphComputer` and one new method on `GraphReader`.

```
GraphComputer vertices(Traversal<Vertex,Vertex> vertexFilter)
GraphComputer edges(Traversal<Vertex,Edge> edgeFilter)
GraphReader.readVertex(InputStream inputStream, GraphFilter graphFilter)
```

TinkerPop provides a `GraphFilter` object that does a lot of the heavy lifting so at minimum, the graph system provider simply needs to `GraphFilter.isLegal()` the vertices and edges it loads. Note that if the graph system provider relies on `GiraphGraphComputer` or `SparkGraphComputer`, then there is no change on their part unless they want to leverage the `GraphFilter` locally before sending their data to Giraph or Spark (an optimization that can be done at a later date without impacting users).

There was a host of changes that took place for this feature to be created. When merged, the `CHANGELOG.txt` will have the following new items:

```
* Added `GraphFilter` to support filtering out vertices and edges that won't be touched by an OLAP job.
* Added `GraphComputer.vertices()` and `GraphComputer.edges()` for `GraphFilter` construction (*breaking*).
* `SparkGraphComputer`, `GiraphGraphComputer`, and `TinkerGraphComputer` all support `GraphFilter`.
* Added `GraphComputerTest.shouldSupportGraphFilter()` which verifies all filtered graphs have the same topology.
* Added `GraphFilterAware` interface to `hadoop-gremlin/` which tells the OLAP engine that the `InputFormat` handles filtering.
* `GryoInputFormat` and `ScriptInputFormat` implement `GraphFilterAware`.
* Added `GraphFilterInputFormat` which handles graph filtering for `InputFormats` that are not `GraphFilterAware`.
* Fixed a bug in `TraversalUtil.isLocalStarGraph()` which allowed certain illegal traversals to pass.
* Added `TraversalUtil.isLocalVertex()` to verify that the traversal does not touch incident edges.
* `GraphReader` IO interface now has `Optional<Vertex> readGraph(InputStream, GraphFilter)`. Default `UnsupportOperationException`.
* `GryoReader` does not materialize edges that will be filtered out and this greatly reduces GC and load times.
* Created custom `Serializers` for `SparkGraphComputer` message-passing classes which reduce graph sizes significantly.
```

Ran `mvn clean install` and integration tests. Passed.

VOTE +1.