### PR TITLE
TINKERPOP-1131: TraversalVertexProgram traverser management is inefficient memory-wise.

### DIFF
--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphComputation.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphComputation.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.io.ObjectWritable;
 import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.ComputerGraph;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.IOException;
 
@@ -41,7 +42,7 @@ public final class GiraphComputation extends BasicComputation<ObjectWritable, Ve
     public void compute(final Vertex<ObjectWritable, VertexWritable, NullWritable> vertex, final Iterable<ObjectWritable> messages) throws IOException {
         final GiraphWorkerContext workerContext = this.getWorkerContext();
         final VertexProgram<?> vertexProgram = workerContext.getVertexProgramPool().take();
-        vertexProgram.execute(ComputerGraph.vertexProgram(vertex.getValue().get(), vertexProgram), workerContext.getMessenger((GiraphVertex) vertex, this, messages.iterator()), workerContext.getMemory());
+        vertexProgram.execute(ComputerGraph.vertexProgram(vertex.getValue().get(), vertexProgram), workerContext.getMessenger((GiraphVertex) vertex, this, IteratorUtils.noRemove(messages.iterator())), workerContext.getMemory());
         workerContext.getVertexProgramPool().offer(vertexProgram);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraverserExecutor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraverserExecutor.java
@@ -61,9 +61,9 @@ public final class TraverserExecutor {
             }
         }
         // while there are still local traversers, process them until they leave the vertex or halt (i.e. isHalted()).
-        Step<?, ?> previousStep = EmptyStep.instance();
         while (!toProcessTraversers.isEmpty()) {
             // process local traversers and if alive, repeat, else halt.
+            Step<?, ?> previousStep = EmptyStep.instance();
             Iterator<Traverser.Admin<Object>> traversers = toProcessTraversers.iterator();
             while (traversers.hasNext()) {
                 final Traverser.Admin<Object> traverser = traversers.next();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountGlobalStep.java
@@ -61,6 +61,16 @@ public final class CountGlobalStep<S> extends ReducingBarrierStep<S, Long> imple
         return CountGlobalMapReduce.instance();
     }
 
+    @Override
+    public Traverser<Long> processNextStart() {
+        if (this.byPass) {
+            final Traverser.Admin<S> traverser = this.starts.next();
+            return traverser.asAdmin().split(1l, this); // if bypassing, just key all the traversers to 1 long (the count is going to be the bulk of course)
+        } else {
+            return super.processNextStart();
+        }
+    }
+
     ///////////
 
     private static class CountBiFunction<S> implements BiFunction<Long, Traverser<S>, Long>, Serializable {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStepV3d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStepV3d0.java
@@ -25,7 +25,9 @@ import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.EngineDependent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
@@ -55,18 +57,24 @@ import java.util.function.Supplier;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 @Deprecated
-public final class GroupStepV3d0<S, K, V, R> extends ReducingBarrierStep<S, Map<K, R>> implements MapReducer, TraversalParent {
+public final class GroupStepV3d0<S, K, V, R> extends ReducingBarrierStep<S, Map<K, R>> implements MapReducer, EngineDependent, TraversalParent {
 
     private char state = 'k';
 
     private Traversal.Admin<S, K> keyTraversal = null;
     private Traversal.Admin<S, V> valueTraversal = null;
     private Traversal.Admin<Collection<V>, R> reduceTraversal = null;
+    private boolean byPass = false;
 
     public GroupStepV3d0(final Traversal.Admin traversal) {
         super(traversal);
         this.setSeedSupplier((Supplier) new GroupMapSupplierV3d0());
         this.setBiFunction(new GroupBiFunction(this));
+    }
+
+    @Override
+    public void onEngine(final TraversalEngine traversalEngine) {
+        this.byPass = traversalEngine.isComputer();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/MaxGlobalStep.java
@@ -27,9 +27,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
-import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.function.ConstantSupplier;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -98,7 +98,9 @@ public final class MaxGlobalStep<S extends Number> extends ReducingBarrierStep<S
 
         @Override
         public void map(final Vertex vertex, final MapEmitter<NullObject, Number> emitter) {
-            vertex.<TraverserSet<Number>>property(TraversalVertexProgram.HALTED_TRAVERSERS).ifPresent(traverserSet -> traverserSet.forEach(traverser -> emitter.emit(traverser.get())));
+            final Iterator<Number> values = IteratorUtils.map(vertex.<Set<Traverser.Admin<Number>>>property(TraversalVertexProgram.HALTED_TRAVERSERS).orElse(Collections.emptySet()).iterator(), Traverser.Admin::get);
+            if (values.hasNext())
+                emitter.emit(getMax(values));
         }
 
         @Override
@@ -108,14 +110,17 @@ public final class MaxGlobalStep<S extends Number> extends ReducingBarrierStep<S
 
         @Override
         public void reduce(final NullObject key, final Iterator<Number> values, final ReduceEmitter<NullObject, Number> emitter) {
-            if (values.hasNext()) {
-                Number max = null;
-                while (values.hasNext()) {
-                    final Number value = values.next();
-                    max = max != null ? max(value, max) : value;
-                }
-                emitter.emit(max);
+            if (values.hasNext())
+                emitter.emit(getMax(values));
+        }
+
+        private Number getMax(final Iterator<Number> numbers) {
+            Number max = null;
+            while (numbers.hasNext()) {
+                final Number value = numbers.next();
+                max = max != null ? max(value, max) : value;
             }
+            return max;
         }
 
         @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -94,16 +94,6 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements M
     }
 
     @Override
-    public Traverser<Tree> processNextStart() {
-        if (this.byPass) {
-            final Traverser.Admin<S> traverser = this.starts.next();
-            return traverser.split(this.reducingBiFunction.apply(new Tree(), traverser), this);
-        } else {
-            return super.processNextStart();
-        }
-    }
-
-    @Override
     public String toString() {
         return StringFactory.stepString(this, this.traversalRing);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/DoubleIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/DoubleIterator.java
@@ -28,8 +28,8 @@ import java.util.Iterator;
  */
 final class DoubleIterator<T> implements Iterator<T>, Serializable {
 
-    private final T a;
-    private final T b;
+    private T a;
+    private T b;
     private char current = 'a';
 
     protected DoubleIterator(final T a, final T b) {
@@ -40,6 +40,14 @@ final class DoubleIterator<T> implements Iterator<T>, Serializable {
     @Override
     public boolean hasNext() {
         return this.current != 'x';
+    }
+
+    @Override
+    public void remove() {
+        if (this.current == 'b')
+            this.a = null;
+        else if (this.current == 'x')
+            this.b = null;
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java
@@ -105,6 +105,11 @@ public final class IteratorUtils {
             }
 
             @Override
+            public void remove() {
+                iterator.remove();
+            }
+
+            @Override
             public S next() {
                 if (this.count++ >= limit)
                     throw FastNoSuchElementException.instance();
@@ -205,6 +210,11 @@ public final class IteratorUtils {
             }
 
             @Override
+            public void remove() {
+                iterator.remove();
+            }
+
+            @Override
             public S next() {
                 final S s = iterator.next();
                 consumer.accept(s);
@@ -225,6 +235,11 @@ public final class IteratorUtils {
             @Override
             public boolean hasNext() {
                 return iterator.hasNext();
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
             }
 
             @Override
@@ -254,6 +269,11 @@ public final class IteratorUtils {
                     advance();
                     return null != this.nextResult;
                 }
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
             }
 
             @Override
@@ -309,6 +329,11 @@ public final class IteratorUtils {
                     }
                 }
                 return false;
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
             }
 
             @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/IteratorUtils.java
@@ -392,4 +392,23 @@ public final class IteratorUtils {
     public static <T> Stream<T> stream(final Iterable<T> iterable) {
         return IteratorUtils.stream(iterable.iterator());
     }
+
+    public static <T> Iterator<T> noRemove(final Iterator<T> iterator) {
+        return new Iterator<T>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public void remove() {
+                // do nothing
+            }
+
+            @Override
+            public T next() {
+                return iterator.next();
+            }
+        };
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
@@ -42,7 +42,7 @@ public final class MultiIterator<T> implements Iterator<T>, Serializable {
         if (this.current >= this.iterators.size())
             return false;
 
-        Iterator<T> currentIterator = iterators.get(this.current);
+        Iterator<T> currentIterator = this.iterators.get(this.current);
 
         while (true) {
             if (currentIterator.hasNext()) {
@@ -55,6 +55,11 @@ public final class MultiIterator<T> implements Iterator<T>, Serializable {
             }
         }
         return false;
+    }
+
+    @Override
+    public void remove() {
+        // this.iterators.get(this.current).remove();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/MultiIterator.java
@@ -59,7 +59,7 @@ public final class MultiIterator<T> implements Iterator<T>, Serializable {
 
     @Override
     public void remove() {
-        // this.iterators.get(this.current).remove();
+        this.iterators.get(this.current).remove();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/SingleIterator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/util/iterator/SingleIterator.java
@@ -26,9 +26,9 @@ import java.util.Iterator;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-final class SingleIterator<T> implements Iterator<T>,Serializable {
+final class SingleIterator<T> implements Iterator<T>, Serializable {
 
-    private final T t;
+    private T t;
     private boolean alive = true;
 
     protected SingleIterator(final T t) {
@@ -38,6 +38,11 @@ final class SingleIterator<T> implements Iterator<T>,Serializable {
     @Override
     public boolean hasNext() {
         return this.alive;
+    }
+
+    @Override
+    public void remove() {
+        this.t = null;
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1131

This will go into TinkerPop 3.1.2. I will then upmerge it to master/ (3.2.0) and when https://github.com/apache/incubator-tinkerpop/pull/210 is merged to master/ (3.2.0), we will have a lean-mean OLAP processing machine!

I realized that I was copying `TraverserSets` instead of draining one into the other. By draining, for every traverser put into one set, it is removed from the other. In the worst case, we could have up to 3 sets of equivalent size all in memory at one vertex in OLAP. If you do any sort of `outE()`-type traversal, thats ALOT of data. Moreover, I reorganized the flow of processing as previously I was determining if messages needed to be sent right after received messages! Pointless waste of CPU cycles. Finally, I create a "bulking model" where by I try and fill a `Step` with as many traversers as I can before I have to drain it for message passing. Prior, it was one traverser at a time -- again, this can lead to significant inefficiencies.

`mvn clean install` -- integration tests (Giraph still running, but it will work as if one `TraversalVertexProgram` test passes then the meat is right). 

VOTE +1.