### PR TITLE
slf4j-log4j12 / log4j is only required for testing (TINKERPOP-1151)

### DIFF
--- a/gremlin-core/pom.xml
+++ b/gremlin-core/pom.xml
@@ -66,6 +66,7 @@ limitations under the License.
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/TINKERPOP-1151