### PR TITLE
TINKERPOP-1138 Improve messaging on server timeouts

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
+* Improved messages for the different distinct "timeouts" that a user can encounter with Gremlin Server.
 
 [[release-3.1.1-incubating]]
 TinkerPop 3.1.1 (Release Date: February 8, 2016)

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutor.java
@@ -277,7 +277,7 @@ public class GremlinExecutor implements AutoCloseable {
                 // check for that situation and convert to TimeoutException
                 if (root instanceof InterruptedException)
                     evaluationFuture.completeExceptionally(new TimeoutException(
-                            String.format("Script evaluation exceeded the configured threshold of %s ms for request [%s]: %s", scriptEvaluationTimeout, script, root.getMessage())));
+                            String.format("Script evaluation exceeded the configured 'scriptEvaluationTimeout' threshold of %s ms for request [%s]: %s", scriptEvaluationTimeout, script, root.getMessage())));
                 else {
                     lifeCycle.getAfterFailure().orElse(afterFailure).accept(bindings, root);
                     evaluationFuture.completeExceptionally(root);

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/TimedInterruptCustomizerProvider.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/TimedInterruptCustomizerProvider.java
@@ -57,6 +57,7 @@ public class TimedInterruptCustomizerProvider implements CompilerCustomizerProvi
         timedInterruptAnnotationParams.put("value", interruptionTimeout);
         timedInterruptAnnotationParams.put("unit", GeneralUtils.propX(GeneralUtils.classX(TimeUnit.class), TimeUnit.MILLISECONDS.toString()));
         timedInterruptAnnotationParams.put("checkOnMethodStart", false);
+        timedInterruptAnnotationParams.put("thrown", GeneralUtils.classX(TimedInterruptTimeoutException.class));
         return new ASTTransformationCustomizer(timedInterruptAnnotationParams, TimedInterrupt.class);
     }
 }

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/TimedInterruptTimeoutException.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/customizer/TimedInterruptTimeoutException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.groovy.jsr223.customizer;
+
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An exception thrown from the {@link TimedInterruptCustomizerProvider} when the timeout is exceeded. This exception
+ * allows differentiation from other "timeout exceptions" that might occur.
+ */
+public class TimedInterruptTimeoutException extends TimeoutException {
+    public TimedInterruptTimeoutException() {
+    }
+
+    public TimedInterruptTimeoutException(final String message) {
+        super(message);
+    }
+}

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/engine/GremlinExecutorTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.ThreadInterruptCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptCustomizerProvider;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptTimeoutException;
 import org.javatuples.Pair;
 import org.javatuples.Triplet;
 import org.junit.Test;
@@ -501,7 +502,7 @@ public class GremlinExecutorTest {
                 gremlinExecutor.eval("s = System.currentTimeMillis();\nwhile((System.currentTimeMillis() - s) < 10000) {}").get();
                 fail("This should have timed out");
             } catch (Exception se) {
-                assertEquals(TimeoutException.class, se.getCause().getClass());
+                assertEquals(TimedInterruptTimeoutException.class, se.getCause().getClass());
             }
 
             // this script takes significantly less than the interruptionTimeout

--- a/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTimedInterruptTest.java
+++ b/gremlin-groovy/src/test/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngineTimedInterruptTest.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 
 import org.apache.tinkerpop.gremlin.groovy.DefaultImportCustomizerProvider;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptCustomizerProvider;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.TimedInterruptTimeoutException;
 import org.junit.Test;
 
 import javax.script.ScriptEngine;
@@ -42,7 +43,7 @@ public class GremlinGroovyScriptEngineTimedInterruptTest {
             engine.eval("s = System.currentTimeMillis();\nwhile((System.currentTimeMillis() - s) < 10000) {}");
             fail("This should have timed out");
         } catch (ScriptException se) {
-            assertEquals(TimeoutException.class, se.getCause().getCause().getClass());
+            assertEquals(TimedInterruptTimeoutException.class, se.getCause().getCause().getClass());
         }
     }
 
@@ -55,7 +56,7 @@ public class GremlinGroovyScriptEngineTimedInterruptTest {
             engine.eval("s = System.currentTimeMillis();\nwhile((System.currentTimeMillis() - s) < 10000) {}");
             fail("This should have timed out");
         } catch (ScriptException se) {
-            assertEquals(TimeoutException.class, se.getCause().getCause().getClass());
+            assertEquals(TimedInterruptTimeoutException.class, se.getCause().getCause().getClass());
         }
 
         assertEquals(2, engine.eval("1+1"));
@@ -72,7 +73,7 @@ public class GremlinGroovyScriptEngineTimedInterruptTest {
                 engine.eval("s = System.currentTimeMillis();\nwhile((System.currentTimeMillis() - s) < 2000) {}");
                 fail("This should have timed out");
             } catch (ScriptException se) {
-                assertEquals(TimeoutException.class, se.getCause().getCause().getClass());
+                assertEquals(TimedInterruptTimeoutException.class, se.getCause().getCause().getClass());
             }
 
             // this script takes 500 ms less than the interruptionTimeout


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1138

Provide distinct messaging for the different kinds of timeouts that Gremlin Server can generate.

Tested with: `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`

VOTE: +1