### PR TITLE
Tp31  - fix for gremlin server and console to open Neo4j 2.3.* databases

### DIFF
--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -190,7 +190,7 @@ limitations under the License.
                 <dependency>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-tinkerpop-api-impl</artifactId>
-                    <version>0.1-2.2</version>
+                    <version>0.3-2.3.2</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- *** WARNING *** -->

--- a/neo4j-gremlin/pom.xml
+++ b/neo4j-gremlin/pom.xml
@@ -114,7 +114,7 @@ limitations under the License.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.1-2.2
+                            <Gremlin-Plugin-Dependencies>org.neo4j:neo4j-tinkerpop-api-impl:0.3-2.3.2
                             </Gremlin-Plugin-Dependencies>
                         </manifestEntries>
                     </archive>


### PR DESCRIPTION
Neo4j 2.3.0 changed the format of the neostore.nodestore.db 

This causes Neo4j databases created w/ Gremlin-server (e.g.  /tmp/neo4j) and neo4j databases created by the neo4j server from neo4j.com to be incompatible with each other.   Also Gremlin-server/console cannot open databases created by the newer Neo4j code (2.3.0 and higher)

The fix is two one line each in the gremlin pom files:
   gremlin-server/pom.xml
   neo4j-gremlin/pom.xml
