### PR TITLE
TINKERPOP-916 Provide more robust SimpleClient implementations.

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/AbstractClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/AbstractClient.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.driver.simple;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public abstract class AbstractClient implements SimpleClient {
+    protected final CallbackResponseHandler callbackResponseHandler = new CallbackResponseHandler();
+    protected final EventLoopGroup group;
+
+    public AbstractClient(final String threadPattern) {
+        final BasicThreadFactory threadFactory = new BasicThreadFactory.Builder().namingPattern(threadPattern).build();
+        group = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors(), threadFactory);
+    }
+
+    public abstract void writeAndFlush(final RequestMessage requestMessage) throws Exception;
+
+    @Override
+    public void submit(final RequestMessage requestMessage, final Consumer<ResponseMessage> callback) throws Exception {
+        callbackResponseHandler.callback = callback;
+        writeAndFlush(requestMessage);
+    }
+
+    @Override
+    public List<ResponseMessage> submit(final RequestMessage requestMessage) throws Exception {
+        return submitAsync(requestMessage).get();
+    }
+
+    @Override
+    public CompletableFuture<List<ResponseMessage>> submitAsync(final RequestMessage requestMessage) throws Exception {
+        final List<ResponseMessage> results = new ArrayList<>();
+        final CompletableFuture<List<ResponseMessage>> f = new CompletableFuture<>();
+        callbackResponseHandler.callback = response -> {
+            if (f.isDone())
+                throw new RuntimeException("A terminating message was already encountered - no more messages should have been received");
+
+            results.add(response);
+
+            // check if the current message is terminating - if it is then we can mark complete
+            if (!response.getStatus().getCode().equals(ResponseStatusCode.PARTIAL_CONTENT)) {
+                f.complete(results);
+            }
+        };
+
+        writeAndFlush(requestMessage);
+
+        return f;
+    }
+
+    static class CallbackResponseHandler extends SimpleChannelInboundHandler<ResponseMessage> {
+        public Consumer<ResponseMessage> callback;
+
+        @Override
+        protected void channelRead0(final ChannelHandlerContext channelHandlerContext, final ResponseMessage response) throws Exception {
+            try {
+                callback.accept(response);
+            } finally {
+                ReferenceCountUtil.release(response);
+            }
+        }
+    }
+}

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/NioClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/NioClient.java
@@ -24,43 +24,31 @@ import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
 import org.apache.tinkerpop.gremlin.driver.handler.NioGremlinRequestEncoder;
 import org.apache.tinkerpop.gremlin.driver.handler.NioGremlinResponseDecoder;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
-import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.util.ReferenceCountUtil;
-import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.function.Consumer;
 
 /**
  * A simple, non-thread safe Gremlin Server client using NIO.  Typical use is for testing and demonstration.
  *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
-public class NioClient implements SimpleClient {
+public class NioClient extends AbstractClient {
     private final Channel channel;
-
-    private final EventLoopGroup group;
-    private final CallbackResponseHandler callbackResponseHandler = new CallbackResponseHandler();
 
     public NioClient() {
         this(URI.create("gs://localhost:8182"));
     }
 
     public NioClient(final URI uri) {
-        final BasicThreadFactory threadFactory = new BasicThreadFactory.Builder().namingPattern("nio-client-%d").build();
-        group = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors(), threadFactory);
+        super("nio-client-%d");
         final Bootstrap b = new Bootstrap().group(group);
         b.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
 
@@ -85,8 +73,7 @@ public class NioClient implements SimpleClient {
     }
 
     @Override
-    public void submit(final RequestMessage requestMessage, final Consumer<ResponseMessage> callback) throws Exception {
-        callbackResponseHandler.callback = callback;
+    public void writeAndFlush(final RequestMessage requestMessage) throws Exception {
         channel.writeAndFlush(requestMessage).get();
     }
 
@@ -98,19 +85,6 @@ public class NioClient implements SimpleClient {
 
         } finally {
             group.shutdownGracefully().awaitUninterruptibly();
-        }
-    }
-
-    static class CallbackResponseHandler extends SimpleChannelInboundHandler<ResponseMessage> {
-        public Consumer<ResponseMessage> callback;
-
-        @Override
-        protected void channelRead0(final ChannelHandlerContext channelHandlerContext, final ResponseMessage response) throws Exception {
-            try {
-                callback.accept(response);
-            } finally {
-                ReferenceCountUtil.release(response);
-            }
         }
     }
 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/SimpleClient.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/simple/SimpleClient.java
@@ -23,6 +23,8 @@ import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 
 import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -35,4 +37,16 @@ public interface SimpleClient extends Closeable {
     }
 
     public void submit(final RequestMessage requestMessage, final Consumer<ResponseMessage> callback) throws Exception;
+
+    public default List<ResponseMessage> submit(final String gremlin) throws Exception {
+        return submit(RequestMessage.build(Tokens.OPS_EVAL).addArg(Tokens.ARGS_GREMLIN, gremlin).create());
+    }
+
+    public List<ResponseMessage> submit(final RequestMessage requestMessage) throws Exception;
+
+    public default CompletableFuture<List<ResponseMessage>> submitAsync(final String gremlin) throws Exception {
+        return submitAsync(RequestMessage.build(Tokens.OPS_EVAL).addArg(Tokens.ARGS_GREMLIN, gremlin).create());
+    }
+
+    public CompletableFuture<List<ResponseMessage>> submitAsync(final RequestMessage requestMessage) throws Exception;
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.is;
@@ -638,6 +639,18 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         assertEquals(4, results3.all().get().get(0).getInt());
 
         cluster.close();
+    }
+    @Test
+    public void shouldNotThrowNoSuchElementException() throws Exception {
+        final Cluster cluster = Cluster.open();
+        final Client client = cluster.connect();
+
+        try {
+            // this should return "nothing" - there should be no exception
+            assertNull(client.submit("g.V().has('name','kadfjaldjfla')").one());
+        } finally {
+            cluster.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-916

These implementations provide for a no-frills way to test Gremlin Server. Added methods to collect all messages returned from the server as opposed to just capturing messages via callback.  Updated all integration tests that were using the old methods.

I will update CHANGELOG after the merge for this one.

Tested with: `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE: +1