### PR TITLE
TINKERPOP-1146 Use GraphProvider.clear() to auto-clear graphs created in tests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Optimized memory-usage in `TraversalVertexProgram`.
+* `Graph` instances are not merely "closed" at the end of tests, they are "cleared" via `GraphProvider.clear()`, which should in turn cleans up old data for an implementation.
 * Greatly reduced the amount of objects required in OLAP for the `ReducingBarrierStep` steps.
 
 [[release-3.1.1-incubating]]

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -22,6 +22,32 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 
 *A 187 On The Undercover Gremlinz*
 
+TinkerPop 3.1.2
+---------------
+
+*Release Date: NOT OFFICIALLY RELEASED YET*
+
+Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.1.1-incubating/CHANGELOG.asciidoc#tinkerpop-312-release-date-XXXXXXXXXXXXXXXXXXXXXXXXXX[changelog] for a complete list of all the modifications that are part of this release.
+
+Upgrading for Providers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+IMPORTANT: It is recommended that providers also review all the upgrade instructions specified for users. Many of the
+changes there may prove important for the provider's implementation.
+
+Graph System Providers
+^^^^^^^^^^^^^^^^^^^^^^
+
+GraphProvider.clear() Semantics
++++++++++++++++++++++++++++++++
+
+The semantics of the various `clear()` methods on `GraphProvider` didn't really change, but it would be worth reviewing
+their implementations to ensure that implementations can be called successfully in an idempotent fashion. Multiple
+calls to `clear()` may occur for a single test on the same `Graph` instance, as `3.1.1-incubating` introduced an
+automated method for clearing graphs at the end of a test and some tests call `clear()` manually.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1146[TINKERPOP-1146]
+
 TinkerPop 3.1.1
 ---------------
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -138,7 +138,7 @@ public abstract class AbstractGremlinTest {
             // which wraps injected GraphProviders with a ManagedGraphProvider instance. If this doesn't happen, there
             // is no way to trace open graphs.
             if(graphProvider instanceof GraphManager.ManagedGraphProvider)
-                ((GraphManager.ManagedGraphProvider)graphProvider).tryCloseGraphs();
+                ((GraphManager.ManagedGraphProvider)graphProvider).tryClearGraphs();
             else
                 logger.warn("The {} is not of type ManagedGraphProvider and therefore graph instances may leak between test cases.", graphProvider.getClass());
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphProvider.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/GraphProvider.java
@@ -152,12 +152,15 @@ public interface GraphProvider {
 
     /**
      * Clears a {@link Graph} of all data and settings.  Implementations will have different ways of handling this.
+     * It is typically expected that {@link Graph#close()} will be called and open transactions will be closed.
      * For a brute force approach, implementers can simply delete data directories provided in the configuration.
      * Implementers may choose a more elegant approach if it exists.
      * <p/>
      * Implementations should be able to accept an argument of null for the Graph, in which case the only action
      * that can be performed is a clear given the configuration.  The method will typically be called this way
      * as clean up task on setup to ensure that a persisted graph has a clear space to create a test graph.
+     * <p/>
+     * Calls to this method may occur multiple times for a specific test. Develop this method to be idempotent.
      */
     public void clear(final Graph graph, final Configuration configuration) throws Exception;
 

--- a/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
+++ b/neo4j-gremlin/src/test/java/org/apache/tinkerpop/gremlin/neo4j/AbstractNeo4jGraphProvider.java
@@ -57,8 +57,7 @@ public abstract class AbstractNeo4jGraphProvider extends AbstractGraphProvider {
     @Override
     public void clear(final Graph graph, final Configuration configuration) throws Exception {
         if (null != graph) {
-            if (graph.features().graph().supportsTransactions() && graph.tx().isOpen())
-                graph.tx().rollback();
+            if (graph.tx().isOpen()) graph.tx().rollback();
             graph.close();
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1146

Was formerly just calling `Graph.close()` which wasn't enough to actually empty graphs of data. This led to test errors for some graph providers.  This change actually calls `GraphProvider.clear()` which by definition should empty a graph of data at the end of a test.

To test you technically need a graph that is persistent (e.g. Neo4j). Ran `mvn clean install -DincludeNeo4j` without problems.

VOTE +1