### PR TITLE
TINKERPOP-1153 & TINKERPOP-1154: (Summary) Multi-OLAP compilation in a single Traversal (hardened)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,15 @@ TinkerPop 3.2.0 (XXX)
 TinkerPop 3.2.0 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `PeerPressureVertexProgramStep` and `GraphTraversal.peerPressure()`.
+* Added `PureTraversal` for handling pure and compiled versions of a `Traversal`. Useful in OLAP.
+* Added `ScriptTraversal` which allows for delayed compilation of script-based `Traversals`.
+* Simplified `VertexProgram` implementations with a `PureTraversal`-model and deprecated `ConfigurationTraversal`.
+* Simplified script-based `Traversals` via `ScriptTraversal` and deprecated `TraversalScriptFunction` and `TraversalScriptHelper`.
+* Added `ByModulating` interface which allows the `Step` to decide how a `by()`-modulation should be handled. (*breaking*)
+* Simplified the `by()`-modulation patterns of `OrderGlobalStep` and `OrderLocalStep`.
+* Added `GraphComputerTest.shouldSupportPreExistingComputeKeys()` to ensure existing compute keys are "revived." (*breaking*)
+* Added `GraphComputerTest.shouldSupportJobChaining()` to ensure OLAP jobs can be linearly chained. (*breaking*)
 * Fixed a bug in both `SparkGraphComputer` and `GiraphGraphComputer` regarding source data access in job chains.
 * Expanded job chaining test coverage for `GraphComputer` providers.
 * Added `TraversalHelper.onGraphComputer(traversal)`.

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -186,54 +186,74 @@ methods of a `VertexProgram`, the PageRankVertexProgram code is analyzed below.
 
 [source,java]
 ----
-public class PageRankVertexProgram implements VertexProgram<Double> { <1>
+public class PageRankVertexProgram extends StaticVertexProgram<Double> { <1>
 
-    private MessageScope.Local<Double> incidentMessageScope = MessageScope.Local.of(__::outE); <2>
-    private MessageScope.Local<Double> countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
-
-    public static final String PAGE_RANK = "gremlin.pageRankVertexProgram.pageRank"; <3>
+    public static final String PAGE_RANK = "gremlin.pageRankVertexProgram.pageRank";
     public static final String EDGE_COUNT = "gremlin.pageRankVertexProgram.edgeCount";
 
+    public static final String PROPERTY = "gremlin.pageRankVertexProgram.property";
     private static final String VERTEX_COUNT = "gremlin.pageRankVertexProgram.vertexCount";
     private static final String ALPHA = "gremlin.pageRankVertexProgram.alpha";
     private static final String TOTAL_ITERATIONS = "gremlin.pageRankVertexProgram.totalIterations";
-    private static final String INCIDENT_TRAVERSAL_SUPPLIER = "gremlin.pageRankVertexProgram.incidentTraversalSupplier";
+    private static final String EDGE_TRAVERSAL = "gremlin.pageRankVertexProgram.edgeTraversal";
+    private static final String VERTEX_TRAVERSAL = "gremlin.pageRankVertexProgram.vertexTraversal";
 
-    private ConfigurationTraversal<Vertex, Edge> configurationTraversal;
+    private MessageScope.Local<Double> incidentMessageScope = MessageScope.Local.of(__::outE); <2>
+    private MessageScope.Local<Double> countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
+    private PureTraversal<Vertex, Edge> edgeTraversal = null;
+    private PureTraversal<Vertex, Vertex> vertexTraversal = null;
     private double vertexCountAsDouble = 1.0d;
     private double alpha = 0.85d;
     private int totalIterations = 30;
+    private String property = PAGE_RANK; <3>
+    private Set<String> computeKeys;
 
-    private static final Set<String> COMPUTE_KEYS = new HashSet<>(Arrays.asList(PAGE_RANK, EDGE_COUNT));
+    private PageRankVertexProgram() {
 
-    private PageRankVertexProgram() {}
+    }
 
     @Override
     public void loadState(final Graph graph, final Configuration configuration) { <4>
-        if (configuration.containsKey(TRAVERSAL_SUPPLIER)) {
-                    this.configurationTraversal = ConfigurationTraversal.loadState(graph, configuration, TRAVERSAL_SUPPLIER);
-                    this.incidentMessageScope = MessageScope.Local.of(this.configurationTraversal);
-                    this.countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
-                }
+        if (configuration.containsKey(VERTEX_TRAVERSAL))
+            this.vertexTraversal = PureTraversal.loadState(configuration, VERTEX_TRAVERSAL, graph);
+        if (configuration.containsKey(EDGE_TRAVERSAL)) {
+            this.edgeTraversal = PureTraversal.loadState(configuration, EDGE_TRAVERSAL, graph);
+            this.incidentMessageScope = MessageScope.Local.of(() -> this.edgeTraversal.get().clone());
+            this.countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
+        }
         this.vertexCountAsDouble = configuration.getDouble(VERTEX_COUNT, 1.0d);
         this.alpha = configuration.getDouble(ALPHA, 0.85d);
         this.totalIterations = configuration.getInt(TOTAL_ITERATIONS, 30);
+        this.property = configuration.getString(PROPERTY, PAGE_RANK);
+        this.computeKeys = new HashSet<>(Arrays.asList(this.property, EDGE_COUNT));
     }
 
     @Override
     public void storeState(final Configuration configuration) {
-        configuration.setProperty(VERTEX_PROGRAM, PageRankVertexProgram.class.getName());
+        super.storeState(configuration);
         configuration.setProperty(VERTEX_COUNT, this.vertexCountAsDouble);
         configuration.setProperty(ALPHA, this.alpha);
         configuration.setProperty(TOTAL_ITERATIONS, this.totalIterations);
-        if (null != this.traversalSupplier) {
-            this.traversalSupplier.storeState(configuration);
-        }
+        configuration.setProperty(PROPERTY, this.property);
+        if (null != this.edgeTraversal)
+            this.edgeTraversal.storeState(configuration, EDGE_TRAVERSAL);
+        if (null != this.vertexTraversal)
+            this.vertexTraversal.storeState(configuration, VERTEX_TRAVERSAL);
     }
 
     @Override
-    public Set<String> getElementComputeKeys() { <5>
-        return COMPUTE_KEYS;
+    public GraphComputer.ResultGraph getPreferredResultGraph() {
+        return GraphComputer.ResultGraph.NEW;
+    }
+
+    @Override
+    public GraphComputer.Persist getPreferredPersist() {
+        return GraphComputer.Persist.VERTEX_PROPERTIES;
+    }
+
+    @Override
+    public Set<String> getElementComputeKeys() {  <5>
+        return this.computeKeys;
     }
 
     @Override
@@ -242,9 +262,9 @@ public class PageRankVertexProgram implements VertexProgram<Double> { <1>
     }
 
     @Override
-    public Set<MessageScope> getMessageScopes(final int iteration) {
+    public Set<MessageScope> getMessageScopes(final Memory memory) {
         final Set<MessageScope> set = new HashSet<>();
-        set.add(0 == iteration ? this.countMessageScope : this.incidentMessageScope);
+        set.add(memory.isInitialIteration() ? this.countMessageScope : this.incidentMessageScope);
         return set;
     }
 
@@ -253,39 +273,41 @@ public class PageRankVertexProgram implements VertexProgram<Double> { <1>
 
     }
 
-   @Override
-    public void execute(final Vertex vertex, Messenger<Double> messenger, final Memory memory) { <6>
-        if (memory.isInitialIteration()) {  <7>
-            messenger.sendMessage(this.countMessageScope, 1.0d);
-        } else if (1 == memory.getIteration()) {  <8>
-            double initialPageRank = 1.0d / this.vertexCountAsDouble;
+    @Override
+    public void execute(final Vertex vertex, Messenger<Double> messenger, final Memory memory) {  <6>
+        if (memory.isInitialIteration()) {
+            messenger.sendMessage(this.countMessageScope, 1.0d); <7>
+        } else if (1 == memory.getIteration()) {
+            double initialPageRank = 1.0d / this.vertexCountAsDouble; <8>
             double edgeCount = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
-            vertex.property(PAGE_RANK, initialPageRank);
-            vertex.property(EDGE_COUNT, edgeCount);
+            vertex.property(VertexProperty.Cardinality.single, this.property, initialPageRank);
+            vertex.property(VertexProperty.Cardinality.single, EDGE_COUNT, edgeCount);
             messenger.sendMessage(this.incidentMessageScope, initialPageRank / edgeCount);
-        } else { <9>
-            double newPageRank = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
+        } else {
+            if (2 == memory.getIteration() && null != this.vertexTraversal && !TraversalUtil.test(vertex, this.vertexTraversal.get()))
+                return;
+            double newPageRank = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b); <9>
             newPageRank = (this.alpha * newPageRank) + ((1.0d - this.alpha) / this.vertexCountAsDouble);
-            vertex.property(PAGE_RANK, newPageRank);
+            vertex.property(VertexProperty.Cardinality.single, this.property, newPageRank);
             messenger.sendMessage(this.incidentMessageScope, newPageRank / vertex.<Double>value(EDGE_COUNT));
         }
     }
 
     @Override
-    public boolean terminate(final Memory memory) { <10>
-        return memory.getIteration() >= this.totalIterations;
+    public boolean terminate(final Memory memory) {
+        return memory.getIteration() >= this.totalIterations; <10>
     }
 
     @Override
     public String toString() {
-        return StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ",iterations=" + this.totalIterations);
+        return StringFactory.vertexProgramString(this, "alpha=" + this.alpha + ", iterations=" + this.totalIterations);
     }
 }
 ----
 
 <1> `PageRankVertexProgram` implements `VertexProgram<Double>` because the messages it sends are Java doubles.
 <2> The default path of energy propagation is via outgoing edges from the current vertex.
-<3> The resulting PageRank values for the vertices are stored as a hidden property.
+<3> The resulting PageRank values for the vertices are stored as a vertex property.
 <4> A vertex program is constructed using an Apache `Configuration` to ensure easy dissemination across a cluster of JVMs.
 <5> A vertex program must define the "compute keys" that are the properties being operated on during the computation.
 <6> The "while"-loop of the vertex program.
@@ -301,7 +323,15 @@ The above `PageRankVertexProgram` is used as follows.
 result = graph.compute().program(PageRankVertexProgram.build().create()).submit().get()
 result.memory().runtime
 g = result.graph().traversal()
-g.V().valueMap('name',PageRankVertexProgram.PAGE_RANK)
+g.V().valueMap('name', PageRankVertexProgram.PAGE_RANK)
+----
+
+Note that `GraphTraversal` provides a <<pagerank-step,`pageRank()`>>-step.
+
+[gremlin-groovy,modern]
+----
+g = graph.traversal().withComputer()
+g.V().pageRank().valueMap('name', PageRankVertexProgram.PAGE_RANK)
 ----
 
 [[peerpressurevertexprogram]]

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -1215,6 +1215,37 @@ g.V().groupCount().by(inE().count()).order(local).by(keys, incr) <4>
 
 NOTE: The `values` and `keys` enums are from `Column` which is used to select "columns" from a `Map`, `Map.Entry`, or `Path`.
 
+[[pagerank-step]]
+PageRank Step
+~~~~~~~~~~~~~
+
+The `pageRank()`-step (*map*/*sideEffect*) calculates link:http://en.wikipedia.org/wiki/PageRank[PageRank] using <<pagerankvertexprogram,`PageRankVertexProgram`>>.
+
+IMPORTANT: The `pageRank()`-step is a `VertexComputing`-step and as such, can only be used against a graph that supports `GraphComputer` (OLAP).
+
+[gremlin-groovy,modern]
+----
+g = graph.traversal().withComputer()
+g.V().pageRank().by('pageRank').values('pageRank')
+g.V().hasLabel('person').
+  pageRank().
+    by(outE('knows')).
+    by('friendRank').
+  order().by('friendRank',decr).valueMap('name','friendRank')
+----
+
+The <<explain-step,`explain()`>>-step can be used to understand how the traversal is compiled into multiple `GraphComputer` jobs.
+
+[gremlin-groovy,modern]
+----
+g = graph.traversal().withComputer()
+g.V().hasLabel('person').
+  pageRank().
+    by(outE('knows')).
+    by('friendRank').
+  order().by('friendRank',decr).valueMap('name','friendRank').explain()
+----
+
 [[path-step]]
 Path Step
 ~~~~~~~~~
@@ -1284,6 +1315,23 @@ path.a
 path.b
 path.c
 path.d == path.e
+----
+
+[[peerpressure-step]]
+PeerPressure Step
+~~~~~~~~~~~~~~~~~
+
+The `peerPressure()`-step (*map*/*sideEffect*) clusters vertices using <<peerpressurevertexprogram,`PeerPressureVertexProgram`>>.
+
+IMPORTANT: The `peerPressure()`-step is a `VertexComputing`-step and as such, can only be used against a graph that supports `GraphComputer` (OLAP).
+
+[gremlin-groovy,modern]
+----
+g = graph.traversal().withComputer()
+g.V().peerPressure().by('cluster').values('cluster')
+g.V().hasLabel('person').
+  peerPressure().by('cluster').
+  group().by('cluster').by('name')
 ----
 
 [[profile-step]]

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -32,6 +32,22 @@ Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.2.0-inc
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+ScriptTraversal and Gremlin Language Variants
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Providers that have custom Gremlin language implementations (e.g. Gremlin-Scala), there is a new class called `ScriptTraversal`
+which will handle script-based processing of traversals. The entire `GroovyXXXTest`-suite was updated to use this new class.
+The previous `TraversalScriptHelper` class has been deprecated so immediate upgrading is not required, but do look into
+`ScriptTraversal` as TinkerPop will be using it as a way to serialize "String-based traversals" over the network.
+
+ByModulating and Custom Steps
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the provider has custom steps that leverage `by()`-modulation, those will now need to implement `ByModulating`.
+Most of the methods in `ByModulating` are `default` and, for most situations, only `ByModulating.modulateBy(Traversal)`
+needs to be implemented. Note that this method's body will most like be identical the custom step's already existing
+`TraversalParent.addLocalChild()`.
+
 TraversalEngine Deprecation and GraphProvider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -59,3 +75,20 @@ and ensure that `GraphFilter` is processed correctly. There is a new test case c
 which ensures the semantics of `GraphFilter` are handled correctly. For a "quick and easy" way to move forward, look to
 `GraphFilterInputFormat` as a way of wrapping an existing `InputFormat` to do filtering prior to `VertexProgram` or `MapReduce`
 execution.
+
+Job Chaining and GraphComputer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TinkerPop 3.2.0 has integrated `VertexPrograms` into `GraphTraversal`. This means, that a single traversal can compile to multiple
+`GraphComputer` OLAP jobs. This requires that `ComputeResults` be chainable. There was never any explicit tests to verify if a
+providers `GraphComputer` could be chained, but now there are
+
+* For providers that support their own `GraphComputer` implementation, note that there is a new `GraphComputerTest.shouldSupportJobChaining()`.
+This tests verifies that the `ComputerResult` output of one job can be fed into the input of a subsequent job. Only linear chains are tested/required
+currently. In the future, branching DAGs may be required.
+
+* For providers that support their own `GraphComputer` implementation, note that there is a new `GraphComputerTest.shouldSupportPreExistingComputeKeys()`.
+When chaining OLAP jobs together, if an OLAP job requires the compute keys of a previous OLAP job, then the existing compute keys must be accessible.
+A simple 2 line change to `SparkGraphComputer` and `TinkerGraphComputer` solved this for TinkerPop.
+`GiraphGraphComputer` did not need an update as this feature was already naturally supported.
+

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/bulkloading/BulkLoaderVertexProgram.java
@@ -301,12 +301,12 @@ public class BulkLoaderVertexProgram implements VertexProgram<Tuple> {
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         if (bulkLoader != null) {
-            sb.append("bulkLoader=").append(bulkLoader.getClass().getSimpleName()).append(",");
-            sb.append("vertexIdProperty=").append(bulkLoader.getVertexIdProperty()).append(",");
-            sb.append("userSuppliedIds=").append(bulkLoader.useUserSuppliedIds()).append(",");
-            sb.append("keepOriginalIds=").append(bulkLoader.keepOriginalIds()).append(",");
+            sb.append("bulkLoader=").append(bulkLoader.getClass().getSimpleName()).append(", ");
+            sb.append("vertexIdProperty=").append(bulkLoader.getVertexIdProperty()).append(", ");
+            sb.append("userSuppliedIds=").append(bulkLoader.useUserSuppliedIds()).append(", ");
+            sb.append("keepOriginalIds=").append(bulkLoader.keepOriginalIds()).append(", ");
         } else {
-            sb.append("bulkLoader=").append(bulkLoader).append(",");
+            sb.append("bulkLoader=").append(bulkLoader).append(", ");
         }
         sb.append("batchSize=").append(intermediateBatchSize);
         return StringFactory.vertexProgramString(this, sb.toString());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -189,7 +189,7 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
 
     @Override
     public String toString() {
-        return StringFactory.vertexProgramString(this, "distributeVote=" + this.distributeVote + ",maxIterations=" + this.maxIterations);
+        return StringFactory.vertexProgramString(this, "distributeVote=" + this.distributeVote + ", maxIterations=" + this.maxIterations);
     }
 
     //////////////////////////////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -92,6 +92,7 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
     @Override
     public void storeState(final Configuration configuration) {
         super.storeState(configuration);
+        configuration.setProperty(PROPERTY, this.property);
         configuration.setProperty(MAX_ITERATIONS, this.maxIterations);
         configuration.setProperty(DISTRIBUTE_VOTE, this.distributeVote);
         if (null != this.edgeTraversal)

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -80,7 +80,7 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
     public void loadState(final Graph graph, final Configuration configuration) {
         if (configuration.containsKey(EDGE_TRAVERSAL)) {
             this.edgeTraversal = PureTraversal.loadState(configuration, EDGE_TRAVERSAL, graph);
-            this.voteScope = MessageScope.Local.of(() -> this.edgeTraversal.getCompiled().clone());
+            this.voteScope = MessageScope.Local.of(() -> this.edgeTraversal.get().clone());
             this.countScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.voteScope));
         }
         this.maxIterations = configuration.getInt(MAX_ITERATIONS, 30);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/clustering/peerpressure/PeerPressureVertexProgram.java
@@ -30,9 +30,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MapHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalClassFunction;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalObjectFunction;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -217,8 +217,7 @@ public class PeerPressureVertexProgram extends StaticVertexProgram<Pair<Serializ
         }
 
         public Builder traversal(final TraversalSource traversalSource, final String scriptEngine, final String traversalScript, final Object... bindings) {
-            ConfigurationTraversal.storeState(new TraversalScriptFunction<>(traversalSource, scriptEngine, traversalScript, bindings), this.configuration, TRAVERSAL_SUPPLIER);
-            return this;
+            return this.traversal(new ScriptTraversal<>(traversalSource, scriptEngine, traversalScript, bindings));
         }
 
         public Builder traversal(final Traversal.Admin<Vertex, Edge> traversal) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -24,8 +24,8 @@ import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MessageCombiner;
 import org.apache.tinkerpop.gremlin.process.computer.MessageScope;
 import org.apache.tinkerpop.gremlin.process.computer.Messenger;
+import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.util.AbstractVertexProgramBuilder;
-import org.apache.tinkerpop.gremlin.process.computer.util.StaticVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
@@ -47,7 +47,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class PageRankVertexProgram extends StaticVertexProgram<Double> {
+public class PageRankVertexProgram implements VertexProgram<Double> {
 
 
     public static final String PAGE_RANK = "gremlin.pageRankVertexProgram.pageRank";
@@ -92,7 +92,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
 
     @Override
     public void storeState(final Configuration configuration) {
-        super.storeState(configuration);
+        VertexProgram.super.storeState(configuration);
         configuration.setProperty(VERTEX_COUNT, this.vertexCountAsDouble);
         configuration.setProperty(ALPHA, this.alpha);
         configuration.setProperty(TOTAL_ITERATIONS, this.totalIterations);
@@ -128,6 +128,18 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
         final Set<MessageScope> set = new HashSet<>();
         set.add(memory.isInitialIteration() ? this.countMessageScope : this.incidentMessageScope);
         return set;
+    }
+
+    @Override
+    public PageRankVertexProgram clone() {
+        try {
+            final PageRankVertexProgram clone = (PageRankVertexProgram) super.clone();
+            if (null != this.initialRankTraversal)
+                clone.initialRankTraversal = this.initialRankTraversal.clone();
+            return clone;
+        } catch (final CloneNotSupportedException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -80,7 +80,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
             this.vertexTraversal = PureTraversal.loadState(configuration, VERTEX_TRAVERSAL, graph);
         if (configuration.containsKey(EDGE_TRAVERSAL)) {
             this.edgeTraversal = PureTraversal.loadState(configuration, EDGE_TRAVERSAL, graph);
-            this.incidentMessageScope = MessageScope.Local.of(() -> this.edgeTraversal.getCompiled().clone());
+            this.incidentMessageScope = MessageScope.Local.of(() -> this.edgeTraversal.get().clone());
             this.countMessageScope = MessageScope.Local.of(new MessageScope.Local.ReverseTraversalSupplier(this.incidentMessageScope));
         }
         this.vertexCountAsDouble = configuration.getDouble(VERTEX_COUNT, 1.0d);
@@ -146,7 +146,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
             vertex.property(VertexProperty.Cardinality.single, EDGE_COUNT, edgeCount);
             messenger.sendMessage(this.incidentMessageScope, initialPageRank / edgeCount);
         } else {
-            if (2 == memory.getIteration() && null != this.vertexTraversal && !TraversalUtil.test(vertex, this.vertexTraversal.getCompiled()))
+            if (2 == memory.getIteration() && null != this.vertexTraversal && !TraversalUtil.test(vertex, this.vertexTraversal.get()))
                 return;
             double newPageRank = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
             newPageRank = (this.alpha * newPageRank) + ((1.0d - this.alpha) / this.vertexCountAsDouble);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -30,9 +30,9 @@ import org.apache.tinkerpop.gremlin.process.computer.util.StaticVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalClassFunction;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalObjectFunction;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -179,8 +179,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
         }
 
         public Builder traversal(final TraversalSource traversalSource, final String scriptEngine, final String traversalScript, final Object... bindings) {
-            ConfigurationTraversal.storeState(new TraversalScriptFunction<>(traversalSource, scriptEngine, traversalScript, bindings), this.configuration, TRAVERSAL_SUPPLIER);
-            return this;
+            return this.traversal(new ScriptTraversal<>(traversalSource, scriptEngine, traversalScript, bindings));
         }
 
         public Builder traversal(final Traversal.Admin<Vertex, Edge> traversal) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -53,7 +53,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
     public static final String PAGE_RANK = "gremlin.pageRankVertexProgram.pageRank";
     public static final String EDGE_COUNT = "gremlin.pageRankVertexProgram.edgeCount";
 
-    public static final String PAGE_RANK_PROPERTY = "gremlin.pageRankVertexProgram.pageRankProperty";
+    public static final String PROPERTY = "gremlin.pageRankVertexProgram.property";
     private static final String VERTEX_COUNT = "gremlin.pageRankVertexProgram.vertexCount";
     private static final String ALPHA = "gremlin.pageRankVertexProgram.alpha";
     private static final String TOTAL_ITERATIONS = "gremlin.pageRankVertexProgram.totalIterations";
@@ -67,7 +67,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
     private double vertexCountAsDouble = 1.0d;
     private double alpha = 0.85d;
     private int totalIterations = 30;
-    private String pageRankProperty = PAGE_RANK;
+    private String property = PAGE_RANK;
     private Set<String> computeKeys;
 
     private PageRankVertexProgram() {
@@ -86,9 +86,8 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
         this.vertexCountAsDouble = configuration.getDouble(VERTEX_COUNT, 1.0d);
         this.alpha = configuration.getDouble(ALPHA, 0.85d);
         this.totalIterations = configuration.getInt(TOTAL_ITERATIONS, 30);
-        this.pageRankProperty = configuration.getString(PAGE_RANK_PROPERTY, PAGE_RANK);
-        this.computeKeys = new HashSet<>(Arrays.asList(this.pageRankProperty, EDGE_COUNT));
-
+        this.property = configuration.getString(PROPERTY, PAGE_RANK);
+        this.computeKeys = new HashSet<>(Arrays.asList(this.property, EDGE_COUNT));
     }
 
     @Override
@@ -97,7 +96,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
         configuration.setProperty(VERTEX_COUNT, this.vertexCountAsDouble);
         configuration.setProperty(ALPHA, this.alpha);
         configuration.setProperty(TOTAL_ITERATIONS, this.totalIterations);
-        configuration.setProperty(PAGE_RANK_PROPERTY, this.pageRankProperty);
+        configuration.setProperty(PROPERTY, this.property);
         if (null != this.edgeTraversal)
             this.edgeTraversal.storeState(configuration, EDGE_TRAVERSAL);
         if (null != this.vertexTraversal)
@@ -143,7 +142,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
         } else if (1 == memory.getIteration()) {
             double initialPageRank = 1.0d / this.vertexCountAsDouble;
             double edgeCount = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
-            vertex.property(VertexProperty.Cardinality.single, this.pageRankProperty, initialPageRank);
+            vertex.property(VertexProperty.Cardinality.single, this.property, initialPageRank);
             vertex.property(VertexProperty.Cardinality.single, EDGE_COUNT, edgeCount);
             messenger.sendMessage(this.incidentMessageScope, initialPageRank / edgeCount);
         } else {
@@ -151,7 +150,7 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
                 return;
             double newPageRank = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
             newPageRank = (this.alpha * newPageRank) + ((1.0d - this.alpha) / this.vertexCountAsDouble);
-            vertex.property(VertexProperty.Cardinality.single, this.pageRankProperty, newPageRank);
+            vertex.property(VertexProperty.Cardinality.single, this.property, newPageRank);
             messenger.sendMessage(this.incidentMessageScope, newPageRank / vertex.<Double>value(EDGE_COUNT));
         }
     }
@@ -188,8 +187,8 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
             return this;
         }
 
-        public Builder pageRankProperty(final String key) {
-            this.configuration.setProperty(PAGE_RANK_PROPERTY, key);
+        public Builder property(final String key) {
+            this.configuration.setProperty(PROPERTY, key);
             return this;
         }
 
@@ -208,11 +207,17 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
             return this;
         }
 
+        /**
+         * @deprecated As of release 3.2.0, replaced by {@link org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram.Builder#edges(Traversal.Admin)}
+         */
         @Deprecated
         public Builder traversal(final TraversalSource traversalSource, final String scriptEngine, final String traversalScript, final Object... bindings) {
             return this.edges(new ScriptTraversal<>(traversalSource, scriptEngine, traversalScript, bindings));
         }
 
+        /**
+         * @deprecated As of release 3.2.0, replaced by {@link org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram.Builder#edges(Traversal.Admin)}
+         */
         @Deprecated
         public Builder traversal(final Traversal.Admin<Vertex, Edge> traversal) {
             return this.edges(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/ranking/pagerank/PageRankVertexProgram.java
@@ -140,9 +140,9 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
         if (memory.isInitialIteration()) {
             messenger.sendMessage(this.countMessageScope, 1.0d);
         } else if (1 == memory.getIteration()) {
-            double initialPageRank = null == this.initialRankTraversal ?
+            double initialPageRank = (null == this.initialRankTraversal ?
                     1.0d :
-                    TraversalUtil.apply(vertex, this.initialRankTraversal.get()).doubleValue() / this.vertexCountAsDouble;
+                    TraversalUtil.apply(vertex, this.initialRankTraversal.get()).doubleValue()) / this.vertexCountAsDouble;
             double edgeCount = IteratorUtils.reduce(messenger.receiveMessages(), 0.0d, (a, b) -> a + b);
             vertex.property(VertexProperty.Cardinality.single, this.property, initialPageRank);
             vertex.property(VertexProperty.Cardinality.single, EDGE_COUNT, edgeCount);
@@ -194,11 +194,6 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
             return this;
         }
 
-        public Builder vertexCount(final long vertexCount) {
-            this.configuration.setProperty(VERTEX_COUNT, (double) vertexCount);
-            return this;
-        }
-
         public Builder edges(final Traversal.Admin<Vertex, Edge> edgeTraversal) {
             PureTraversal.storeState(this.configuration, EDGE_TRAVERSAL, edgeTraversal);
             return this;
@@ -206,6 +201,15 @@ public class PageRankVertexProgram extends StaticVertexProgram<Double> {
 
         public Builder initialRank(final Traversal.Admin<Vertex, ? extends Number> initialRankTraversal) {
             PureTraversal.storeState(this.configuration, INITIAL_RANK_TRAVERSAL, initialRankTraversal);
+            return this;
+        }
+
+        /**
+         * @deprecated As of release 3.2.0, replaced by {@link org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram.Builder#initialRank(Traversal.Admin)}
+         */
+        @Deprecated
+        public Builder vertexCount(final long vertexCount) {
+            this.configuration.setProperty(VERTEX_COUNT, (double) vertexCount);
             return this;
         }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -40,11 +40,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SideEffect
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
 import org.apache.tinkerpop.gremlin.process.traversal.util.EmptyTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalClassFunction;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMatrix;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalObjectFunction;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptFunction;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -280,8 +280,7 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
         }
 
         public Builder traversal(final TraversalSource traversalSource, final String scriptEngine, final String traversalScript, final Object... bindings) {
-            ConfigurationTraversal.storeState(new TraversalScriptFunction<>(traversalSource, scriptEngine, traversalScript, bindings), this.configuration, TRAVERSAL_SUPPLIER);
-            return this;
+            return this.traversal(new ScriptTraversal<>(traversalSource, scriptEngine, traversalScript, bindings));
         }
 
         public Builder traversal(final Traversal.Admin<?, ?> traversal) {
@@ -293,8 +292,6 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
             ConfigurationTraversal.storeState(new TraversalClassFunction(traversalClass), this.configuration, TRAVERSAL_SUPPLIER);
             return this;
         }
-
-        // TODO Builder resolveElements(boolean) to be fed to ComputerResultStep
     }
 
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -106,7 +106,9 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
         if (!configuration.containsKey(TRAVERSAL))
             throw new IllegalArgumentException("The configuration does not have a traversal supplier: " + TRAVERSAL);
         this.pureTraversal = PureTraversal.loadState(configuration, TRAVERSAL, graph);
-        this.traversal = this.pureTraversal.getCompiled();
+        this.traversal = this.pureTraversal.get();
+        if (!this.traversal.isLocked())
+            this.traversal.applyStrategies();
         this.traversalMatrix = new TraversalMatrix<>(this.traversal);
         for (final MapReducer<?, ?, ?, ?, ?> mapReducer : TraversalHelper.getStepsOfAssignableClassRecursively(MapReducer.class, this.traversal)) {
             this.mapReducers.add(mapReducer.getMapReduce());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraversalVertexProgram.java
@@ -137,10 +137,10 @@ public final class TraversalVertexProgram implements VertexProgram<TraverserSet<
         if (memory.isInitialIteration()) {    // ITERATION 1
             if (!(this.traversal.getStartStep() instanceof GraphStep)) {  // NOT A GRAPH-STEP TRAVERSAL
                 final TraverserSet<Object> haltedTraversers = vertex.<TraverserSet<Object>>property(HALTED_TRAVERSERS).orElse(new TraverserSet<>());
+                vertex.property(VertexProperty.Cardinality.single, HALTED_TRAVERSERS, haltedTraversers);
                 if (haltedTraversers.isEmpty()) {
                     memory.and(VOTE_TO_HALT, true);
                 } else {
-                    vertex.property(VertexProperty.Cardinality.single, HALTED_TRAVERSERS, haltedTraversers);
                     final TraverserSet<Object> aliveTraverses = new TraverserSet<>();
                     haltedTraversers.forEach(traverser -> {
                         traverser.setStepId(this.traversal.getStartStep().getId());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/lambda/HaltedTraversersCountTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/lambda/HaltedTraversersCountTraversal.java
@@ -35,7 +35,7 @@ public final class HaltedTraversersCountTraversal extends AbstractLambdaTraversa
 
     @Override
     public Long next() {
-        return count;
+        return this.count;
     }
 
     @Override
@@ -46,7 +46,7 @@ public final class HaltedTraversersCountTraversal extends AbstractLambdaTraversa
 
     @Override
     public String toString() {
-        return "count(" + TraversalVertexProgram.HALTED_TRAVERSERS + ')';
+        return "count(" + TraversalVertexProgram.HALTED_TRAVERSERS + ")";
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/lambda/HaltedTraversersCountTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/lambda/HaltedTraversersCountTraversal.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer.traversal.lambda;
+
+import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.AbstractLambdaTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class HaltedTraversersCountTraversal extends AbstractLambdaTraversal<Vertex, Long> {
+
+    private Long count;
+
+    @Override
+    public Long next() {
+        return count;
+    }
+
+    @Override
+    public void addStart(final Traverser<Vertex> start) {
+        final VertexProperty<TraverserSet<Object>> property = start.get().<TraverserSet<Object>>property(TraversalVertexProgram.HALTED_TRAVERSERS);
+        this.count = property.isPresent() ? property.value().bulkSize() : 0l;
+    }
+
+    @Override
+    public String toString() {
+        return "count(" + TraversalVertexProgram.HALTED_TRAVERSERS + ')';
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getClass().hashCode();
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ComputerResultStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ComputerResultStep.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierS
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
@@ -60,7 +61,7 @@ public final class ComputerResultStep<S> extends AbstractStep<ComputerResult, S>
     public Iterator<Traverser.Admin<S>> attach(final Iterator<Traverser.Admin<S>> iterator, final Graph graph) {
         return IteratorUtils.map(iterator, traverser -> {
             traverser.setSideEffects(this.getTraversal().getSideEffects());   // necessary to ensure no NPE
-            if (this.attachElements && (traverser.get() instanceof Attachable))
+            if (this.attachElements && (traverser.get() instanceof Attachable) && !(traverser.get() instanceof Property))
                 traverser.set((S) ((Attachable<Element>) traverser.get()).attach(Attachable.Method.get(graph)));
             return traverser;
         });
@@ -110,7 +111,7 @@ public final class ComputerResultStep<S> extends AbstractStep<ComputerResult, S>
 
     @Override
     public ComputerResultStep<S> clone() {
-        final ComputerResultStep<S> clone = (ComputerResultStep<S>)super.clone();
+        final ComputerResultStep<S> clone = (ComputerResultStep<S>) super.clone();
         clone.currentIterator = EmptyIterator.instance();
         return clone;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ComputerResultStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ComputerResultStep.java
@@ -76,7 +76,7 @@ public final class ComputerResultStep<S> extends AbstractStep<ComputerResult, S>
                 final ComputerResult result = this.starts.next().get();
                 result.memory().keys().forEach(key -> this.getTraversal().getSideEffects().set(key, result.memory().get(key)));
                 final Step endStep = this.getPreviousStep() instanceof TraversalVertexProgramStep ?
-                        ((TraversalVertexProgramStep) this.getPreviousStep()).computerTraversal.getEndStep() :
+                        ((TraversalVertexProgramStep) this.getPreviousStep()).computerTraversal.get().getEndStep() :
                         EmptyStep.instance();   // TODO: need to be selective and smart
                 if (endStep instanceof SideEffectCapStep) {
                     final List<String> sideEffectKeys = ((SideEffectCapStep<?, ?>) endStep).getSideEffectKeys();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
@@ -44,7 +45,7 @@ import java.util.function.Function;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class PageRankVertexProgramStep extends AbstractStep<ComputerResult, ComputerResult> implements VertexComputing, TraversalParent {
+public final class PageRankVertexProgramStep extends AbstractStep<ComputerResult, ComputerResult> implements VertexComputing, TraversalParent, ByModulating {
 
     private transient Function<Graph, GraphComputer> graphComputerFunction = Graph::compute;
 
@@ -55,7 +56,7 @@ public final class PageRankVertexProgramStep extends AbstractStep<ComputerResult
 
     public PageRankVertexProgramStep(final Traversal.Admin traversal) {
         super(traversal);
-        this.addLocalChild(__.<Vertex>outE().asAdmin());
+        this.modulateBy(__.<Vertex>outE().asAdmin());
     }
 
     @Override
@@ -78,7 +79,7 @@ public final class PageRankVertexProgramStep extends AbstractStep<ComputerResult
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> localChildTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> localChildTraversal) {
         this.pageRankTraversal = this.integrateChild((Traversal.Admin) localChildTraversal);
         this.purePageRankTraversal = this.pageRankTraversal.clone();
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -90,14 +90,13 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
 
     @Override
     public PageRankVertexProgram generateProgram(final Graph graph) {
-        this.edgeTraversal.reset();
-        final Traversal.Admin<Vertex, Edge> compiledTraversal = this.edgeTraversal.get();
-        compiledTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+        final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
+        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
         return PageRankVertexProgram.build()
                 .property(this.pageRankProperty)
-                .iterations(this.times)
+                .iterations(this.times + 1)
                 .alpha(this.alpha)
-                .edges(compiledTraversal)
+                .edges(detachedTraversal)
                 .create(graph);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -117,7 +117,7 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
     public PageRankVertexProgramStep clone() {
         final PageRankVertexProgramStep clone = (PageRankVertexProgramStep) super.clone();
         clone.edgeTraversal = this.edgeTraversal.clone();
-        this.integrateChild(this.edgeTraversal.get());
+        clone.integrateChild(clone.edgeTraversal.get());
         return clone;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -107,7 +107,7 @@ public final class PageRankVertexProgramStep extends AbstractStep<ComputerResult
 
     private PageRankVertexProgram generateProgram(final Graph graph) {
         return PageRankVertexProgram.build()
-                .pageRankProperty(this.pageRankProperty)
+                .property(this.pageRankProperty)
                 .edges(this.compileTraversal(graph))
                 .create(graph);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
@@ -88,13 +88,12 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
 
     @Override
     public PeerPressureVertexProgram generateProgram(final Graph graph) {
-        this.edgeTraversal.reset();
-        final Traversal.Admin<Vertex, Edge> compiledTraversal = this.edgeTraversal.get();
-        compiledTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
+        final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
+        detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
         return PeerPressureVertexProgram.build()
                 .property(this.clusterProperty)
                 .maxIterations(this.times)
-                .edges(compiledTraversal)
+                .edges(detachedTraversal)
                 .create(graph);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
@@ -111,7 +111,7 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
     public PeerPressureVertexProgramStep clone() {
         final PeerPressureVertexProgramStep clone = (PeerPressureVertexProgramStep) super.clone();
         clone.edgeTraversal = this.edgeTraversal.clone();
-        this.integrateChild(this.edgeTraversal.get());
+        clone.integrateChild(clone.edgeTraversal.get());
         return clone;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -77,15 +77,13 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
 
     @Override
     public TraversalVertexProgram generateProgram(final Graph graph) {
-        this.computerTraversal.reset();
-        final Traversal.Admin<?, ?> compiledComputerTraversal = this.computerTraversal.get();
-        compiledComputerTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()).clone());
-        this.getTraversal().getStrategies().toList().forEach(compiledComputerTraversal.getStrategies()::addStrategies);
-        compiledComputerTraversal.setSideEffects(this.getTraversal().getSideEffects());
-        compiledComputerTraversal.setParent(this);
-        compiledComputerTraversal.applyStrategies();
+        final Traversal.Admin<?, ?> computerSpecificTraversal = this.computerTraversal.getPure();
+        computerSpecificTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()).clone());
+        this.getTraversal().getStrategies().toList().forEach(computerSpecificTraversal.getStrategies()::addStrategies);
+        computerSpecificTraversal.setSideEffects(this.getTraversal().getSideEffects());
+        computerSpecificTraversal.setParent(this);
         return TraversalVertexProgram.build()
-                .traversal(compiledComputerTraversal)
+                .traversal(computerSpecificTraversal)
                 .create(graph);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -68,7 +68,7 @@ public final class TraversalVertexProgramStep extends AbstractStep<ComputerResul
                 this.first = false;
                 final Graph graph = this.getTraversal().getGraph().get();
                 final GraphComputer graphComputer = this.graphComputerFunction.apply(graph);
-                final ComputerResult result = graphComputer.program(TraversalVertexProgram.build().traversal(this.compileTraversal(graph)).create(this.getTraversal().getGraph().get())).submit().get();
+                final ComputerResult result = graphComputer.program(TraversalVertexProgram.build().traversal(this.compileTraversal(graph)).create(graph)).submit().get();
                 return this.getTraversal().getTraverserGenerator().generate(result, (Step) this, 1l);
             } else {
                 final Traverser.Admin<ComputerResult> traverser = this.starts.next();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.computer.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.VertexComputing;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class VertexProgramStep extends AbstractStep<ComputerResult, ComputerResult> implements VertexComputing {
+
+    protected boolean first = true;
+
+    public VertexProgramStep(final Traversal.Admin traversal) {
+        super(traversal);
+    }
+
+    @Override
+    protected Traverser<ComputerResult> processNextStart() throws NoSuchElementException {
+        try {
+            if (this.first && this.getPreviousStep() instanceof EmptyStep) {
+                this.first = false;
+                final Graph graph = this.getTraversal().getGraph().get();
+                return this.getTraversal().getTraverserGenerator().generate(this.generateComputer(graph).program(this.generateProgram(graph)).submit().get(), this, 1l);
+            } else {
+                final Traverser.Admin<ComputerResult> traverser = this.starts.next();
+                final Graph graph = traverser.get().graph();
+                return traverser.split(this.generateComputer(graph).program(this.generateProgram(graph)).submit().get(), this);
+            }
+        } catch (final InterruptedException | ExecutionException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/VertexProgramStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.computer.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.VertexComputing;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
@@ -56,5 +57,15 @@ public abstract class VertexProgramStep extends AbstractStep<ComputerResult, Com
         } catch (final InterruptedException | ExecutionException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
+    }
+
+    protected boolean previousTraversalVertexProgram() {
+        Step<?, ?> currentStep = this;
+        while (!(currentStep instanceof EmptyStep)) {
+            if (currentStep instanceof TraversalVertexProgramStep)
+                return true;
+            currentStep = currentStep.getPreviousStep();
+        }
+        return false;
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/AbstractVertexProgramBuilder.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/AbstractVertexProgramBuilder.java
@@ -27,14 +27,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
  */
 public abstract class AbstractVertexProgramBuilder<B extends VertexProgram.Builder> implements VertexProgram.Builder {
 
-    public static final String GREMLIN_GROOVY = "gremlin-groovy";
-
     protected final BaseConfiguration configuration = new BaseConfiguration();
 
     public AbstractVertexProgramBuilder() {
+        this.configuration.setDelimiterParsingDisabled(true);
     }
 
     public AbstractVertexProgramBuilder(final Class<? extends VertexProgram> vertexProgramClass) {
+        this();
         this.configuration.setProperty(VertexProgram.VERTEX_PROGRAM, vertexProgramClass.getName());
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/ConfigurationTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/util/ConfigurationTraversal.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.computer.util;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.util.function.Function;
@@ -28,7 +29,9 @@ import java.util.function.Supplier;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated As of release 3.2.0, replaced by {@link org.apache.tinkerpop.gremlin.process.traversal.util.PureTraversal}.
  */
+@Deprecated
 public final class ConfigurationTraversal<S, E> implements Supplier<Traversal.Admin<S, E>> {
 
     private Function<Graph, Traversal.Admin<S, E>> traversalFunction;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -33,6 +33,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.lambda.PredicateTraverser;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.TrueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TimesModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.BranchStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseStep;
@@ -1135,7 +1136,11 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     }
 
     public default GraphTraversal<S, E> times(final int maxLoops) {
-        return this.until(new LoopTraversal<>(maxLoops));
+        if (this.asAdmin().getEndStep() instanceof TimesModulating) {
+            ((TimesModulating) this.asAdmin().getEndStep()).modulateTimes(maxLoops);
+            return this;
+        } else
+            return this.until(new LoopTraversal<>(maxLoops));
     }
 
     public default <E2> GraphTraversal<S, E2> local(final Traversal<?, E2> localTraversal) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.dsl.graph;
 
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PageRankVertexProgramStep;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PeerPressureVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
@@ -1150,7 +1151,15 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
     /////////////////// VERTEX PROGRAM STEPS ////////////////
 
     public default GraphTraversal<S, E> pageRank() {
-        return this.asAdmin().addStep((Step<?, E>) new PageRankVertexProgramStep(this.asAdmin()));
+        return this.pageRank(0.85d);
+    }
+
+    public default GraphTraversal<S, E> pageRank(final double alpha) {
+        return this.asAdmin().addStep((Step<E, E>) new PageRankVertexProgramStep(this.asAdmin(), alpha));
+    }
+
+    public default GraphTraversal<S, E> peerPressure() {
+        return this.asAdmin().addStep((Step<E, E>) new PeerPressureVertexProgramStep(this.asAdmin()));
     }
 
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -1223,6 +1223,16 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         return this;
     }
 
+    /*public default <V> GraphTraversal<S, E> by(final Column column, final Comparator<V> comparator) {
+        ((ByModulating) this.asAdmin().getEndStep()).modulateBy(column, comparator);
+        return this;
+    }
+
+    public default <V> GraphTraversal<S, E> by(final T token, final Comparator<V> comparator) {
+        ((ByModulating) this.asAdmin().getEndStep()).modulateBy(token, comparator);
+        return this;
+    }*/
+
     public default <U> GraphTraversal<S, E> by(final Function<U, Object> function, final Comparator comparator) {
         ((ByModulating) this.asAdmin().getEndStep()).modulateBy(function, comparator);
         return this;

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalSource.java
@@ -28,10 +28,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.engine.StandardTraversalEn
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.RequirementsStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SackStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SideEffectStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.VertexProgramStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -98,9 +94,7 @@ public class GraphTraversalSource implements TraversalSource {
 
     @Override
     public GraphTraversalSource withComputer(final Function<Graph, GraphComputer> graphComputerFunction) {
-        final GraphTraversalSource clone = this.clone();
-        clone.strategies.addStrategies(new VertexProgramStrategy(graphComputerFunction), ComputerVerificationStrategy.instance());
-        return clone;
+        return (GraphTraversalSource) TraversalSource.super.withComputer(graphComputerFunction);
     }
 
     @Override
@@ -115,24 +109,18 @@ public class GraphTraversalSource implements TraversalSource {
 
     @Override
     public GraphTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
-        final GraphTraversalSource clone = this.clone();
-        clone.strategies.addStrategies(traversalStrategies);
-        return clone;
+        return (GraphTraversalSource) TraversalSource.super.withStrategies(traversalStrategies);
     }
 
     @Override
     @SuppressWarnings({"unchecked", "varargs"})
     public GraphTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
-        final GraphTraversalSource clone = this.clone();
-        clone.strategies.removeStrategies(traversalStrategyClasses);
-        return clone;
+        return (GraphTraversalSource) TraversalSource.super.withoutStrategies(traversalStrategyClasses);
     }
 
     @Override
     public GraphTraversalSource withSideEffect(final String key, final Supplier initialValue) {
-        final GraphTraversalSource clone = this.clone();
-        SideEffectStrategy.addSideEffect(clone.strategies, key, initialValue);
-        return clone;
+        return (GraphTraversalSource) TraversalSource.super.withSideEffect(key, initialValue);
     }
 
     @Override
@@ -142,9 +130,7 @@ public class GraphTraversalSource implements TraversalSource {
 
     @Override
     public <A> GraphTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
-        final GraphTraversalSource clone = this.clone();
-        clone.strategies.addStrategies(SackStrategy.<A>build().initialValue(initialValue).splitOperator(splitOperator).mergeOperator(mergeOperator).create());
-        return clone;
+        return (GraphTraversalSource) TraversalSource.super.withSack(initialValue, splitOperator, mergeOperator);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/ColumnTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/lambda/ColumnTraversal.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.lambda;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.structure.Column;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class ColumnTraversal extends AbstractLambdaTraversal {
+
+    private Object selection;
+    private final Column column;
+
+    public ColumnTraversal(final Column column) {
+        this.column = column;
+    }
+
+    @Override
+    public Object next() {
+        return this.selection;
+    }
+
+    @Override
+    public void addStart(final Traverser start) {
+        this.selection = this.column.apply(start.get());
+    }
+
+    @Override
+    public String toString() {
+        return this.column.toString();
+    }
+
+    public Column getColumn() {
+        return this.column;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getClass().hashCode() ^ this.column.hashCode();
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ByModulating.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ByModulating.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.FunctionTraverser;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.Comparator;
+import java.util.function.Function;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public interface ByModulating {
+
+    public default void modulateBy(final Traversal.Admin<?, ?> traversal) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("The by()-modulating step does not support traversal-based modulation: " + this);
+    }
+
+    public default void modulateBy(final String string) throws UnsupportedOperationException {
+        this.modulateBy(new ElementValueTraversal(string));
+    }
+
+    public default void modulateBy(final T token) throws UnsupportedOperationException {
+        this.modulateBy(new TokenTraversal(token));
+    }
+
+    public default void modulateBy(final Function function) throws UnsupportedOperationException {
+        if (function instanceof T)
+            this.modulateBy((T) function);
+        else
+            this.modulateBy(__.map(new FunctionTraverser<>(function)).asAdmin());
+    }
+
+    public default void modulateBy() throws UnsupportedOperationException {
+        this.modulateBy(new IdentityTraversal());
+    }
+
+    //////
+
+    public default void modulateBy(final Traversal.Admin<?, ?> traversal, final Comparator comparator) {
+        throw new UnsupportedOperationException("The by()-modulating step does not support traversal/comparator-based modulation: " + this);
+    }
+
+    public default void modulateBy(final String key, final Comparator comparator) {
+        this.modulateBy(new ElementValueTraversal<>(key), comparator);
+    }
+
+    public default void modulateBy(final Comparator comparator) {
+        this.modulateBy(new IdentityTraversal<>(), comparator);
+    }
+
+    public default void modulateBy(final Order order) {
+        this.modulateBy(new IdentityTraversal<>(), order);
+    }
+
+    public default void modulateBy(final T t, final Comparator comparator) {
+        this.modulateBy(new TokenTraversal<>(t), comparator);
+    }
+
+    public default void modulateBy(final Function function, final Comparator comparator) {
+        if (function instanceof T)
+            this.modulateBy((T) function, comparator);
+        else
+            this.modulateBy(__.map(new FunctionTraverser<>(function)).asAdmin(), comparator);
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ByModulating.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/ByModulating.java
@@ -22,10 +22,12 @@ package org.apache.tinkerpop.gremlin.process.traversal.step;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.lambda.ColumnTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.FunctionTraverser;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
+import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.T;
 
 import java.util.Comparator;
@@ -81,9 +83,15 @@ public interface ByModulating {
         this.modulateBy(new TokenTraversal<>(t), comparator);
     }
 
+    public default void modulateBy(final Column column, final Comparator comparator) {
+        this.modulateBy(new ColumnTraversal(column), comparator);
+    }
+
     public default void modulateBy(final Function function, final Comparator comparator) {
         if (function instanceof T)
             this.modulateBy((T) function, comparator);
+        else if (function instanceof Column)
+            this.modulateBy((Column) function, comparator);
         else
             this.modulateBy(__.map(new FunctionTraverser<>(function)).asAdmin(), comparator);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TimesModulating.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TimesModulating.java
@@ -17,22 +17,12 @@
  * under the License.
  */
 
-package org.apache.tinkerpop.gremlin.process.computer.traversal.step;
-
-import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
-import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-
-import java.util.function.Function;
+package org.apache.tinkerpop.gremlin.process.traversal.step;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public interface VertexComputing {
+public interface TimesModulating {
 
-    public void setGraphComputerFunction(final Function<Graph, GraphComputer> graphComputerFunction);
-
-    public VertexProgram generateProgram(final Graph graph);
-
-    public GraphComputer generateComputer(final Graph graph);
+    public void modulateTimes(final int times);
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TraversalParent.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/TraversalParent.java
@@ -56,12 +56,12 @@ public interface TraversalParent {
         throw new IllegalStateException("This traversal parent does not support the removal of global traversals: " + this.getClass().getCanonicalName());
     }
 
-    public default boolean isLocalChild(final Traversal.Admin<?, ?> child) {
-        return this.getLocalChildren().contains(child);
+    public default boolean isLocalChild(final Traversal.Admin<?, ?> childTraversal) {
+        return this.getLocalChildren().contains(childTraversal);
     }
 
-    public default boolean isGlobalChild(final Traversal.Admin<?, ?> child) {
-        return this.getGlobalChildren().contains(child);
+    public default boolean isGlobalChild(final Traversal.Admin<?, ?> childTraversal) {
+        return this.getGlobalChildren().contains(childTraversal);
     }
 
     public default Set<TraverserRequirement> getSelfAndChildRequirements(final TraverserRequirement... selfRequirements) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/DedupGlobalStep.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Bypassing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -39,7 +40,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class DedupGlobalStep<S> extends FilterStep<S> implements TraversalParent, Scoping, Bypassing, Barrier {
+public final class DedupGlobalStep<S> extends FilterStep<S> implements TraversalParent, Scoping, Bypassing, Barrier, ByModulating {
 
     private Traversal.Admin<S, Object> dedupTraversal = null;
     private Set<Object> duplicateSet = new HashSet<>();
@@ -70,7 +71,7 @@ public final class DedupGlobalStep<S> extends FilterStep<S> implements Traversal
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin dedupTraversal) {
+    public void modulateBy(final Traversal.Admin<?,?> dedupTraversal) {
         this.dedupTraversal = this.integrateChild(dedupTraversal);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/SampleGlobalStep.java
@@ -20,12 +20,13 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.filter;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.CollectingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ConstantTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.CollectingBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.Collections;
@@ -36,7 +37,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implements TraversalParent {
+public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implements TraversalParent, ByModulating {
 
     private Traversal.Admin<S, Number> probabilityTraversal = new ConstantTraversal<>(1.0d);
     private final int amountToSample;
@@ -53,7 +54,7 @@ public final class SampleGlobalStep<S> extends CollectingBarrierStep<S> implemen
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> probabilityTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> probabilityTraversal) {
         this.probabilityTraversal = this.integrateChild(probabilityTraversal);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphStep.java
@@ -131,6 +131,7 @@ public class GraphStep<S, E extends Element> extends AbstractStep<S, E> implemen
     public void reset() {
         super.reset();
         this.head = null;
+        this.done = false;
         this.iterator = EmptyIterator.instance();
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexPr
 import org.apache.tinkerpop.gremlin.process.computer.util.StaticMapReduce;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MapHelper;
@@ -47,7 +48,7 @@ import java.util.function.BiFunction;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupCountStep<S, E> extends ReducingBarrierStep<S, Map<E, Long>> implements MapReducer, TraversalParent {
+public final class GroupCountStep<S, E> extends ReducingBarrierStep<S, Map<E, Long>> implements MapReducer, TraversalParent, ByModulating {
 
     private Traversal.Admin<S, E> groupTraversal = null;
 
@@ -59,8 +60,8 @@ public final class GroupCountStep<S, E> extends ReducingBarrierStep<S, Map<E, Lo
 
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> groupTraversal) {
-        this.groupTraversal = this.integrateChild(groupTraversal);
+    public void modulateBy(final Traversal.Admin<?, ?> keyTraversal) {
+        this.groupTraversal = this.integrateChild(keyTraversal);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -56,7 +57,7 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> implements MapReducer, GraphComputing, TraversalParent {
+public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> implements MapReducer, GraphComputing, TraversalParent, ByModulating {
 
     private char state = 'k';
 
@@ -89,7 +90,7 @@ public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> 
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> kvTraversal) {
+    public void modulateBy(final Traversal.Admin<?,?> kvTraversal) {
         if ('k' == this.state) {
             this.keyTraversal = this.integrateChild(kvTraversal);
             this.state = 'v';

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStepV3d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStepV3d0.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexPr
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -56,7 +57,7 @@ import java.util.function.Supplier;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 @Deprecated
-public final class GroupStepV3d0<S, K, V, R> extends ReducingBarrierStep<S, Map<K, R>> implements MapReducer, GraphComputing, TraversalParent {
+public final class GroupStepV3d0<S, K, V, R> extends ReducingBarrierStep<S, Map<K, R>> implements MapReducer, ByModulating, GraphComputing, TraversalParent {
 
     private char state = 'k';
 
@@ -93,7 +94,7 @@ public final class GroupStepV3d0<S, K, V, R> extends ReducingBarrierStep<S, Map<
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> kvrTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> kvrTraversal) {
         if ('k' == this.state) {
             this.keyTraversal = this.integrateChild(kvrTraversal);
             this.state = 'v';

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderGlobalStep.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ComparatorHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.CollectingBarrierStep;
@@ -40,7 +41,7 @@ import java.util.stream.Collectors;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrderGlobalStep<S> extends CollectingBarrierStep<S> implements ComparatorHolder<S>, TraversalParent {
+public final class OrderGlobalStep<S> extends CollectingBarrierStep<S> implements ComparatorHolder<S>, TraversalParent, ByModulating {
 
     private List<Comparator<S>> comparators = new ArrayList<>();
     private ChainedComparator chainedComparator = null;
@@ -64,6 +65,16 @@ public final class OrderGlobalStep<S> extends CollectingBarrierStep<S> implement
         if (comparator instanceof TraversalComparator)
             this.integrateChild(((TraversalComparator) comparator).getTraversal());
         this.comparators.add(comparator);
+    }
+
+    @Override
+    public void modulateBy(final Traversal.Admin<?, ?> traversal) {
+        this.addComparator(new TraversalComparator(traversal, Order.incr));
+    }
+
+    @Override
+    public void modulateBy(final Traversal.Admin<?, ?> traversal, final Comparator comparator) {
+        this.addComparator(new TraversalComparator(traversal, comparator));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderLocalStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ComparatorHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.TraversalComparator;
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class OrderLocalStep<S, M> extends MapStep<S, S> implements ComparatorHolder<M>, TraversalParent {
+public final class OrderLocalStep<S, M> extends MapStep<S, S> implements ComparatorHolder<M>, ByModulating, TraversalParent {
 
     private List<Comparator<M>> comparators = new ArrayList<>();
     private ChainedComparator<M> chainedComparator = null;
@@ -68,6 +69,16 @@ public final class OrderLocalStep<S, M> extends MapStep<S, S> implements Compara
         this.comparators.add(comparator);
         if (comparator instanceof TraversalComparator)
             this.integrateChild(((TraversalComparator) comparator).getTraversal());
+    }
+
+    @Override
+    public void modulateBy(final Traversal.Admin<?, ?> traversal) {
+        this.addComparator(new TraversalComparator(traversal, Order.incr));
+    }
+
+    @Override
+    public void modulateBy(final Traversal.Admin<?, ?> traversal, final Comparator comparator) {
+        this.addComparator(new TraversalComparator(traversal, comparator));
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PathStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.MutablePath;
@@ -35,7 +36,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class PathStep<S> extends MapStep<S, Path> implements TraversalParent, PathProcessor {
+public final class PathStep<S> extends MapStep<S, Path> implements TraversalParent, PathProcessor, ByModulating {
 
     private TraversalRing<Object, Object> traversalRing;
 
@@ -82,7 +83,7 @@ public final class PathStep<S> extends MapStep<S, Path> implements TraversalPare
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> pathTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> pathTraversal) {
         this.traversalRing.addTraversal(this.integrateChild(pathTraversal));
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectOneStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -36,7 +37,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SelectOneStep<S, E> extends MapStep<S, E> implements TraversalParent, Scoping, PathProcessor {
+public final class SelectOneStep<S, E> extends MapStep<S, E> implements TraversalParent, Scoping, PathProcessor, ByModulating {
 
     private final Pop pop;
     private final String selectKey;
@@ -83,7 +84,7 @@ public final class SelectOneStep<S, E> extends MapStep<S, E> implements Traversa
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> selectTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> selectTraversal) {
         this.selectTraversal = this.integrateChild(selectTraversal);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/SelectStep.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -41,7 +42,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implements Scoping, TraversalParent, PathProcessor {
+public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implements Scoping, TraversalParent, PathProcessor, ByModulating {
 
     private TraversalRing<Object, E> traversalRing = new TraversalRing<>();
     private final Pop pop;
@@ -106,7 +107,7 @@ public final class SelectStep<S, E> extends MapStep<S, Map<String, E>> implement
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> selectTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> selectTraversal) {
         this.traversalRing.addTraversal(this.integrateChild(selectTraversal));
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/TreeStep.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.computer.util.StaticMapReduce;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -48,7 +49,7 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements MapReducer, TraversalParent, PathProcessor {
+public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements MapReducer, TraversalParent, ByModulating, PathProcessor {
 
     private TraversalRing<Object, Object> traversalRing = new TraversalRing<>();
 
@@ -65,7 +66,7 @@ public final class TreeStep<S> extends ReducingBarrierStep<S, Tree> implements M
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> treeTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> treeTraversal) {
         this.traversalRing.addTraversal(this.integrateChild(treeTraversal));
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/AggregateStep.java
@@ -25,6 +25,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexPr
 import org.apache.tinkerpop.gremlin.process.computer.traversal.VertexTraversalSideEffects;
 import org.apache.tinkerpop.gremlin.process.computer.util.StaticMapReduce;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -39,13 +40,17 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.function.BulkSetSupplier;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class AggregateStep<S> extends CollectingBarrierStep<S> implements SideEffectCapable, TraversalParent, MapReducer<MapReduce.NullObject, Object, MapReduce.NullObject, Object, Collection> {
+public final class AggregateStep<S> extends CollectingBarrierStep<S> implements SideEffectCapable, TraversalParent, ByModulating, MapReducer<MapReduce.NullObject, Object, MapReduce.NullObject, Object, Collection> {
 
     private Traversal.Admin<S, Object> aggregateTraversal = null;
     private String sideEffectKey;
@@ -72,7 +77,7 @@ public final class AggregateStep<S> extends CollectingBarrierStep<S> implements 
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> aggregateTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> aggregateTraversal) {
         this.aggregateTraversal = this.integrateChild(aggregateTraversal);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.VertexTraversalSi
 import org.apache.tinkerpop.gremlin.process.computer.util.StaticMapReduce;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -37,13 +38,18 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.function.HashMapSupplier;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupCountSideEffectStep<S, E> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, MapReducer<E, Long, E, Long, Map<E, Long>> {
+public final class GroupCountSideEffectStep<S, E> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, ByModulating, MapReducer<E, Long, E, Long, Map<E, Long>> {
 
     private Traversal.Admin<S, E> groupTraversal = null;
     private String sideEffectKey;
@@ -103,6 +109,11 @@ public final class GroupCountSideEffectStep<S, E> extends SideEffectStep<S> impl
         int result = super.hashCode() ^ this.sideEffectKey.hashCode();
         if (this.groupTraversal != null) result ^= this.groupTraversal.hashCode();
         return result;
+    }
+
+    @Override
+    public void modulateBy(final Traversal.Admin<?,?> keyTraversal) throws UnsupportedOperationException {
+        this.groupTraversal = this.integrateChild(keyTraversal);
     }
 
     ///////

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
@@ -55,7 +56,7 @@ import java.util.function.Supplier;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, GraphComputing, MapReducer<K, Collection<?>, K, V, Map<K, V>> {
+public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, ByModulating, GraphComputing, MapReducer<K, Collection<?>, K, V, Map<K, V>> {
 
     private char state = 'k';
     private Traversal.Admin<S, K> keyTraversal = null;
@@ -75,7 +76,7 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implem
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> kvTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> kvTraversal) {
         if ('k' == this.state) {
             this.keyTraversal = this.integrateChild(kvTraversal);
             this.state = 'v';

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStepV3d0.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStepV3d0.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.TraversalVertexPr
 import org.apache.tinkerpop.gremlin.process.computer.traversal.VertexTraversalSideEffects;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.GraphComputing;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
@@ -53,7 +54,7 @@ import java.util.function.Supplier;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 @Deprecated
-public final class GroupSideEffectStepV3d0<S, K, V, R> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, GraphComputing, MapReducer<K, Collection<V>, K, R, Map<K, R>> {
+public final class GroupSideEffectStepV3d0<S, K, V, R> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, ByModulating, GraphComputing, MapReducer<K, Collection<V>, K, R, Map<K, R>> {
 
     private char state = 'k';
     private Traversal.Admin<S, K> keyTraversal = null;
@@ -126,7 +127,7 @@ public final class GroupSideEffectStepV3d0<S, K, V, R> extends SideEffectStep<S>
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> kvrTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> kvrTraversal) {
         if ('k' == this.state) {
             this.keyTraversal = this.integrateChild(kvrTraversal);
             this.state = 'v';

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SackValueStep.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
@@ -33,7 +34,7 @@ import java.util.function.BiFunction;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements TraversalParent {
+public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements TraversalParent, ByModulating {
 
     private Traversal.Admin<S, B> sackTraversal = null;
 
@@ -45,7 +46,7 @@ public final class SackValueStep<S, A, B> extends SideEffectStep<S> implements T
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> sackTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> sackTraversal) {
         this.sackTraversal = this.integrateChild(sackTraversal);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/StoreStep.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.computer.traversal.VertexTraversalSi
 import org.apache.tinkerpop.gremlin.process.computer.util.StaticMapReduce;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
@@ -38,13 +39,17 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.function.BulkSetSupplier;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class StoreStep<S> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, MapReducer<MapReduce.NullObject, Object, MapReduce.NullObject, Object, Collection> {
+public final class StoreStep<S> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, ByModulating, MapReducer<MapReduce.NullObject, Object, MapReduce.NullObject, Object, Collection> {
 
     private Traversal.Admin<S, Object> storeTraversal = null;
     private String sideEffectKey;
@@ -84,7 +89,7 @@ public final class StoreStep<S> extends SideEffectStep<S> implements SideEffectC
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> storeTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> storeTraversal) {
         this.storeTraversal = this.integrateChild(storeTraversal);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/TreeSideEffectStep.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.computer.util.StaticMapReduce;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.MapReducer;
 import org.apache.tinkerpop.gremlin.process.traversal.step.PathProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.step.SideEffectCapable;
@@ -46,7 +47,7 @@ import java.util.Set;
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, PathProcessor, MapReducer<MapReduce.NullObject, Tree, MapReduce.NullObject, Tree, Tree> {
+public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements SideEffectCapable, TraversalParent, ByModulating, PathProcessor, MapReducer<MapReduce.NullObject, Tree, MapReduce.NullObject, Tree, Tree> {
 
     private TraversalRing<Object, Object> traversalRing;
     private String sideEffectKey;
@@ -111,7 +112,7 @@ public final class TreeSideEffectStep<S> extends SideEffectStep<S> implements Si
     }
 
     @Override
-    public void addLocalChild(final Traversal.Admin<?, ?> treeTraversal) {
+    public void modulateBy(final Traversal.Admin<?, ?> treeTraversal) {
         this.traversalRing.addTraversal(this.integrateChild(treeTraversal));
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/ConnectiveStrategy.java
@@ -104,8 +104,10 @@ public final class ConnectiveStrategy extends AbstractTraversalStrategy<Traversa
             }
             processConnectiveMarker(leftTraversal);
 
-            connectiveStep.addLocalChild(leftTraversal);
-            connectiveStep.addLocalChild(rightTraversal);
+            TraversalHelper.replaceStep(connectiveStep,
+                    connectiveStep instanceof AndStep ?
+                            new AndStep(traversal, leftTraversal, rightTraversal) :
+                            new OrStep(traversal, leftTraversal, rightTraversal), traversal);
         });
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategy.java
@@ -96,7 +96,7 @@ public final class VertexProgramStrategy extends AbstractTraversalStrategy<Trave
                 TraversalHelper.insertAfterStep(computerResultStep, (Step) step, traversal);
             }
         });
-        if (traversal.getEndStep() instanceof PageRankVertexProgramStep) {
+        if (traversal.getEndStep() instanceof PageRankVertexProgramStep) {  // TODO: VertexComputing but not TraversalVertexProgramStep
             final TraversalVertexProgramStep traversalVertexProgramStep = new TraversalVertexProgramStep(traversal, __.identity().asAdmin());
             traversal.addStep(traversalVertexProgramStep);
             traversal.addStep(new ComputerResultStep<>(traversal, true));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategy.java
@@ -130,7 +130,7 @@ public final class VertexProgramStrategy extends AbstractTraversalStrategy<Trave
     }
 
     private static Step<?, ?> getLastLegalOLAPStep(Step<?, ?> currentStep) {
-        if (currentStep instanceof VertexComputing)
+        while (currentStep instanceof VertexComputing)
             currentStep = currentStep.getNextStep();
         while (!(currentStep instanceof EmptyStep)) {
             if (ComputerVerificationStrategy.isStepInstanceOfEndStep(currentStep))

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PureTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PureTraversal.java
@@ -38,15 +38,13 @@ public final class PureTraversal<S, E> implements Serializable, Cloneable {
         this.pureTraversal = pureTraversal;
     }
 
-    public void reset() {
-        this.cachedTraversal = null;
+    public Traversal.Admin<S, E> getPure() {
+        return this.pureTraversal.clone();
     }
 
     public Traversal.Admin<S, E> get() {
-        if (null == this.cachedTraversal) {
+        if (null == this.cachedTraversal)
             this.cachedTraversal = this.pureTraversal.clone();
-            this.pureTraversal.getGraph().ifPresent(this.cachedTraversal::setGraph);
-        }
         return this.cachedTraversal;
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PureTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PureTraversal.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.util;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.process.computer.util.VertexProgramHelper;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+
+import java.io.Serializable;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public final class PureTraversal<S, E> implements Serializable {
+
+    private final Traversal.Admin<S, E> pureTraversal;
+    private transient Traversal.Admin<S, E> compiledTraversal;
+
+    public PureTraversal(final Traversal.Admin<S, E> pureTraversal) {
+        this.pureTraversal = pureTraversal;
+    }
+
+    public Traversal.Admin<S, E> getPure() {
+        return this.pureTraversal;
+    }
+
+    public Traversal.Admin<S, E> getCompiled() {
+        if (null == this.compiledTraversal) {
+            this.compiledTraversal = this.pureTraversal.clone();
+            this.pureTraversal.getGraph().ifPresent(this.compiledTraversal::setGraph);
+            if (!this.compiledTraversal.isLocked())
+                this.compiledTraversal.applyStrategies();
+        }
+        return this.compiledTraversal;
+    }
+
+    public void storeState(final Configuration configuration, final String configurationKey) {
+        try {
+            VertexProgramHelper.serialize(this, configuration, configurationKey);   // the traversal can not be serialized (probably because of lambdas). As such, try direct reference.
+        } catch (final IllegalArgumentException e) {
+            configuration.setProperty(configurationKey, this);
+        }
+    }
+
+    ////////////
+
+    public static <S, E> void storeState(final Configuration configuration, final String configurationKey, final Traversal.Admin<S, E> traversal) {
+        new PureTraversal<>(traversal).storeState(configuration, configurationKey);
+    }
+
+    public static <S, E> PureTraversal<S, E> loadState(final Configuration configuration, final String configurationKey, final Graph graph) {
+        final Object configValue = configuration.getProperty(configurationKey);
+        final PureTraversal<S, E> pureTraversal = (configValue instanceof String ? (PureTraversal<S, E>) VertexProgramHelper.deserialize(configuration, configurationKey) : ((PureTraversal<S, E>) configValue));
+        pureTraversal.pureTraversal.setGraph(graph);
+        return pureTraversal;
+    }
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalHelper.java
@@ -24,6 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ElementValueTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.TokenTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.LambdaHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Scoping;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
@@ -69,11 +70,12 @@ public final class TraversalHelper {
     public static boolean isBeyondElementId(final Traversal.Admin<?, ?> traversal) {
         if (traversal instanceof TokenTraversal && !((TokenTraversal) traversal).getToken().equals(T.id))
             return true;
-        if (traversal instanceof ElementValueTraversal)
+        else if (traversal instanceof ElementValueTraversal)
             return true;
         else
             return traversal.getSteps().stream()
                     .filter(step -> step instanceof VertexStep ||
+                            step instanceof LambdaHolder || // if we don't know, then yes.
                             step instanceof LabelStep ||
                             step instanceof EdgeVertexStep ||
                             step instanceof PropertiesStep ||

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalScriptHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalScriptHelper.java
@@ -19,7 +19,9 @@
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -29,6 +31,20 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 public final class TraversalScriptHelper {
 
     private TraversalScriptHelper() {
+    }
+
+    public static <S, E> Traversal.Admin<S, E> compute(
+            final Graph graph,
+            final TraversalSource traversalSource,
+            final String scriptEngineName,
+            final String traversalScript,
+            final Object... bindings) {
+
+        try {
+            return new TraversalScriptFunction<S, E>(traversalSource, scriptEngineName, traversalScript, bindings).apply(graph);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
     }
 
     @Deprecated

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalScriptHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalScriptHelper.java
@@ -33,6 +33,7 @@ public final class TraversalScriptHelper {
     private TraversalScriptHelper() {
     }
 
+    @Deprecated
     public static <S, E> Traversal.Admin<S, E> compute(
             final Graph graph,
             final TraversalSource traversalSource,

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalScriptHelper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalScriptHelper.java
@@ -19,33 +19,20 @@
 package org.apache.tinkerpop.gremlin.process.traversal.util;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @deprecated As of release 3.2.0, replaced by {@link ScriptTraversal}.
  */
+@Deprecated
 public final class TraversalScriptHelper {
 
     private TraversalScriptHelper() {
     }
 
-    public static <S, E> Traversal.Admin<S, E> compute(
-            final Graph graph,
-            final TraversalSource traversalSource,
-            final String scriptEngineName,
-            final String traversalScript,
-            final Object... bindings) {
-
-        try {
-            return new TraversalScriptFunction<S, E>(traversalSource, scriptEngineName, traversalScript, bindings).apply(graph);
-        } catch (final Exception e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
-    }
-
+    @Deprecated
     public static <S, E> Traversal.Admin<S, E> compute(final String script, final GraphTraversalSource g, final Object... bindings) {
-        return TraversalScriptHelper.compute(g.getGraph(), g, "gremlin-groovy", script, bindings);
+        return new ScriptTraversal<>(g, "gremlin-groovy", script, bindings);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
@@ -87,7 +87,7 @@ final class GryoSerializers {
 
         @Override
         public void write(final Kryo kryo, final Output output, final Property property) {
-            kryo.writeClassAndObject(output, DetachedFactory.detach(property));
+            kryo.writeClassAndObject(output, property instanceof VertexProperty ? DetachedFactory.detach((VertexProperty) property, true) : DetachedFactory.detach(property));
         }
 
         @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertex.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertex.java
@@ -81,7 +81,7 @@ public class DetachedVertex extends DetachedElement<Vertex> implements Vertex {
             this.properties = new HashMap<>();
             properties.entrySet().stream().forEach(
                     entry -> this.properties.put(entry.getKey(), ((List<Map<String, Object>>) entry.getValue()).stream()
-                            .map(m -> (Property) new DetachedVertexProperty<>(m.get(ID), entry.getKey(), m.get(VALUE), (Map<String, Object>) m.getOrDefault(PROPERTIES, new HashMap<>()), this))
+                            .map(m -> new DetachedVertexProperty<>(m.get(ID), entry.getKey(), m.get(VALUE), (Map<String, Object>) m.getOrDefault(PROPERTIES, new HashMap<>()), this))
                             .collect(Collectors.toList())));
         }
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class GraphTraversalTest {
 
-    private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "option", "iterate", "to", "from", "profile", "pageRank"));
+    private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "option", "iterate", "to", "from", "profile", "pageRank", "peerPressure"));
     private static Set<String> NO_ANONYMOUS = new HashSet<>(Arrays.asList("start", "__"));
 
     @Test

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration;
+
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ComputerResultStep;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.TraversalVertexProgramStep;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.util.EmptyTraversal;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+@RunWith(Parameterized.class)
+public class VertexProgramStrategyTest {
+
+    @Parameterized.Parameter(value = 0)
+    public Traversal original;
+
+    @Parameterized.Parameter(value = 1)
+    public Traversal optimized;
+
+
+    @Test
+    public void doTest() {
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(new VertexProgramStrategy(Graph::compute), ComputerVerificationStrategy.instance());
+        original.asAdmin().setStrategies(strategies);
+        original.asAdmin().applyStrategies();
+        assertEquals(optimized, original);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> generateTestParameters() {
+
+        final ComputerResultStep computerResultStep = new ComputerResultStep(EmptyTraversal.instance(), true);
+
+        return Arrays.asList(new Traversal[][]{
+                {__.V().out().count(), start().addStep(traversal(__.V().out().count())).addStep(computerResultStep)},
+                {__.V().pageRank().out().count(), start().pageRank().asAdmin().addStep(traversal(__.V().out().count())).addStep(computerResultStep)},
+                {__.V().out().pageRank(), start().addStep(traversal(__.V().out())).pageRank().asAdmin().addStep(traversal(__.identity())).addStep(computerResultStep)},
+                {__.V().out().pageRank().count(), start().addStep(traversal(__.V().out())).pageRank().asAdmin().addStep(traversal(__.count())).addStep(computerResultStep)},
+                {__.V().pageRank().order().limit(1), start().pageRank().asAdmin().addStep(traversal(__.V().order())).addStep(computerResultStep).limit(1)}
+        });
+    }
+
+    private static GraphTraversal.Admin<?, ?> start() {
+        return new DefaultGraphTraversal<>().asAdmin();
+    }
+
+    private static Step<?, ?> traversal(final Traversal<?, ?> traversal) {
+        return new TraversalVertexProgramStep(EmptyTraversal.instance(), traversal.asAdmin());
+    }
+}

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.strategy.verification;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversalStrategies;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,15 +45,19 @@ public class LambdaRestrictionStrategyTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {"filter(x->true)", __.filter(x -> true)},
-                {"map(Traverser::get)", __.map(Traverser::get)},
+                {"filter(x->true)", __.filter(x -> true), false},
+                {"map(Traverser::get)", __.map(Traverser::get), false},
                 {"sideEffect(x -> {int i = 1+1;})", __.sideEffect(x -> {
                     int i = 1 + 1;
-                })},
-                {"select('a','b').by(Object::toString)", __.select("a", "b").by(Object::toString)},
-                {"order().by((a,b)->a.compareTo(b))", __.order().by((a, b) -> ((Integer) a).compareTo((Integer) b))},
-                {"order(local).by((a,b)->a.compareTo(b))", __.order(Scope.local).by((a, b) -> ((Integer) a).compareTo((Integer) b))},
-                {"__.choose(v->v.toString().equals(\"marko\"),__.out(),__.in())", __.choose(v -> v.toString().equals("marko"), __.out(), __.in())},
+                }), false},
+                {"select('a','b').by(Object::toString)", __.select("a", "b").by(Object::toString), false},
+                {"order().by((a,b)->a.compareTo(b))", __.order().by((a, b) -> ((Integer) a).compareTo((Integer) b)), false},
+                {"order(local).by((a,b)->a.compareTo(b))", __.order(Scope.local).by((a, b) -> ((Integer) a).compareTo((Integer) b)), false},
+                {"__.choose(v->v.toString().equals(\"marko\"),__.out(),__.in())", __.choose(v -> v.toString().equals("marko"), __.out(), __.in()), false},
+                //
+                {"order(local).by(values,decr)", __.order(Scope.local).by(Column.values, Order.decr), true},
+                {"order().by(label,decr)", __.order().by(T.label, Order.decr), true},
+                {"groupCount().by(label)", __.groupCount().by(T.label), true},
         });
     }
 
@@ -60,16 +67,23 @@ public class LambdaRestrictionStrategyTest {
     @Parameterized.Parameter(value = 1)
     public Traversal traversal;
 
+    @Parameterized.Parameter(value = 2)
+    public boolean allow;
+
     @Test
     public void shouldBeVerifiedIllegal() {
-        try {
-            final TraversalStrategies strategies = new DefaultTraversalStrategies();
-            strategies.addStrategies(LambdaRestrictionStrategy.instance());
-            traversal.asAdmin().setStrategies(strategies);
+        final TraversalStrategies strategies = new DefaultTraversalStrategies();
+        strategies.addStrategies(LambdaRestrictionStrategy.instance());
+        traversal.asAdmin().setStrategies(strategies);
+        if (allow) {
             traversal.asAdmin().applyStrategies();
-            fail("The strategy should not allow lambdas: " + this.traversal);
-        } catch (VerificationException ise) {
-            assertTrue(ise.getMessage().contains("lambda"));
+        } else {
+            try {
+                traversal.asAdmin().applyStrategies();
+                fail("The strategy should not allow lambdas: " + this.traversal);
+            } catch (VerificationException ise) {
+                assertTrue(ise.getMessage().contains("lambda"));
+            }
         }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/verification/LambdaRestrictionStrategyTest.java
@@ -54,6 +54,7 @@ public class LambdaRestrictionStrategyTest {
                 {"order().by((a,b)->a.compareTo(b))", __.order().by((a, b) -> ((Integer) a).compareTo((Integer) b)), false},
                 {"order(local).by((a,b)->a.compareTo(b))", __.order(Scope.local).by((a, b) -> ((Integer) a).compareTo((Integer) b)), false},
                 {"__.choose(v->v.toString().equals(\"marko\"),__.out(),__.in())", __.choose(v -> v.toString().equals("marko"), __.out(), __.in()), false},
+                {"order(local).by(values,decr)", __.order(Scope.local).by(Column.values, (a, b) -> ((Double) a).compareTo((Double) b)), false},
                 //
                 {"order(local).by(values,decr)", __.order(Scope.local).by(Column.values, Order.decr), true},
                 {"order().by(label,decr)", __.order().by(T.label, Order.decr), true},

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyBranchTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyBranchTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.branch
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,17 +31,17 @@ public abstract class GroovyBranchTest {
 
         @Override
         public Traversal<Vertex, Object> get_g_V_branchXlabel_eq_person__a_bX_optionXa__ageX_optionXb__langX_optionXb__nameX() {
-            TraversalScriptHelper.compute("g.V.branch(__.label.is('person').count).option(1L, __.age).option(0L, __.lang).option(0L,__.name)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.branch(__.label.is('person').count).option(1L, __.age).option(0L, __.lang).option(0L,__.name)");
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_V_branchXlabelX_optionXperson__ageX_optionXsoftware__langX_optionXsoftware__nameX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
             g.V.branch{it.label == 'person' ? 'a' : 'b'}
                     .option('a', __.age)
                     .option('b', __.lang)
                     .option('b', __.name)
-            """, g)
+            """)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyChooseTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyChooseTest.groovy
@@ -18,11 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.branch
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
-
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -33,12 +31,12 @@ public abstract class GroovyChooseTest {
     public static class Traversals extends ChooseTest {
         @Override
         public Traversal<Vertex, Object> get_g_V_chooseXout_countX_optionX2L__nameX_optionX3L__valueMapX() {
-            TraversalScriptHelper.compute("g.V.choose(__.out.count).option(2L, __.values('name')).option(3L, __.valueMap())", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(__.out.count).option(2L, __.values('name')).option(3L, __.valueMap())")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_chooseXlabel_eqXpersonX__outXknowsX__inXcreatedXX_name() {
-            TraversalScriptHelper.compute("g.V.choose({it.label() == 'person'}, out('knows'), __.in('created')).name",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose({it.label() == 'person'}, out('knows'), __.in('created')).name")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyLocalTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyLocalTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.branch
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -32,52 +32,52 @@ public abstract class GroovyLocalTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_localXpropertiesXlocationX_order_byXvalueX_limitX2XX_value() {
-            TraversalScriptHelper.compute("g.V.local(__.properties('location').order.by(value,incr).limit(2)).value", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.local(__.properties('location').order.by(value,incr).limit(2)).value");
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXlabel_personX_asXaX_localXoutXcreatedX_asXbXX_selectXa_bX_byXnameX_byXidX() {
-            TraversalScriptHelper.compute("g.V.has(T.label, 'person').as('a').local(__.out('created').as('b')).select('a', 'b').by('name').by(T.id)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has(T.label, 'person').as('a').local(__.out('created').as('b')).select('a', 'b').by('name').by(T.id)");
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_localXoutE_countX() {
-            TraversalScriptHelper.compute("g.V.local(__.outE.count())", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.local(__.outE.count())");
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_localXoutEXknowsX_limitX1XX_inV_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).local(__.outE('knows').limit(1)).inV.name", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).local(__.outE('knows').limit(1)).inV.name", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_localXbothEXcreatedX_limitX1XX_otherV_name() {
-            TraversalScriptHelper.compute("g.V().local(__.bothE('created').limit(1)).otherV.name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().local(__.bothE('created').limit(1)).otherV.name");
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX4X_localXbothEX1_createdX_limitX1XX(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).local(__.bothE('created').limit(1))", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).local(__.bothE('created').limit(1))", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX4X_localXbothEXknows_createdX_limitX1XX(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).local(__.bothE('knows', 'created').limit(1))", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).local(__.bothE('knows', 'created').limit(1))", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX4X_localXbothE_limitX1XX_otherV_name(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).local(__.bothE.limit(1)).otherV.name", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).local(__.bothE.limit(1)).otherV.name", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX4X_localXbothE_limitX2XX_otherV_name(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).local(__.bothE.limit(2)).otherV.name", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).local(__.bothE.limit(2)).otherV.name", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_localXinEXknowsX_limitX2XX_outV_name() {
-            TraversalScriptHelper.compute("g.V().local(__.inE('knows').limit(2).outV).name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().local(__.inE('knows').limit(2).outV).name");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyRepeatTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyRepeatTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.branch
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,57 +32,57 @@ public abstract class GroovyRepeatTest {
 
         @Override
         public Traversal<Vertex, Path> get_g_V_repeatXoutX_timesX2X_emit_path() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out).times(2).emit.path", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out).times(2).emit.path")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_repeatXoutX_timesX2X_repeatXinX_timesX2X_name() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out).times(2).repeat(__.in).times(2).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out).times(2).repeat(__.in).times(2).name")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_repeatXoutX_timesX2X() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out).times(2)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out).times(2)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_repeatXoutX_timesX2X_emit() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out).times(2).emit", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out).times(2).emit")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_timesX2X_repeatXoutX_name(Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).times(2).repeat(__.out).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).times(2).repeat(__.out).name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_emit_repeatXoutX_timesX2X_path() {
-            TraversalScriptHelper.compute("g.V.emit.repeat(__.out).times(2).path", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.emit.repeat(__.out).times(2).path")
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_emit_timesX2X_repeatXoutX_path() {
-            TraversalScriptHelper.compute("g.V.emit.times(2).repeat(__.out).path", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.emit.times(2).repeat(__.out).path")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_emitXhasXlabel_personXX_repeatXoutX_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).emit(has(T.label, 'person')).repeat(__.out).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).emit(has(T.label, 'person')).repeat(__.out).name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXgroupCountXmX_byXnameX_outX_timesX2X_capXmX() {
-            TraversalScriptHelper.compute("g.V.repeat(groupCount('m').by('name').out).times(2).cap('m')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(groupCount('m').by('name').out).times(2).cap('m')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_repeatXbothX_timesX10X_asXaX_out_asXbX_selectXa_bX() {
-            TraversalScriptHelper.compute("g.V.repeat(both()).times(10).as('a').out().as('b').select('a', 'b')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both()).times(10).as('a').out().as('b').select('a', 'b')");
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_repeatXoutX_untilXoutE_count_isX0XX_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).repeat(out()).until(__.outE.count.is(0)).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(out()).until(__.outE.count.is(0)).name", "v1Id", v1Id)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyUnionTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/branch/GroovyUnionTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.branch
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -30,23 +30,23 @@ public abstract class GroovyUnionTest {
     public static class Traversals extends UnionTest {
 
         public Traversal<Vertex, String> get_g_V_unionXout__inX_name() {
-            TraversalScriptHelper.compute("g.V.union(__.out, __.in).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.union(__.out, __.in).name")
         }
 
         public Traversal<Vertex, String> get_g_VX1X_unionXrepeatXoutX_timesX2X__outX_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).union(repeat(__.out).times(2), __.out).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).union(repeat(__.out).times(2), __.out).name", "v1Id", v1Id)
         }
 
         public Traversal<Vertex, String> get_g_V_chooseXlabel_is_person__unionX__out_lang__out_nameX__in_labelX() {
-            TraversalScriptHelper.compute("g.V.choose(__.label.is('person'), union(__.out.lang, __.out.name), __.in.label)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(__.label.is('person'), union(__.out.lang, __.out.name), __.in.label)")
         }
 
         public Traversal<Vertex, Map<String, Long>> get_g_V_chooseXlabel_is_person__unionX__out_lang__out_nameX__in_labelX_groupCount() {
-            TraversalScriptHelper.compute("g.V.choose(__.label.is('person'), union(__.out.lang, __.out.name), __.in.label).groupCount", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(__.label.is('person'), union(__.out.lang, __.out.name), __.in.label).groupCount")
         }
 
         public Traversal<Vertex, Map<String, Long>> get_g_V_unionXrepeatXunionXoutXcreatedX__inXcreatedXX_timesX2X__repeatXunionXinXcreatedX__outXcreatedXX_timesX2XX_label_groupCount() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
             g.V.union(
                     repeat(union(
                             out('created'),
@@ -54,13 +54,13 @@ public abstract class GroovyUnionTest {
                     repeat(union(
                             __.in('created'),
                             out('created'))).times(2)).label.groupCount()
-           """, g)
+           """)
         }
 
         @Override
         public Traversal<Vertex, Number> get_g_VX1_2X_unionXoutE_count__inE_count__outE_weight_sumX(
                 final Object v1Id, final Object v2Id) {
-            TraversalScriptHelper.compute("g.V(v1Id, v2Id).union(outE().count, inE().count, outE().weight.sum)", g, "v1Id", v1Id, "v2Id", v2Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id).union(outE().count, inE().count, outE().weight.sum)", "v1Id", v1Id, "v2Id", v2Id);
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyAndTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyAndTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,22 +31,22 @@ public abstract class GroovyAndTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_andXhasXage_gt_27X__outE_count_gt_2X_name() {
-            TraversalScriptHelper.compute("g.V.and(has('age',gt(27)), outE().count.is(gte(2l))).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.and(has('age',gt(27)), outE().count.is(gte(2l))).name")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_andXoutE__hasXlabel_personX_and_hasXage_gte_32XX_name() {
-            TraversalScriptHelper.compute("g.V.and(outE(), has(label, 'person') & has('age', gte(32))).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.and(outE(), has(label, 'person') & has('age',gte(32))).name")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_asXaX_outXknowsX_and_outXcreatedX_inXcreatedX_asXaX_name() {
-            TraversalScriptHelper.compute("g.V.as('a').out('knows') & out('created').in('created').as('a').name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('knows') & out('created').in('created').as('a').name")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_asXaX_andXselectXaX_selectXaXX() {
-            TraversalScriptHelper.compute("g.V().as('a').and(__.select('a'), __.select('a'))", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').and(__.select('a'), __.select('a'))");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyCoinTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyCoinTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -30,12 +30,12 @@ public abstract class GroovyCoinTest {
     public static class Traversals extends CoinTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_coinX1X() {
-            TraversalScriptHelper.compute("g.V.coin(1.0f)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.coin(1.0f)");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_coinX0X() {
-            TraversalScriptHelper.compute("g.V.coin(0.0f)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.coin(0.0f)");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyCyclicPathTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyCyclicPathTest.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,12 +32,12 @@ public abstract class GroovyCyclicPathTest {
 
         @Override
         Traversal<Vertex, Vertex> get_g_VX1X_outXcreatedX_inXcreatedX_cyclicPath(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('created').in('created').cyclicPath", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('created').in('created').cyclicPath", "v1Id", v1Id);
         }
 
         @Override
         Traversal<Vertex, Path> get_g_VX1X_outXcreatedX_inXcreatedX_cyclicPath_path(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('created').in('created').cyclicPath().path()", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('created').in('created').cyclicPath().path()", "v1Id", v1Id);
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDedupTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDedupTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -33,52 +33,52 @@ public abstract class GroovyDedupTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_both_dedup_name() {
-            TraversalScriptHelper.compute("g.V.both.dedup.name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.dedup.name");
         }
 
         @Override
         public Traversal<Vertex, Map<String, List<Double>>> get_g_V_group_byXlabelX_byXbothE_weight_dedup_foldX() {
-            TraversalScriptHelper.compute("g.V.group.by(label).by(__.bothE.weight.dedup.fold)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group.by(label).by(__.bothE.weight.dedup.fold)");
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_both_hasXlabel_softwareX_dedup_byXlangX_name() {
-            TraversalScriptHelper.compute("g.V.both.has(label, 'software').dedup.by('lang').name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.has(label, 'software').dedup.by('lang').name");
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_both_name_order_byXa_bX_dedup_value() {
-            TraversalScriptHelper.compute("g.V().both().properties('name').order.by { a, b -> a.value() <=> b.value() }.dedup.value", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().both().properties('name').order.by { a, b -> a.value() <=> b.value() }.dedup.value");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_both_both_dedup() {
-            TraversalScriptHelper.compute("g.V.both.both.dedup", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.both.dedup")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_both_both_dedup_byXlabelX() {
-            TraversalScriptHelper.compute("g.V.both.both.dedup.by(label)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.both.dedup.by(label)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_both_both_name_dedup() {
-            TraversalScriptHelper.compute("g.V.both.both.name.dedup", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.both.name.dedup")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_asXaX_both_asXbX_dedupXa_bX_byXlabelX_selectXa_bX() {
-            TraversalScriptHelper.compute("g.V.as('a').both.as('b').dedup('a', 'b').by(label).select('a','b')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').both.as('b').dedup('a', 'b').by(label).select('a','b')")
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_asXaX_outXcreatedX_asXbX_inXcreatedX_asXcX_dedupXa_bX_path() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').as('b').in('created').as('c').dedup('a','b').path", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').as('b').in('created').as('c').dedup('a','b').path")
         }
 
         @Override
         Traversal<Vertex, String> get_g_V_outE_asXeX_inV_asXvX_selectXeX_order_byXweight_incrX_selectXvX_valuesXnameX_dedup() {
-            TraversalScriptHelper.compute("g.V.outE.as('e').inV.as('v').select('e').order.by('weight', incr).select('v').values('name').dedup", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.as('e').inV.as('v').select('e').order.by('weight', incr).select('v').values('name').dedup")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDropTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyDropTest.groovy
@@ -19,6 +19,7 @@
 
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.structure.Edge
@@ -34,17 +35,17 @@ public abstract class GroovyDropTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_drop() {
-            TraversalScriptHelper.compute("g.V.drop", g)
+            new ScriptTraversal<>(g, "gremlin-groovy","g.V.drop")
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_outE_drop() {
-            TraversalScriptHelper.compute("g.V.outE.drop", g)
+            new ScriptTraversal<>(g, "gremlin-groovy","g.V.outE.drop")
         }
 
         @Override
         public Traversal<Vertex, VertexProperty> get_g_V_properties_drop() {
-            TraversalScriptHelper.compute("g.V.properties().drop", g)
+            new ScriptTraversal<>(g, "gremlin-groovy","g.V.properties().drop")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyFilterTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyFilterTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -32,42 +32,42 @@ public abstract class GroovyFilterTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_filterXfalseX() {
-            TraversalScriptHelper.compute("g.V.filter { false }", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.filter { false }");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_filterXtrueX() {
-            TraversalScriptHelper.compute("g.V.filter { true }", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.filter { true }");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_filterXlang_eq_javaX() {
-            TraversalScriptHelper.compute("g.V.filter { it.property('lang').orElse('none') == 'java' }", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.filter { it.property('lang').orElse('none') == 'java' }");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_filterXage_gt_30X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).filter { it.age > 30 }", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).filter { it.age > 30 }", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_filterXage_gt_30X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.filter { it.property('age').orElse(0) > 30 }", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.filter { it.property('age').orElse(0) > 30 }", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_filterXname_startsWith_m_OR_name_startsWith_pX() {
-            TraversalScriptHelper.compute("g.V.filter { it.name.startsWith('m') || it.name.startsWith('p') }", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.filter { it.name.startsWith('m') || it.name.startsWith('p') }");
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_E_filterXfalseX() {
-            TraversalScriptHelper.compute("g.E.filter { false }", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E.filter { false }");
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_E_filterXtrueX() {
-            TraversalScriptHelper.compute("g.E.filter { true }", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E.filter { true }");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -31,108 +31,108 @@ public abstract class GroovyHasTest {
     public static class Traversals extends HasTest {
         @Override
         public Traversal<Edge, Edge> get_g_EX11X_outV_outE_hasXid_10X(final Object e11Id, final Object e8Id) {
-            TraversalScriptHelper.compute("g.E(e11Id).outV.outE.has(T.id, e8Id)", g, "e11Id", e11Id, "e8Id", e8Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E(e11Id).outV.outE.has(T.id, e8Id)", "e11Id", e11Id, "e8Id", e8Id);
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_outXcreatedX_hasXname__mapXlengthX_isXgtX3XXX_name() {
-            TraversalScriptHelper.compute("g.V.out('created').has('name',map{it.length()}.is(gt(3))).name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('created').has('name',map{it.length()}.is(gt(3))).name");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_hasXkeyX(final Object v1Id, final String key) {
-            TraversalScriptHelper.compute("g.V(v1Id).has(k)", g, "v1Id", v1Id, "k", key);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).has(k)", "v1Id", v1Id, "k", key);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_hasXname_markoX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).has('name', 'marko')", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).has('name', 'marko')", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXname_markoX() {
-            TraversalScriptHelper.compute("g.V.has('name', 'marko')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name', 'marko')");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXname_blahX() {
-            TraversalScriptHelper.compute("g.V.has('name', 'blah')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name', 'blah')");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXblahX() {
-            TraversalScriptHelper.compute("g.V.has('blah')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('blah')");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_hasXage_gt_30X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).has('age', gt(30))", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).has('age',gt(30))", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VXv1X_hasXage_gt_30X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(g.V(v1Id).next()).has('age', gt(30))", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(g.V(v1Id).next()).has('age',gt(30))", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_hasIdX2X(final Object v1Id, final Object v2Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.hasId(v2Id)", g, "v1Id", v1Id, "v2Id", v2Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.hasId(v2Id)", "v1Id", v1Id, "v2Id", v2Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_hasIdX2_3X(
                 final Object v1Id, final Object v2Id, final Object v3Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.hasId(v2Id, v3Id)", g, "v1Id", v1Id, "v2Id", v2Id, "v3Id", v3Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.hasId(v2Id, v3Id)", "v1Id", v1Id, "v2Id", v2Id, "v3Id", v3Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_hasXid_lt_3X(final Object v1Id, final Object v3Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out().has(T.id, P.lt(v3Id))", g, "v1Id", v1Id, "v3Id", v3Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out().has(T.id, P.lt(v3Id))", "v1Id", v1Id, "v3Id", v3Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXage_gt_30X() {
-            TraversalScriptHelper.compute("g.V.has('age', gt(30))", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age',gt(30))");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXage_isXgt_30XX() {
-            TraversalScriptHelper.compute("g.V.has('age', __.is(gt(30)))", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age', __.is(gt(30)))");
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_EX7X_hasLabelXknowsX(final Object e7Id) {
-            TraversalScriptHelper.compute("g.E(e7Id).hasLabel('knows')", g, "e7Id", e7Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E(e7Id).hasLabel('knows')", "e7Id", e7Id);
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_E_hasLabelXknowsX() {
-            TraversalScriptHelper.compute("g.E.hasLabel('knows')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E.hasLabel('knows')");
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_E_hasLabelXuses_traversesX() {
-            TraversalScriptHelper.compute("g.E.hasLabel('uses', 'traverses')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E.hasLabel('uses', 'traverses')");
         }
 
         @Override
         Traversal<Vertex, Vertex> get_g_V_hasLabelXperson_software_blahX() {
-            TraversalScriptHelper.compute("g.V.hasLabel('person', 'software', 'blah')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person', 'software', 'blah')");
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_hasXperson_name_markoX_age() {
-            TraversalScriptHelper.compute("g.V.has('person', 'name', 'marko').age", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('person', 'name', 'marko').age");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outE_hasXweight_inside_0_06X_inV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE.has('weight', inside(0.0d, 0.6d)).inV", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE.has('weight', inside(0.0d, 0.6d)).inV", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXlocationX() {
-            TraversalScriptHelper.compute("g.V.has('location')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('location')")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyIsTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyIsTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,27 +31,27 @@ public abstract class GroovyIsTest {
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_valuesXageX_isX32X() {
-            TraversalScriptHelper.compute("g.V.age.is(32)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.is(32)")
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_valuesXageX_isXlte_30X() {
-            TraversalScriptHelper.compute("g.V.age.is(lte(30))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.is(lte(30))")
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_valuesXageX_isXgte_29X_isXlt_34X() {
-            TraversalScriptHelper.compute("g.V.age.is(gte(29)).is(lt(34))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.is(gte(29)).is(lt(34))")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_whereXinXcreatedX_count_isX1XX_valuesXnameX() {
-            TraversalScriptHelper.compute("g.V.where(__.in('created').count.is(1)).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.where(__.in('created').count.is(1)).name")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_whereXinXcreatedX_count_isXgte_2XX_valuesXnameX() {
-            TraversalScriptHelper.compute("g.V.where(__.in('created').count.is(gte(2l))).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.where(__.in('created').count.is(gte(2l))).name")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyOrTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyOrTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,17 +31,17 @@ public abstract class GroovyOrTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_orXhasXage_gt_27X__outE_count_gte_2X_name() {
-            TraversalScriptHelper.compute("g.V.or(has('age', gt(27)), outE().count.is(gte(2l))).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.or(has('age',gt(27)), outE().count.is(gte(2l))).name")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_orXoutEXknowsX__hasXlabel_softwareX_or_hasXage_gte_35XX_name() {
-            TraversalScriptHelper.compute("g.V.or(outE('knows'), has(T.label, 'software') | has('age', gte(35))).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.or(outE('knows'), has(T.label, 'software') | has('age',gte(35))).name")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_asXaX_orXselectXaX_selectXaXX() {
-            TraversalScriptHelper.compute("g.V().as('a').or(__.select('a'), __.select('a'))", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').or(__.select('a'), __.select('a'))");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyRangeTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,82 +31,82 @@ public abstract class GroovyRangeTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_limitX2X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.limit(2)", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.limit(2)", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_localXoutE_limitX1X_inVX_limitX3X() {
-            TraversalScriptHelper.compute("g.V.local(__.outE.limit(3)).inV.limit(3)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.local(__.outE.limit(3)).inV.limit(3)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('knows').outE('created')[0].inV()", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('knows').outE('created')[0].inV()", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('knows').out('created')[0]", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('knows').out('created')[0]", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXcreatedX_inXcreatedX_rangeX1_3X(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('created').in('created')[1..3]", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('created').in('created')[1..3]", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXcreatedX_inEXcreatedX_rangeX1_3X_outV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('created').inE('created')[1..3].outV", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('created').inE('created')[1..3].outV", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_rangeX5_11X() {
-            TraversalScriptHelper.compute("g.V().repeat(__.both).times(3)[5..11]", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().repeat(__.both).times(3)[5..11]")
         }
 
         @Override
         public Traversal<Vertex, List<String>> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_2X() {
-            TraversalScriptHelper.compute("g.V().as('a').in().as('a').in().as('a').select('a').by(unfold().values('name').fold).limit(local,2)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').in().as('a').in().as('a').select('a').by(unfold().values('name').fold).limit(local,2)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_in_asXaX_in_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_limitXlocal_1X() {
-            TraversalScriptHelper.compute("g.V().as('a').in().as('a').in().as('a').select('a').by(unfold().values('name').fold).limit(local,1)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').in().as('a').in().as('a').select('a').by(unfold().values('name').fold).limit(local,1)")
         }
 
         @Override
         public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_3X() {
-            TraversalScriptHelper.compute("g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,1,3)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,1,3)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_1_2X() {
-            TraversalScriptHelper.compute("g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,1,2)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,1,2)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_rangeXlocal_4_5X() {
-            TraversalScriptHelper.compute("g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,4,5)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').out().as('a').out().as('a').select('a').by(unfold().values('name').fold).range(local,4,5)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_2X() {
-            TraversalScriptHelper.compute("g.V.as('a').in.as('b').in.as('c').select('a','b','c').by('name').limit(local,2)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').in.as('b').in.as('c').select('a','b','c').by('name').limit(local,2)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_in_asXbX_in_asXcX_selectXa_b_cX_byXnameX_limitXlocal_1X() {
-            TraversalScriptHelper.compute("g.V.as('a').in.as('b').in.as('c').select('a','b','c').by('name').limit(local,1)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').in.as('b').in.as('c').select('a','b','c').by('name').limit(local,1)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_3X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').range(local,1,3)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').range(local,1,3)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_rangeXlocal_1_2X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').range(local,1,2)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').range(local,1,2)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovySampleTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovySampleTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -32,27 +32,27 @@ public abstract class GroovySampleTest {
 
         @Override
         public Traversal<Edge, Edge> get_g_E_sampleX1X() {
-            TraversalScriptHelper.compute("g.E.sample(1)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E.sample(1)")
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_E_sampleX2X_byXweightX() {
-            TraversalScriptHelper.compute("g.E.sample(2).by('weight')",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E.sample(2).by('weight')")
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_localXoutE_sampleX1X_byXweightXX() {
-            TraversalScriptHelper.compute("g.V.local(__.outE.sample(1).by('weight'))",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.local(__.outE.sample(1).by('weight'))")
         }
 
         @Override
         Traversal<Vertex, Map<String, Collection<Double>>> get_g_V_group_byXlabelX_byXbothE_weight_sampleX2X_foldX() {
-            TraversalScriptHelper.compute("g.V().group().by(T.label).by(bothE().weight.sample(2).fold)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().group().by(T.label).by(bothE().weight.sample(2).fold)")
         }
 
         @Override
         Traversal<Vertex, Map<String, Collection<Double>>> get_g_V_group_byXlabelX_byXbothE_weight_fold_sampleXlocal_5XX() {
-            TraversalScriptHelper.compute("g.V().group().by(label).by(bothE().weight.fold().sample(local, 5))",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().group().by(label).by(bothE().weight.fold().sample(local, 5))")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovySimplePathTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovySimplePathTest.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,12 +32,12 @@ public abstract class GroovySimplePathTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXcreatedX_inXcreatedX_simplePath(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('created').in('created').simplePath", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('created').in('created').simplePath", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_repeatXboth_simplePathX_timesX3X_path() {
-            TraversalScriptHelper.compute("g.V.repeat(__.both.simplePath).times(3).path()", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.both.simplePath).times(3).path()");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyTailTest.groovy
@@ -19,18 +19,8 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
-import org.apache.tinkerpop.gremlin.structure.T
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
-
-import java.util.List
-import java.util.Map
-
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.limit
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.unfold
-import static org.apache.tinkerpop.gremlin.process.traversal.Scope.global
-import static org.apache.tinkerpop.gremlin.process.traversal.Scope.local
 
 /**
  * @author Matt Frantz (http://github.com/mhfrantz)
@@ -41,57 +31,57 @@ public abstract class GroovyTailTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailXglobal_2X() {
-            TraversalScriptHelper.compute("g.V.values('name').order.tail(global, 2)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.values('name').order.tail(global, 2)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX2X() {
-            TraversalScriptHelper.compute("g.V.values('name').order.tail(2)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.values('name').order.tail(2)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tail() {
-            TraversalScriptHelper.compute("g.V.values('name').order.tail",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.values('name').order.tail")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_valuesXnameX_order_tailX7X() {
-            TraversalScriptHelper.compute("g.V.values('name').order.tail(7)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.values('name').order.tail(7)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_tailX7X() {
-            TraversalScriptHelper.compute("g.V.repeat(both()).times(3).tail(7)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both()).times(3).tail(7)")
         }
 
         @Override
         public Traversal<Vertex, List<String>> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_2X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 2)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 2)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocal_1X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 1)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local, 1)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXunfold_valuesXnameX_foldX_tailXlocalX() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(unfold().values('name').fold).tail(local)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_asXaX_out_asXaX_out_asXaX_selectXaX_byXlimitXlocal_0XX_tailXlocal_1X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('a').out.as('a').select('a').by(limit(local, 0)).tail(local, 1)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('a').out.as('a').select('a').by(limit(local, 0)).tail(local, 1)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_2X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').tail(local, 2)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').tail(local, 2)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_out_asXcX_selectXa_b_cX_byXnameX_tailXlocal_1X() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').tail(local, 1)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').out.as('c').select('a','b','c').by('name').tail(local, 1)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyWhereTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyWhereTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.filter
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -34,22 +34,22 @@ public abstract class GroovyWhereTest {
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXa_eqXbXX() {
-            TraversalScriptHelper.compute("g.V.has('age').as('a').out.in.has('age').as('b').select('a','b').where('a', eq('b'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').as('a').out.in.has('age').as('b').select('a','b').where('a', eq('b'))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXa_neqXbXX() {
-            TraversalScriptHelper.compute("g.V.has('age').as('a').out.in.has('age').as('b').select('a','b').where('a', neq('b'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').as('a').out.in.has('age').as('b').select('a','b').where('a', neq('b'))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXb_hasXname_markoXX() {
-            TraversalScriptHelper.compute("g.V.has('age').as('a').out.in.has('age').as('b').select('a','b').where(__.as('b').has('name', 'marko'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').as('a').out.in.has('age').as('b').select('a','b').where(__.as('b').has('name', 'marko'))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXageX_asXaX_out_in_hasXageX_asXbX_selectXa_bX_whereXa_outXknowsX_bX() {
-            TraversalScriptHelper.compute("g.V().has('age').as('a').out.in.has('age').as('b').select('a','b').where(__.as('a').out('knows').as('b'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().has('age').as('a').out.in.has('age').as('b').select('a','b').where(__.as('a').out('knows').as('b'))")
         }
 
         /// where(global)
@@ -57,13 +57,13 @@ public abstract class GroovyWhereTest {
         @Override
         public Traversal<Vertex, String> get_g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_neqXbXX_name(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').in('created').as('b').where('a', neq('b')).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').in('created').as('b').where('a', neq('b')).name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').in('created').as('b').where(__.as('b').out('created').has('name','ripple')).values('age','name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').in('created').as('b').where(__.as('b').out('created').has('name','ripple')).values('age','name')", "v1Id", v1Id)
         }
 
         // except/retain functionality
@@ -71,65 +71,65 @@ public abstract class GroovyWhereTest {
         @Override
         public Traversal<Vertex, String> get_g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').in('created').where(eq('a')).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').in('created').where(eq('a')).name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_name(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').in('created').where(neq('a')).name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').in('created').where(neq('a')).name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_aggregateXxX_out_whereXnotXwithinXaXXX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.aggregate('x').out.where(not(within('x')))", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.aggregate('x').out.where(not(within('x')))", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_withSideEffectXa_graph_verticesX2XX_VX1X_out_whereXneqXaXX(
                 final Object v1Id, final Object v2Id) {
-            TraversalScriptHelper.compute("g.withSideEffect('a'){graph.vertices(v2Id).next()}.V(v1Id).out.where(neq('a'))", g, "graph", graph, "v1Id", v1Id, "v2Id", v2Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('a'){graph.vertices(v2Id).next()}.V(v1Id).out.where(neq('a'))", "graph", graph, "v1Id", v1Id, "v2Id", v2Id)
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_VX1X_repeatXbothEXcreatedX_whereXwithoutXeXX_aggregateXeX_otherVX_emit_path(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).repeat(__.bothE('created').where(without('e')).aggregate('e').otherV).emit.path", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(__.bothE('created').where(without('e')).aggregate('e').otherV).emit.path", "v1Id", v1Id)
         }
 
         // hasNot functionality
 
         @Override
         public Traversal<Vertex, String> get_g_V_whereXnotXoutXcreatedXXX_name() {
-            TraversalScriptHelper.compute("g.V.where(__.not(out('created'))).name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.where(__.not(out('created'))).name");
         }
 
         // complex and/or functionality
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_whereXandXasXaX_outXknowsX_asXbX__orXasXbX_outXcreatedX_hasXname_rippleX__asXbX_inXknowsX_count_isXnotXeqX0XXXXX_selectXa_bX() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').where(and(__.as('a').out('knows').as('b'),or(__.as('b').out('created').has('name','ripple'),__.as('b').in('knows').count.is(not(eq(0)))))).select('a','b')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').where(and(__.as('a').out('knows').as('b'),or(__.as('b').out('created').has('name','ripple'),__.as('b').in('knows').count.is(not(eq(0)))))).select('a','b')")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_whereXoutXcreatedX_and_outXknowsX_or_inXknowsXX_valuesXnameX() {
-            TraversalScriptHelper.compute("g.V.where(out('created').and.out('knows').or.in('knows')).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.where(out('created').and.out('knows').or.in('knows')).name")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_outXcreatedX_asXbX_whereXandXasXbX_in__notXasXaX_outXcreatedX_hasXname_rippleXXX_selectXa_bX() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').as('b').where(and(__.as('b').in,__.not(__.as('a').out('created').has('name','ripple')))).select('a','b')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').as('b').where(and(__.as('b').in,__.not(__.as('a').out('created').has('name','ripple')))).select('a','b')")
         }
 
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_outXcreatedX_asXbX_inXcreatedX_asXcX_bothXknowsX_bothXknowsX_asXdX_whereXc__notXeqXaX_orXeqXdXXXX_selectXa_b_c_dX() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').as('b').in('created').as('c').both('knows').both('knows').as('d').where('c',not(eq('a').or(eq('d')))).select('a','b','c','d')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').as('b').in('created').as('c').both('knows').both('knows').as('d').where('c',not(eq('a').or(eq('d')))).select('a','b','c','d')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').where(__.as('b').in.count.is(eq(3)).or.where(__.as('b').out('created').and.as('b').has(label,'person'))).select('a','b')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').where(__.as('b').in.count.is(eq(3)).or.where(__.as('b').out('created').and.as('b').has(label,'person'))).select('a','b')")
         }
 
     }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddEdgeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddEdgeTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -32,54 +32,54 @@ public abstract class GroovyAddEdgeTest {
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addEXcreatedByX_toXaX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').addE('createdBy').to('a')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').addE('createdBy').to('a')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addEXcreatedByX_toXaX_propertyXweight_2X(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').addE('createdBy').to('a').property('weight', 2.0d)", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').addE('createdBy').to('a').property('weight', 2.0d)", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_aggregateXxX_asXaX_selectXxX_unfold_addEXexistsWithX_toXaX_propertyXtime_nowX() {
-            TraversalScriptHelper.compute("g.V.aggregate('x').as('a').select('x').unfold.addE('existsWith').to('a').property('time', 'now')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.aggregate('x').as('a').select('x').unfold.addE('existsWith').to('a').property('time', 'now')");
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_addEXcodeveloperX_fromXaX_toXbX_propertyXyear_2009X() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').in('created').where(neq('a')).as('b').addE('co-developer').from('a').to('b').property('year', 2009)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').in('created').where(neq('a')).as('b').addE('co-developer').from('a').to('b').property('year', 2009)");
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_inXcreatedX_addEXcreatedByX_fromXaX_propertyXyear_2009X_propertyXacl_publicX() {
-            TraversalScriptHelper.compute("g.V.as('a').in('created').addE('createdBy').from('a').property('year', 2009).property('acl', 'public')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').in('created').addE('createdBy').from('a').property('year', 2009).property('acl', 'public')");
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_aX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').addOutE('createdBy', 'a')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').addOutE('createdBy', 'a')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_asXaX_outXcreatedX_addOutEXcreatedBy_a_weight_2X(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('created').addOutE('createdBy', 'a', 'weight', 2.0d)", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('created').addOutE('createdBy', 'a', 'weight', 2.0d)", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_withSideEffectXx__g_V_toListX_addOutEXexistsWith_x_time_nowX() {
-            TraversalScriptHelper.compute("g.withSideEffect('x',g.V.toList()).V.addOutE('existsWith', 'x', 'time', 'now')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('x',g.V.toList()).V.addOutE('existsWith', 'x', 'time', 'now')");
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_asXbX_selectXa_bX_addInEXa_codeveloper_b_year_2009X() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').in('created').where(neq('a')).as('b').select('a','b').addInE('a', 'co-developer', 'b', 'year', 2009)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').in('created').where(neq('a')).as('b').select('a','b').addInE('a', 'co-developer', 'b', 'year', 2009)");
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_asXaX_inXcreatedX_addInEXcreatedBy_a_year_2009_acl_publicX() {
-            TraversalScriptHelper.compute("g.V.as('a').in('created').addInE('createdBy', 'a', 'year', 2009, 'acl', 'public')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').in('created').addInE('createdBy', 'a', 'year', 2009, 'acl', 'public')");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddVertexTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyAddVertexTest.groovy
@@ -20,7 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,60 +31,61 @@ public abstract class GroovyAddVertexTest {
     public static class Traversals extends AddVertexTest {
 
         @Override
-        public Traversal<Vertex, Vertex> get_g_VX1X_addVXanimalX_propertyXage_selectXaX_byXageXX_propertyXname_puppyX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').addV('animal').property('age', select('a').by('age')).property('name', 'puppy')", g, "v1Id", v1Id);
+        public Traversal<Vertex, Vertex> get_g_VX1X_addVXanimalX_propertyXage_selectXaX_byXageXX_propertyXname_puppyX(
+                final Object v1Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').addV('animal').property('age', select('a').by('age')).property('name', 'puppy')", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_addVXanimalX_propertyXage_0X() {
-            TraversalScriptHelper.compute("g.V().addV('animal').property('age', 0)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().addV('animal').property('age', 0)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_addVXpersonX_propertyXname_stephenX() {
-            TraversalScriptHelper.compute("g.addV(label, 'person', 'name', 'stephen')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.addV(label, 'person', 'name', 'stephen')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_addVXpersonX_propertyXname_stephenX_propertyXname_stephenmX() {
-            TraversalScriptHelper.compute("g.addV('person').property('name', 'stephen').property('name', 'stephenm')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.addV('person').property('name', 'stephen').property('name', 'stephenm')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_addVXpersonX_propertyXsingle_name_stephenX_propertyXsingle_name_stephenmX() {
-            TraversalScriptHelper.compute("g.addV('person').property(VertexProperty.Cardinality.single, 'name', 'stephen').property(VertexProperty.Cardinality.single, 'name', 'stephenm')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.addV('person').property(VertexProperty.Cardinality.single, 'name', 'stephen').property(VertexProperty.Cardinality.single, 'name', 'stephenm')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_addVXpersonX_propertyXsingle_name_stephenX_propertyXsingle_name_stephenm_since_2010X() {
-            TraversalScriptHelper.compute("g.addV('person').property(VertexProperty.Cardinality.single, 'name', 'stephen').property(VertexProperty.Cardinality.single, 'name', 'stephenm', 'since', 2010)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.addV('person').property(VertexProperty.Cardinality.single, 'name', 'stephen').property(VertexProperty.Cardinality.single, 'name', 'stephenm', 'since', 2010)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXname_markoX_propertyXfriendWeight_outEXknowsX_weight_sum__acl_privateX() {
-            TraversalScriptHelper.compute("g.V.has('name', 'marko').property('friendWeight', outE('knows').weight.sum(), 'acl', 'private')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name', 'marko').property('friendWeight', outE('knows').weight.sum(), 'acl', 'private')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_addVXanimalX_propertyXname_mateoX_propertyXname_gateoX_propertyXname_cateoX_propertyXage_5X() {
-            TraversalScriptHelper.compute("g.addV('animal').property('name', 'mateo').property('name', 'gateo').property('name', 'cateo').property('age', 5)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.addV('animal').property('name', 'mateo').property('name', 'gateo').property('name', 'cateo').property('age', 5)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_addVXanimalX_propertyXname_valuesXnameXX_propertyXname_an_animalX_propertyXvaluesXnameX_labelX() {
-            TraversalScriptHelper.compute("g.V.addV('animal').property('name', values('name')).property('name', 'an animal').property(values('name'), label())", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.addV('animal').property('name', values('name')).property('name', 'an animal').property(values('name'), label())")
         }
 
         ///////// DEPRECATED BELOW
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_addVXlabel_animal_age_0X() {
-            TraversalScriptHelper.compute("g.V.addV(label, 'animal', 'age', 0)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.addV(label, 'animal', 'age', 0)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_addVXlabel_person_name_stephenX() {
-            TraversalScriptHelper.compute("g.addV(label, 'person', 'name', 'stephen')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.addV(label, 'person', 'name', 'stephen')")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCoalesceTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCoalesceTest.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -33,27 +33,27 @@ public abstract class GroovyCoalesceTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_coalesceXoutXfooX_outXbarXX() {
-            TraversalScriptHelper.compute("g.V().coalesce(out('foo'), out('bar'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().coalesce(out('foo'), out('bar'))")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_coalesceXoutXknowsX_outXcreatedXX_valuesXnameX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).coalesce(out('knows'), out('created')).values('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).coalesce(out('knows'), out('created')).values('name')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_coalesceXoutXcreatedX_outXknowsXX_valuesXnameX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).coalesce(out('created'), out('knows')).values('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).coalesce(out('created'), out('knows')).values('name')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_coalesceXoutXlikesX_outXknowsX_inXcreatedXX_groupCount_byXnameX() {
-            TraversalScriptHelper.compute("g.V().coalesce(out('likes'), out('knows'), out('created')).groupCount().by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().coalesce(out('likes'), out('knows'), out('created')).groupCount().by('name')")
         }
 
         @Override
         Traversal<Vertex, Path> get_g_V_coalesceXoutEXknowsX_outEXcreatedXX_otherV_path_byXnameX_byXlabelX() {
-            TraversalScriptHelper.compute("g.V.coalesce(outE('knows'), outE('created')).otherV.path.by('name').by(T.label)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.coalesce(outE('knows'), outE('created')).otherV.path.by('name').by(T.label)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyConstantTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyConstantTest.groovy
@@ -19,10 +19,8 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
-
-import java.util.List
 
 /**
  * @author Matt Frantz (http://github.com/mhfrantz)
@@ -32,12 +30,12 @@ public abstract class GroovyConstantTest {
     public static class Traversals extends ConstantTest {
         @Override
         public Traversal<Vertex, Integer> get_g_V_constantX123X() {
-            TraversalScriptHelper.compute("g.V.constant(123)",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.constant(123)")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_chooseXhasLabelXpersonX_valuesXnameX_constantXinhumanXX() {
-            TraversalScriptHelper.compute("g.V.choose(hasLabel('person'), values('name'), constant('inhuman'))",g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(hasLabel('person'), values('name'), constant('inhuman'))")
         }
 
     }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCountTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyCountTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -30,42 +30,42 @@ public abstract class GroovyCountTest {
     public static class Traversals extends CountTest {
         @Override
         public Traversal<Vertex, Long> get_g_V_count() {
-            TraversalScriptHelper.compute("g.V.count()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.count()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_out_count() {
-            TraversalScriptHelper.compute("g.V.out.count", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.count")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_both_both_count() {
-            TraversalScriptHelper.compute("g.V.both.both.count()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.both.both.count()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_repeatXoutX_timesX3X_count() {
-            TraversalScriptHelper.compute("g.V().repeat(__.out).times(3).count()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().repeat(__.out).times(3).count()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_repeatXoutX_timesX8X_count() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out).times(8).count()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out).times(8).count()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_repeatXoutX_timesX5X_asXaX_outXwrittenByX_asXbX_selectXa_bX_count() {
-            TraversalScriptHelper.compute("g.V.repeat(out()).times(5).as('a').out('writtenBy').as('b').select('a', 'b').count()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(out()).times(5).as('a').out('writtenBy').as('b').select('a', 'b').count()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_hasXnoX_count() {
-            TraversalScriptHelper.compute("g.V.has('no').count", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('no').count")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_fold_countXlocalX() {
-            TraversalScriptHelper.compute("g.V.fold.count(local)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.fold.count(local)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyFlatMapTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyFlatMapTest.groovy
@@ -18,11 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
-
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
 
 /**
  * @author Matt Frantz (http://github.com/mhfrantz)
@@ -32,7 +30,7 @@ public abstract class GroovyFlatMapTest {
     public static class Traversals extends FlatMapTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_flatMapXselectXaXX() {
-            TraversalScriptHelper.compute("g.V.as('a').flatMap(select('a'))", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').flatMap(select('a'))")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyFoldTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyFoldTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -30,17 +30,17 @@ public abstract class GroovyFoldTest {
     public static class Traversals extends FoldTest {
         @Override
         public Traversal<Vertex, List<Vertex>> get_g_V_fold() {
-            TraversalScriptHelper.compute("g.V.fold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.fold")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_fold_unfold() {
-            TraversalScriptHelper.compute("g.V.fold.unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.fold.unfold")
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_age_foldX0_plusX() {
-            TraversalScriptHelper.compute("g.V.age.fold(0,sum)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.fold(0,sum)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyGraphTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyGraphTest.groovy
@@ -20,7 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -33,18 +33,18 @@ public abstract class GroovyGraphTest {
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_V_valuesXnameX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).V.name", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).V.name", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_hasXname_GarciaX_inXsungByX_asXsongX_V_hasXname_Willie_DixonX_inXwrittenByX_whereXeqXsongXX_name() {
-            TraversalScriptHelper.compute("g.V.has('name','Garcia').in('sungBy').as('song').V.has('name','Willie_Dixon').in('writtenBy').where(eq('song')).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name','Garcia').in('sungBy').as('song').V.has('name','Willie_Dixon').in('writtenBy').where(eq('song')).name")
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_hasLabelXpersonX_asXpX_VXsoftwareX_addInEXuses_pX() {
             def software = g.V().hasLabel("software").toList()
-            TraversalScriptHelper.compute("g.V().hasLabel('person').as('p').V(software).addE('uses').from('p')", g, "software", software)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().hasLabel('person').as('p').V(software).addE('uses').from('p')", "software", software)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyGraphTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyGraphTest.groovy
@@ -37,6 +37,11 @@ public abstract class GroovyGraphTest {
         }
 
         @Override
+        public Traversal<Vertex, String> get_g_V_outXknowsX_V_name() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('knows').V.name")
+        }
+
+        @Override
         public Traversal<Vertex, String> get_g_V_hasXname_GarciaX_inXsungByX_asXsongX_V_hasXname_Willie_DixonX_inXwrittenByX_whereXeqXsongXX_name() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name','Garcia').in('sungBy').as('song').V.has('name','Willie_Dixon').in('writtenBy').where(eq('song')).name")
         }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyLoopsTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyLoopsTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -33,24 +33,24 @@ public abstract class GroovyLoopsTest {
         @Override
         Traversal<Vertex, Path> get_g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX3XX_hasXname_peterX_path_byXnameX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).repeat(__.both.simplePath).until(has('name', 'peter').or.loops.is(3)).has('name', 'peter').path.by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(__.both.simplePath).until(has('name', 'peter').or.loops.is(3)).has('name', 'peter').path.by('name')", "v1Id", v1Id)
         }
 
         @Override
         Traversal<Vertex, Path> get_g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_or_loops_isX2XX_hasXname_peterX_path_byXnameX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).repeat(__.both.simplePath).until(has('name', 'peter').or.loops.is(2)).has('name', 'peter').path.by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(__.both.simplePath).until(has('name', 'peter').or.loops.is(2)).has('name', 'peter').path.by('name')", "v1Id", v1Id)
         }
 
         @Override
         Traversal<Vertex, Path> get_g_VX1X_repeatXboth_simplePathX_untilXhasXname_peterX_and_loops_isX3XX_hasXname_peterX_path_byXnameX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).repeat(__.both.simplePath).until(has('name', 'peter').and.loops.is(3)).has('name', 'peter').path.by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(__.both.simplePath).until(has('name', 'peter').and.loops.is(3)).has('name', 'peter').path.by('name')", "v1Id", v1Id)
         }
 
         @Override
         Traversal<Vertex, String> get_g_V_emitXhasXname_markoX_or_loops_isX2XX_repeatXoutX_valuesXnameX() {
-            TraversalScriptHelper.compute("g.V.emit(has('name', 'marko').or.loops.is(2)).repeat(__.out).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.emit(has('name', 'marko').or.loops.is(2)).repeat(__.out).name")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMapKeysTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMapKeysTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,12 +32,12 @@ public abstract class GroovyMapKeysTest {
 
         @Override
         public Traversal<Vertex, Double> get_g_V_outE_valuesXweightX_groupCount_mapKeys() {
-            TraversalScriptHelper.compute("g.V.outE().weight.groupCount().mapKeys()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE().weight.groupCount().mapKeys()")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_V_outE_valuesXweightX_groupCount_unfold_mapKeys() {
-            TraversalScriptHelper.compute("g.V.outE().weight.groupCount().unfold().mapKeys()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE().weight.groupCount().unfold().mapKeys()")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMapTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMapTest.groovy
@@ -18,11 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
-
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -33,32 +31,32 @@ public abstract class GroovyMapTest {
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_mapXnameX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).map { v -> v.name }", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).map { v -> v.name }", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_VX1X_outE_label_mapXlengthX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE.label.map { l -> l.length() }", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE.label.map { l -> l.length() }", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_VX1X_out_mapXnameX_mapXlengthX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.map { v -> v.name }.map { n -> n.length() }", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.map { v -> v.name }.map { n -> n.length() }", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_withPath_V_asXaX_out_mapXa_nameX() {
-            TraversalScriptHelper.compute("g.withPath().V.as('a').out.map { v -> v.path('a').name }", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withPath().V.as('a').out.map { v -> v.path('a').name }")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_withPath_V_asXaX_out_out_mapXa_name_it_nameX() {
-            TraversalScriptHelper.compute("g.withPath().V().as('a').out.out().map { v -> v.path('a').name + v.name }", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withPath().V().as('a').out.out().map { v -> v.path('a').name + v.name }")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_mapXselectXaXX() {
-            TraversalScriptHelper.compute("g.V.as('a').map(select('a'))", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').map(select('a'))")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMapValuesTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMapValuesTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,17 +32,17 @@ public abstract class GroovyMapValuesTest {
 
         @Override
         public Traversal<Vertex, Long> get_g_V_outE_valuesXweightX_groupCount_mapValues() {
-            TraversalScriptHelper.compute("g.V.outE().weight.groupCount().mapValues()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE().weight.groupCount().mapValues()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_outE_valuesXweightX_groupCount_unfold_mapValues() {
-            TraversalScriptHelper.compute("g.V.outE().weight.groupCount().unfold().mapValues()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE().weight.groupCount().unfold().mapValues()")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_outE_valuesXweightX_groupCount_mapValues_groupCount_mapValues() {
-            TraversalScriptHelper.compute("g.V.outE().weight.groupCount().mapValues().groupCount().mapValues()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE().weight.groupCount().mapValues().groupCount().mapValues()")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMatchTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMatchTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.finalization.MatchAlgorithmStrategy
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.junit.Before
 
@@ -49,119 +49,119 @@ public abstract class GroovyMatchTest {
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_valueMap_matchXa_selectXnameX_bX() {
-            TraversalScriptHelper.compute("g.V.valueMap.match(__.as('a').select('name').as('b'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap.match(__.as('a').select('name').as('b'))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_out_bX() {
-            TraversalScriptHelper.compute("g.V.match(__.as('a').out.as('b'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.match(__.as('a').out.as('b'))")
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_V_matchXa_out_bX_selectXb_idX() {
-            TraversalScriptHelper.compute("g.V.match( __.as('a').out.as('b')).select('b').by(id)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.match( __.as('a').out.as('b')).select('b').by(id)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_knows_b__b_created_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('knows').as('b'),
                     __.as('b').out('created').as('c'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_knows_b__a_created_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('knows').as('b'),
                     __.as('a').out('created').as('c'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXd_0knows_a__d_hasXname_vadasX__a_knows_b__b_created_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('d').in('knows').as('a'),
                     __.as('d').has('name', 'vadas'),
                     __.as('a').out('knows').as('b'),
                     __.as('b').out('created').as('c'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_created_b__a_repeatXoutX_timesX2XX_selectXa_bX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('created').as('b'),
                     __.as('a').repeat(__.out).times(2).as('b')).select('a', 'b')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_lop_b__b_0created_29_c__c_whereXrepeatXoutX_timesX2XXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('created').has('name', 'lop').as('b'),
                     __.as('b').in('created').has('age', 29).as('c'),
                     __.as('c').where(repeat(__.out).times(2)))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_out_out_matchXa_0created_b__b_0knows_cX_selectXcX_outXcreatedX_name() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.out.out.match(
                     __.as('a').in('created').as('b'),
                     __.as('b').in('knows').as('c')).select('c').out('created').name
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_created_b__b_0created_aX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('created').as('b'),
                     __.as('b').in('created').as('a'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_knows_b__c_knows_bX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V().match(
                     __.as('a').out('knows').as('b'),
                     __.as('c').out('knows').as('b'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_knows_b__b_created_lop__b_matchXb_created_d__d_0created_cX_selectXcX_cX_selectXa_b_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as("a").out("knows").as("b"),
                     __.as("b").out("created").has("name", "lop"),
                     __.as("b").match(
                             __.as("b").out("created").as("d"),
                             __.as("d").in("created").as("c")).select("c").as("c")).select('a','b','c')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_hasXname_GarciaX__a_0writtenBy_b__a_0sungBy_bX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').has('name', 'Garcia'),
                     __.as('a').in('writtenBy').as('b'),
                     __.as('a').in('sungBy').as('b'));
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_0sungBy_b__a_0sungBy_c__b_writtenBy_d__c_writtenBy_e__d_hasXname_George_HarisonX__e_hasXname_Bob_MarleyXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').in('sungBy').as('b'),
                     __.as('a').in('sungBy').as('c'),
@@ -169,76 +169,76 @@ public abstract class GroovyMatchTest {
                     __.as('c').out('writtenBy').as('e'),
                     __.as('d').has('name', 'George_Harrison'),
                     __.as('e').has('name', 'Bob_Marley'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_0sungBy_b__a_0writtenBy_c__b_writtenBy_d__c_sungBy_d__d_hasXname_GarciaXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').in('sungBy').as('b'),
                     __.as('a').in('writtenBy').as('c'),
                     __.as('b').out('writtenBy').as('d'),
                     __.as('c').out('sungBy').as('d'),
                     __.as('d').has('name', 'Garcia'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_0sungBy_b__a_0writtenBy_c__b_writtenBy_dX_whereXc_sungBy_dX_whereXd_hasXname_GarciaXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').in('sungBy').as('b'),
                     __.as('a').in('writtenBy').as('c'),
                     __.as('b').out('writtenBy').as('d'))
                     .where(__.as('c').out('sungBy').as('d'))
                     .where(__.as('d').has('name', 'Garcia'));
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_lop_b__b_0created_29_cX_whereXc_repeatXoutX_timesX2XX_selectXa_b_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as("a").out("created").has("name", "lop").as("b"),
                     __.as("b").in("created").has("age", 29).as("c"))
                     .where(__.as("c").repeat(__.out).times(2))
                     .select('a','b','c')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_created_b__b_0created_cX_whereXa_neq_cX_selectXa_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('created').as('b'),
                     __.as('b').in('created').as('c'))
                     .where('a', neq('c'))
                     .select('a', 'c')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_b__c_created_bX_selectXa_b_cX_byXnameX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('created').as('b'),
                     __.as('c').out('created').as('b')).select('a','b','c').by('name')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_out_asXcX_matchXb_knows_a__c_created_eX_selectXcX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V().out().as("c").match(
                     as("b").out("knows").as("a"),
                     as("c").out("created").as("e")).select("c")
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_matchXa_whereXa_neqXcXX__a_created_b__orXa_knows_vadas__a_0knows_and_a_hasXlabel_personXX__b_0created_c__b_0created_count_isXgtX1XXX_selectXa_b_cX_byXidX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     where('a', neq('c')),
                     __.as('a').out('created').as('b'),
@@ -249,31 +249,31 @@ public abstract class GroovyMatchTest {
                     __.as('b').in('created').as('c'),
                     __.as('b').in('created').count.is(gt(1)))
                     .select('a','b','c').by(id);
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_matchXa_out_count_c__b_in_count_cX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.as('a').out.as('b').match(__.as('a').out.count.as('c'), __.as('b').in.count.as('c'))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_hasXname_GarciaX__a_0writtenBy_b__b_followedBy_c__c_writtenBy_d__whereXd_neqXaXXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').has('name', 'Garcia'),
                     __.as('a').in('writtenBy').as('b'),
                     __.as('b').out('followedBy').as('c'),
                     __.as('c').out('writtenBy').as('d'),
                     where('d', neq('a')))
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_matchXa_knows_b__andXa_created_c__b_created_c__andXb_created_count_d__a_knows_count_dXXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
                 g.V.match(
                     __.as('a').out('knows').as('b'),
                     and(
@@ -284,11 +284,11 @@ public abstract class GroovyMatchTest {
                                     __.as('a').out('knows').count.as('d')
                             )
                     ))
-            """, g)
+            """)
         }
 
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_out_asXbX_matchXa_out_count_c__orXa_knows_b__b_in_count_c__and__c_isXgtX2XXXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
             g.V.as('a').out.as('b').
                     match(
                             __.as('a').out.count.as('c'),
@@ -297,46 +297,46 @@ public abstract class GroovyMatchTest {
                                     __.as('b').in.count.as('c').and.as('c').is(gt(2))
                             )
                     )
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_matchXa__a_out_b__notXa_created_bXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
             g.V.match(
                     __.as('a').out.as('b'),
                     __.not(__.as('a').out('created').as('b')));
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_matchXwhereXandXa_created_b__b_0created_count_isXeqX3XXXX__a_both_b__whereXb_inXX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
              g.V.match(
                     where(and(
                             __.as('a').out('created').as('b'),
                             __.as('b').in('created').count.is(eq(3)))),
                     __.as('a').both.as('b'),
                     where(__.as('b').in()));
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa__a_both_b__b_both_cX_dedupXa_bX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
              g.V.match(
                     __.as('a').both.as('b'),
                     __.as('b').both.as('c')).dedup('a','b')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_matchXa_both_b__b_both_cX_dedupXa_bX_byXlabelX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
              g.V.match(
                     __.as('a').both.as('b'),
                     __.as('b').both.as('c')).dedup('a','b').by(label)
-            """, g)
+            """)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMaxTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMaxTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,17 +31,17 @@ public abstract class GroovyMaxTest {
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_age_max() {
-            TraversalScriptHelper.compute("g.V.age.max", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.max")
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_repeatXbothX_timesX5X_age_max() {
-            TraversalScriptHelper.compute("g.V.repeat(__.both).times(5).age.max", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.both).times(5).age.max")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Number>> get_g_V_hasLabelXsoftwareX_group_byXnameX_byXbothE_weight_maxX() {
-            TraversalScriptHelper.compute("g.V().hasLabel('software').group().by('name').by(bothE().weight.max)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().hasLabel('software').group().by('name').by(bothE().weight.max)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMeanTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMeanTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,12 +31,12 @@ public abstract class GroovyMeanTest {
 
         @Override
         public Traversal<Vertex, Double> get_g_V_age_mean() {
-            TraversalScriptHelper.compute("g.V.age.mean", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.mean")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Number>> get_g_V_hasLabelXsoftwareX_group_byXnameX_byXbothE_weight_meanX() {
-            TraversalScriptHelper.compute("g.V().hasLabel('software').group().by('name').by(bothE().weight.mean)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().hasLabel('software').group().by('name').by(bothE().weight.mean)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMinTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyMinTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,17 +31,17 @@ public abstract class GroovyMinTest {
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_age_min() {
-            TraversalScriptHelper.compute("g.V.age.min", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.min")
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_V_repeatXbothX_timesX5X_age_min() {
-            TraversalScriptHelper.compute("g.V.repeat(__.both).times(5).age.min", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.both).times(5).age.min")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Number>> get_g_V_hasLabelXsoftwareX_group_byXnameX_byXbothE_weight_minX() {
-            TraversalScriptHelper.compute("g.V().hasLabel('software').group().by('name').by(bothE().weight.min())", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().hasLabel('software').group().by('name').by(bothE().weight.min())")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,80 +31,80 @@ public abstract class GroovyOrderTest {
 
         @Override
         public Traversal<Vertex, String> get_g_V_name_order() {
-            TraversalScriptHelper.compute("g.V().name.order()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().name.order()")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_name_order_byXa1_b1X_byXb2_a2X() {
-            TraversalScriptHelper.compute("g.V.name.order.by { a, b -> a[1] <=> b[1] }.by { a, b -> b[2] <=> a[2] }", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.name.order.by { a, b -> a[1] <=> b[1] }.by { a, b -> b[2] <=> a[2] }")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_order_byXname_incrX_name() {
-            TraversalScriptHelper.compute("g.V.order.by('name', incr).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.order.by('name', incr).name")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_order_byXnameX_name() {
-            TraversalScriptHelper.compute("g.V.order.by('name', incr).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.order.by('name', incr).name")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_V_outE_order_byXweight_decrX_weight() {
-            TraversalScriptHelper.compute("g.V.outE.order.by('weight', Order.decr).weight", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.order.by('weight', Order.decr).weight")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_order_byXname_a1_b1X_byXname_b2_a2X_name() {
-            TraversalScriptHelper.compute("g.V.order.by('name', { a, b -> a[1].compareTo(b[1]) }).by('name', { a, b -> b[2].compareTo(a[2]) }).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.order.by('name', { a, b -> a[1].compareTo(b[1]) }).by('name', { a, b -> b[2].compareTo(a[2]) }).name")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_V_asXaX_outXcreatedX_asXbX_order_byXshuffleX_selectXa_bX() {
-            TraversalScriptHelper.compute("g.V.as('a').out('created').as('b').order.by(shuffle).select('a','b')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out('created').as('b').order.by(shuffle).select('a','b')")
         }
 
         @Override
         public Traversal<Vertex, Map<Integer, Integer>> get_g_VX1X_hasXlabel_personX_mapXmapXint_ageXX_orderXlocalX_byXvalues_decrX_byXkeys_incrX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("""g.V(v1Id).map {
+            new ScriptTraversal<>(g, "gremlin-groovy", """g.V(v1Id).map {
                 final Map map = [:];
                 map[1] = it.age;
                 map[2] = it.age * 2;
                 map[3] = it.age * 3;
                 map[4] = it.age;
                 return map;
-            }.order(local).by(values,decr).by(keys,incr)""", g, "v1Id", v1Id);
+            }.order(local).by(values,decr).by(keys,incr)""", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_order_byXoutE_count__decrX() {
-            TraversalScriptHelper.compute("g.V.order.by(__.outE.count, decr)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.order.by(__.outE.count, decr)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, List<Vertex>>> get_g_V_group_byXlabelX_byXnameX_byXorderXlocalX_byXdecrXX() {
-            TraversalScriptHelper.compute("g.V.group.by(label).by(values('name').order().by(decr).fold())", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group.by(label).by(values('name').order().by(decr).fold())")
         }
 
         @Override
         public Traversal<Vertex, List<Double>> get_g_V_localXbothE_weight_foldX_order_byXsumXlocalX_decrX() {
-            TraversalScriptHelper.compute("g.V.local(__.bothE.weight.fold).order.by(sum(local), decr)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.local(__.bothE.weight.fold).order.by(sum(local), decr)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXvX_mapXbothE_weight_foldX_sumXlocalX_asXsX_selectXv_sX_order_byXselectXsX_decrX() {
-            TraversalScriptHelper.compute("g.V.as('v').map(__.bothE.weight.fold).sum(local).as('s').select('v', 's').order.by(select('s'),decr)", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('v').map(__.bothE.weight.fold).sum(local).as('s').select('v', 's').order.by(select('s'),decr)")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasLabelXpersonX_order_byXageX() {
-            TraversalScriptHelper.compute("g.V.hasLabel('person').order.by('age')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').order.by('age')")
         }
 
         @Override
         public Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX() {
-            TraversalScriptHelper.compute("g.V.hasLabel('person').fold.order(local).by('age')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').fold.order(local).by('age')")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyOrderTest.groovy
@@ -106,5 +106,15 @@ public abstract class GroovyOrderTest {
         public Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').fold.order(local).by('age')")
         }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').order.by({it.age},decr).name")
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_properties_order_byXkey_decrX_key() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.properties().order.by(key, decr).key")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -35,6 +35,10 @@ public abstract class GroovyPageRankTest {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank")
         }
 
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.by(outE('knows')).by('friendRank').valueMap('name','friendRank')")
+        }
 
         @Override
         public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name() {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -20,6 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__
 import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -58,6 +59,11 @@ public abstract class GroovyPageRankTest {
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.by('pageRank').as('a').out('knows').values('pageRank').as('b').select('a', 'b')")
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().hasLabel('software').has('name', 'ripple').pageRank(1.0).by(inE('created')).times(1).by('priors').in('created').union(identity(),both()).valueMap('name', 'priors')")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -49,5 +49,10 @@ public abstract class GroovyPageRankTest {
         public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name_limitX2X() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name.limit(2)")
         }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').pageRank.by('pageRank').order.by('pageRank').valueMap('name', 'pageRank')")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -20,7 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,18 +32,18 @@ public abstract class GroovyPageRankTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_pageRank() {
-            TraversalScriptHelper.compute("g.V.pageRank", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank")
         }
 
 
         @Override
         public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name() {
-            TraversalScriptHelper.compute("g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name_limitX2X() {
-            TraversalScriptHelper.compute("g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name.limit(2)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.order.by(PageRankVertexProgram.PAGE_RANK, decr).name.limit(2)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPageRankTest.groovy
@@ -54,5 +54,10 @@ public abstract class GroovyPageRankTest {
         public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').pageRank.by('pageRank').order.by('pageRank').valueMap('name', 'pageRank')")
         }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.pageRank.by('pageRank').as('a').out('knows').values('pageRank').as('b').select('a', 'b')")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPathTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPathTest.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,27 +32,27 @@ public abstract class GroovyPathTest {
 
         @Override
         public Traversal<Vertex, Path> get_g_VX1X_name_path(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).name.path", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).name.path", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_VX1X_out_path_byXageX_byXnameX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.path.by('age').by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.path.by('age').by('name')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_repeatXoutX_timesX2X_path_by_byXnameX_byXlangX() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out).times(2).path.by.by('name').by('lang')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out).times(2).path.by.by('name').by('lang')")
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_out_out_path_byXnameX_byXageX() {
-            TraversalScriptHelper.compute("g.V.out.out.path.by('name').by('age')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.out.path.by('name').by('age')")
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_asXaX_hasXname_markoX_asXbX_hasXage_29X_asXcX_path() {
-            TraversalScriptHelper.compute("g.V.as('a').has('name', 'marko').as('b').has('age', 29).as('c').path", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').has('name', 'marko').as('b').has('age', 29).as('c').path")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPeerPressureTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPeerPressureTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
+import org.apache.tinkerpop.gremlin.structure.Vertex
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class GroovyPeerPressureTest {
+
+    public static class Traversals extends PeerPressureTest {
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_peerPressure() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.peerPressure")
+        }
+
+    }
+}

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPeerPressureTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPeerPressureTest.groovy
@@ -35,5 +35,9 @@ public abstract class GroovyPeerPressureTest {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.peerPressure")
         }
 
+        @Override
+        public Traversal<Vertex, Map<Object, Number>> get_g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.peerPressure.by('cluster').by(outE('knows')).pageRank(1.0).by('rank').by(outE('knows')).times(1).group.by('cluster').by(values('rank').sum).limit(100)")
+        }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPropertiesTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyPropertiesTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,17 +31,17 @@ public abstract class GroovyPropertiesTest {
 
         @Override
         public Traversal<Vertex, Object> get_g_V_hasXageX_propertiesXname_ageX_value() {
-            TraversalScriptHelper.compute("g.V.has('age').properties('name', 'age').value", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').properties('name', 'age').value")
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_V_hasXageX_propertiesXage_nameX_value() {
-            TraversalScriptHelper.compute("g.V.has('age').properties('age', 'name').value", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').properties('age', 'name').value")
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_V_hasXageX_properties_hasXid_nameIdX_value(final Object nameId) {
-            TraversalScriptHelper.compute("g.V.has('age').properties().has(T.id, nameId).value()", g, "nameId", nameId)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').properties().has(T.id, nameId).value()", "nameId", nameId)
         }
     }
 

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySelectTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Pop
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -34,129 +34,129 @@ public abstract class GroovySelectTest {
 
         @Override
         public Traversal<Vertex, Map<String, Vertex>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectXa_bX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('knows').as('b').select('a','b')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('knows').as('b').select('a','b')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_VX1X_asXaX_outXknowsX_asXbX_selectXa_bX_byXnameX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('knows').as('b').select('a','b').by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('knows').as('b').select('a','b').by('name')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_asXaX_outXknowsX_asXbX_selectXaX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('knows').as('b').select('a')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('knows').as('b').select('a')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_asXaX_outXknowsX_asXbX_selectXaX_byXnameX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('a').out('knows').as('b').select('a').by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('a').out('knows').as('b').select('a').by('name')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_asXbX_selectXa_bX_byXnameX() {
-            TraversalScriptHelper.compute("g.V.as('a').out.as('b').select('a','b').by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.as('b').select('a','b').by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_out_aggregateXxX_asXbX_selectXa_bX_byXnameX() {
-            TraversalScriptHelper.compute("g.V.as('a').out.aggregate('x').as('b').select('a','b').by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').out.aggregate('x').as('b').select('a','b').by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_asXaX_name_order_asXbX_selectXa_bX_byXnameX_by_XitX() {
-            TraversalScriptHelper.compute("g.V().as('a').name.order().as('b').select('a','b').by('name').by", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').name.order().as('b').select('a','b').by('name').by")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasXname_gremlinX_inEXusesX_order_byXskill_incrX_asXaX_outV_asXbX_selectXa_bX_byXskillX_byXnameX() {
-            TraversalScriptHelper.compute("g.V.has('name', 'gremlin').inE('uses').order.by('skill', Order.incr).as('a').outV.as('b').select('a','b').by('skill').by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name', 'gremlin').inE('uses').order.by('skill', Order.incr).as('a').outV.as('b').select('a','b').by('skill').by('name')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXname_isXmarkoXX_asXaX_selectXaX() {
-            TraversalScriptHelper.compute("g.V.has('name',__.is('marko')).as('a').select('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('name',__.is('marko')).as('a').select('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_label_groupCount_asXxX_selectXxX() {
-            TraversalScriptHelper.compute("g.V().label().groupCount().as('x').select('x')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().label().groupCount().as('x').select('x')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXpersonX_asXpX_mapXbothE_label_groupCountX_asXrX_selectXp_rX() {
-            TraversalScriptHelper.compute("g.V.hasLabel('person').as('p').map(__.bothE.label.groupCount()).as('r').select('p','r')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').as('p').map(__.bothE.label.groupCount()).as('r').select('p','r')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_chooseXoutE_count_isX0X__asXaX__asXbXX_chooseXselectXaX__selectXaX__selectXbXX() {
-            TraversalScriptHelper.compute("g.V.choose(__.outE().count().is(0L), __.as('a'), __.as('b')).choose(select('a'),select('a'),select('b'))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.choose(__.outE().count().is(0L), __.as('a'), __.as('b')).choose(select('a'),select('a'),select('b'))")
         }
 
         // below are original back()-tests
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_asXhereX_out_selectXhereX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).as('here').out.select('here')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).as('here').out.select('here')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectXhereX(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).out.as('here').has('lang', 'java').select('here')", g, "v4Id", v4Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).out.as('here').has('lang', 'java').select('here')", "v4Id", v4Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX4X_out_asXhereX_hasXlang_javaX_selectXhereX_name(
                 final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).out.as('here').has('lang', 'java').select('here').name", g, "v4Id", v4Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).out.as('here').has('lang', 'java').select('here').name", "v4Id", v4Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_outE_asXhereX_inV_hasXname_vadasX_selectXhereX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE.as('here').inV.has('name', 'vadas').select('here')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE.as('here').inV.has('name', 'vadas').select('here')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_outEXknowsX_hasXweight_1X_asXhereX_inV_hasXname_joshX_selectXhereX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE('knows').has('weight', 1.0d).as('here').inV.has('name', 'josh').select('here')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE('knows').has('weight', 1.0d).as('here').inV.has('name', 'josh').select('here')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_inV_hasXname_joshX_selectXhereX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE('knows').as('here').has('weight', 1.0d).inV.has('name', 'josh').select('here')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE('knows').as('here').has('weight', 1.0d).inV.has('name', 'josh').select('here')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_outEXknowsX_asXhereX_hasXweight_1X_asXfakeX_inV_hasXname_joshX_selectXhereX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE('knows').as('here').has('weight', 1.0d).as('fake').inV.has('name', 'josh').select('here')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE('knows').as('here').has('weight', 1.0d).as('fake').inV.has('name', 'josh').select('here')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_asXhereXout_name_selectXhereX() {
-            TraversalScriptHelper.compute("g.V().as('here').out.name.select('here')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('here').out.name.select('here')")
         }
 
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectXprojectXX_groupCount_byXnameX() {
-            TraversalScriptHelper.compute("""g.V.out('created')
+            new ScriptTraversal<>(g, "gremlin-groovy", """g.V.out('created')
                     .union(__.as('project').in('created').has('name', 'marko').select('project'),
-                    __.as('project').in('created').in('knows').has('name', 'marko').select('project')).groupCount().by('name')""", g)
+                    __.as('project').in('created').in('knows').has('name', 'marko').select('project')).groupCount().by('name')""")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_asXaX_hasXname_markoX_asXbX_asXcX_selectXa_b_cX_by_byXnameX_byXageX() {
-            TraversalScriptHelper.compute("g.V.as('a').has('name', 'marko').as('b').as('c').select('a','b','c').by().by('name').by('age')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a').has('name', 'marko').as('b').as('c').select('a','b','c').by().by('name').by('age')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_hasLabelXsoftwareX_asXnameX_asXlanguageX_asXcreatorsX_selectXname_language_creatorsX_byXnameX_byXlangX_byXinXcreatedX_name_fold_orderXlocalXX() {
-            TraversalScriptHelper.compute("""g.V.hasLabel('software').as('name').as('language').as('creators').select('name','language','creators').by('name').by('lang').
-                    by(__.in('created').values('name').fold().order(local))""", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", """g.V.hasLabel('software').as('name').as('language').as('creators').select('name','language','creators').by('name').by('lang').
+                    by(__.in('created').values('name').fold().order(local))""")
         }
 
         // TINKERPOP-619: select should not throw
@@ -164,74 +164,74 @@ public abstract class GroovySelectTest {
         @Override
         public Traversal<Vertex, Object> get_g_V_selectXaX(final Pop pop) {
             final String root = "g.V."
-            TraversalScriptHelper.compute(root + (null == pop ? "select('a')" : "select(${pop}, 'a')"), g)
+            new ScriptTraversal<>(g, "gremlin-groovy", root + (null == pop ? "select('a')" : "select(${pop}, 'a')"))
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_selectXa_bX(final Pop pop) {
             final String root = "g.V."
-            TraversalScriptHelper.compute(root + (null == pop ? "select('a', 'b')" : "select(${pop}, 'a', 'b')"), g)
+            new ScriptTraversal<>(g, "gremlin-groovy", root + (null == pop ? "select('a', 'b')" : "select(${pop}, 'a', 'b')"))
         }
 
         @Override
         public Traversal<Vertex, Object> get_g_V_valueMap_selectXpop_aX(final Pop pop) {
             final String root = "g.V.valueMap."
-            TraversalScriptHelper.compute(root + (null == pop ? "select('a')" : "select(${pop}, 'a')"), g)
+            new ScriptTraversal<>(g, "gremlin-groovy", root + (null == pop ? "select('a')" : "select(${pop}, 'a')"))
         }
 
         @Override
         public Traversal<Vertex, Map<String, Object>> get_g_V_valueMap_selectXpop_a_bX(final Pop pop) {
             final String root = "g.V.valueMap."
-            TraversalScriptHelper.compute(root + (null == pop ? "select('a', 'b')" : "select(${pop}, 'a', 'b')"), g)
+            new ScriptTraversal<>(g, "gremlin-groovy", root + (null == pop ? "select('a', 'b')" : "select(${pop}, 'a', 'b')"))
         }
 
         // when labels don't exist
 
         @Override
         public Traversal<Vertex, String> get_g_V_untilXout_outX_repeatXin_asXaXX_selectXaX_byXtailXlocalX_nameX() {
-            TraversalScriptHelper.compute("g.V.until(__.out.out).repeat(__.in.as('a')).select('a').by(tail(local).name)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.until(__.out.out).repeat(__.in.as('a')).select('a').by(tail(local).name)")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_untilXout_outX_repeatXin_asXaX_in_asXbXX_selectXa_bX_byXnameX() {
-            TraversalScriptHelper.compute("g.V.until(__.out.out).repeat(__.in.as('a').in.as('b')).select('a','b').by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.until(__.out.out).repeat(__.in.as('a').in.as('b')).select('a','b').by('name')")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_asXaX_whereXoutXknowsXX_selectXaX() {
-            TraversalScriptHelper.compute("g.V().as('a').where(out('knows')).select('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().as('a').where(out('knows')).select('a')")
         }
 
         // select column tests
 
         @Override
         public Traversal<Vertex, Long> get_g_V_outE_weight_groupCount_selectXvaluesX_unfold() {
-            TraversalScriptHelper.compute("g.V.outE.weight.groupCount.select(values).unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.weight.groupCount.select(values).unfold")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_outE_weight_groupCount_unfold_selectXvaluesX_unfold() {
-            TraversalScriptHelper.compute("g.V.outE.weight.groupCount.unfold.select(values).unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.weight.groupCount.unfold.select(values).unfold")
         }
 
         @Override
         public Traversal<Vertex, Long> get_g_V_outE_weight_groupCount_selectXvaluesX_unfold_groupCount_selectXvaluesX_unfold() {
-            TraversalScriptHelper.compute("g.V.outE.weight.groupCount.select(values).unfold.groupCount.select(values).unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.weight.groupCount.select(values).unfold.groupCount.select(values).unfold")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_V_outE_weight_groupCount_selectXkeysX_unfold() {
-            TraversalScriptHelper.compute("g.V.outE.weight.groupCount.select(keys).unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.weight.groupCount.select(keys).unfold")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_V_outE_weight_groupCount_unfold_selectXkeysX_unfold() {
-            TraversalScriptHelper.compute("g.V.outE.weight.groupCount.unfold.select(keys).unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.weight.groupCount.unfold.select(keys).unfold")
         }
 
         @Override
         public Traversal<Vertex, Collection<Set<String>>> get_g_V_asXa_bX_out_asXcX_path_selectXkeysX() {
-            TraversalScriptHelper.compute("g.V.as('a','b').out.as('c').path.select(keys)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.as('a','b').out.as('c').path.select(keys)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySumTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovySumTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,12 +31,12 @@ public abstract class GroovySumTest {
 
         @Override
         public Traversal<Vertex, Double> get_g_V_valuesXageX_sum() {
-            TraversalScriptHelper.compute("g.V.age.sum", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.age.sum")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Number>> get_g_V_hasLabelXsoftwareX_group_byXnameX_byXbothE_weight_sumX() {
-            TraversalScriptHelper.compute("g.V().hasLabel('software').group().by('name').by(bothE().weight.sum)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().hasLabel('software').group().by('name').by(bothE().weight.sum)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyUnfoldTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyUnfoldTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -32,17 +32,17 @@ public abstract class GroovyUnfoldTest {
 
         @Override
         public Traversal<Vertex, Edge> get_g_V_localXoutE_foldX_unfold() {
-            TraversalScriptHelper.compute("g.V.local(__.outE.fold).unfold", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.local(__.outE.fold).unfold")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_valueMap_unfold_mapXkeyX() {
-            TraversalScriptHelper.compute("g.V.valueMap.unfold.map { it.key }", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap.unfold.map { it.key }")
         }
 
         @Override
         Traversal<Vertex, String> get_g_VX1X_repeatXboth_simplePathX_untilXhasIdX6XX_path_byXnameX_unfold(Object v1Id, Object v6Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).repeat(__.both.simplePath).until(hasId(v6Id)).path.by('name').unfold", g, "v1Id", v1Id, "v6Id", v6Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).repeat(__.both.simplePath).until(hasId(v6Id)).path.by('name').unfold", "v1Id", v1Id, "v6Id", v6Id)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyValueMapTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyValueMapTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -30,17 +30,17 @@ public abstract class GroovyValueMapTest {
     public static class Traversals extends ValueMapTest {
         @Override
         public Traversal<Vertex, Map<String, List>> get_g_V_valueMap() {
-            TraversalScriptHelper.compute("g.V.valueMap", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap");
         }
 
         @Override
         public Traversal<Vertex, Map<String, List>> get_g_V_valueMapXname_ageX() {
-            TraversalScriptHelper.compute("g.V.valueMap('name', 'age')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.valueMap('name', 'age')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, List<String>>> get_g_VX1X_outXcreatedX_valueMap(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('created').valueMap", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('created').valueMap", "v1Id", v1Id)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyVertexTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyVertexTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.map
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -32,142 +32,142 @@ public abstract class GroovyVertexTest {
 
         @Override
         public Traversal<Vertex, String> get_g_VXlistXv1_v2_v3XX_name() {
-            TraversalScriptHelper.compute("g.V(ids).name", g, "ids", [convertToVertex(graph, "marko"), convertToVertex(graph, "vadas"), convertToVertex(graph, "lop")])
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(ids).name", "ids", [convertToVertex(graph, "marko"), convertToVertex(graph, "vadas"), convertToVertex(graph, "lop")])
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VXlistX1_2_3XX_name() {
-            TraversalScriptHelper.compute("g.V(ids).name", g, "ids", [convertToVertexId(graph, "marko"), convertToVertexId(graph, "vadas"), convertToVertexId(graph, "lop")])
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(ids).name", "ids", [convertToVertexId(graph, "marko"), convertToVertexId(graph, "vadas"), convertToVertexId(graph, "lop")])
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V() {
-            TraversalScriptHelper.compute("g.V", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX2X_in(final Object v2Id) {
-            TraversalScriptHelper.compute("g.V(v2Id).in", g, "v2Id", v2Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v2Id).in", "v2Id", v2Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX4X_both(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).both", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).both", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_E() {
-            TraversalScriptHelper.compute("g.E", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E")
         }
 
         @Override
         public Traversal<Edge, Edge> get_g_EX11X(final Object e11Id) {
-            TraversalScriptHelper.compute("g.E(e11Id)", g, "e11Id", e11Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.E(e11Id)", "e11Id", e11Id)
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX1X_outE(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX2X_inE(final Object v2Id) {
-            TraversalScriptHelper.compute("g.V(v2Id).inE", g, "v2Id", v2Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v2Id).inE", "v2Id", v2Id);
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX4X_bothE(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).bothE", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).bothE", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Vertex, Edge> get_g_VX4X_bothEXcreatedX(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).bothE('created')", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).bothE('created')", "v4Id", v4Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outE_inV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE.inV", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE.inV", "v1Id", v1Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX2X_inE_outV(final Object v2Id) {
-            TraversalScriptHelper.compute("g.V(v2Id).inE.outV", g, "v2Id", v2Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v2Id).inE.outV", "v2Id", v2Id);
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_outE_hasXweight_1X_outV() {
-            TraversalScriptHelper.compute("g.V.outE.has('weight', 1.0d).outV", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.outE.has('weight', 1.0d).outV")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_out_outE_inV_inE_inV_both_name() {
-            TraversalScriptHelper.compute("g.V.out.outE.inV.inE.inV.both.name", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.outE.inV.inE.inV.both.name")
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_outEXknowsX_bothV_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE('knows').bothV.name", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE('knows').bothV.name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXknowsX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('knows')", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('knows')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outXknows_createdX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out('knows', 'created')", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out('knows', 'created')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outEXknowsX_inV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE('knows').inV()", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE('knows').inV()", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outEXknows_createdX_inV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE('knows', 'created').inV", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE('knows', 'created').inV", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_out_out() {
-            TraversalScriptHelper.compute("g.V.out().out()", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out().out()")
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_out_out_out(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.out.out", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.out.out", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_out_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.name", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.name", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_outE_otherV(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).outE.otherV", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).outE.otherV", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX4X_bothE_otherV(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).bothE.otherV", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).bothE.otherV", "v4Id", v4Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX4X_bothE_hasXweight_lt_1X_otherV(final Object v4Id) {
-            TraversalScriptHelper.compute("g.V(v4Id).bothE.has('weight', lt(1.0d)).otherV", g, "v4Id", v4Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v4Id).bothE.has('weight', lt(1.0d)).otherV", "v4Id", v4Id)
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_VX1X_to_XOUT_knowsX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).to(Direction.OUT, 'knows')", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).to(Direction.OUT, 'knows')", "v1Id", v1Id)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyAggregateTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyAggregateTest.groovy
@@ -18,9 +18,9 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,17 +32,17 @@ public abstract class GroovyAggregateTest {
 
         @Override
         public Traversal<Vertex, List<String>> get_g_V_name_aggregateXxX_capXxX() {
-            TraversalScriptHelper.compute("g.V.name.aggregate('x').cap('x')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.name.aggregate('x').cap('x')")
         }
 
         @Override
         public Traversal<Vertex, List<String>> get_g_V_aggregateXxX_byXnameX_capXxX() {
-            TraversalScriptHelper.compute("g.V.aggregate('x').by('name').cap('x')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.aggregate('x').by('name').cap('x')")
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_V_out_aggregateXaX_path() {
-            TraversalScriptHelper.compute("g.V.out.aggregate('a').path", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.aggregate('a').path")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyExplainTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyExplainTest.groovy
@@ -29,7 +29,7 @@ public abstract class GroovyExplainTest {
     public static class Traversals extends ExplainTest {
 
         public TraversalExplanation get_g_V_outE_identity_inV_explain() {
-            g.V().outE().identity().inV().explain();
+            g.V().outE().identity().inV().explain()
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyGroupCountTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyGroupCountTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,56 +31,56 @@ public abstract class GroovyGroupCountTest {
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_outXcreatedX_groupCount_byXnameX() {
-            TraversalScriptHelper.compute("g.V.out('created').groupCount.by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('created').groupCount.by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_outXcreatedX_groupCountXaX_byXnameX_capXaX() {
-            TraversalScriptHelper.compute("g.V.out('created').groupCount('a').by('name').cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('created').groupCount('a').by('name').cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_outXcreatedX_name_groupCount() {
-            TraversalScriptHelper.compute("g.V.out('created').name.groupCount", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('created').name.groupCount")
         }
 
         @Override
         public Traversal<Vertex, Map<Vertex, Long>> get_g_V_outXcreatedX_groupCountXxX_capXxX() {
-            TraversalScriptHelper.compute("g.V.out('created').groupCount('x').cap('x')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('created').groupCount('x').cap('x')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_outXcreatedX_name_groupCountXaX_capXaX() {
-            TraversalScriptHelper.compute("g.V.out('created').name.groupCount('a').cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out('created').name.groupCount('a').cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<Object, Long>> get_g_V_hasXnoX_groupCount() {
-            TraversalScriptHelper.compute("g.V.has('no').groupCount", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('no').groupCount")
         }
 
         @Override
         public Traversal<Vertex, Map<Object, Long>> get_g_V_hasXnoX_groupCountXaX_capXaX() {
-            TraversalScriptHelper.compute("g.V.has('no').groupCount('a').cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('no').groupCount('a').cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXout_groupCountXaX_byXnameXX_timesX2X_capXaX() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out.groupCount('a').by('name')).times(2).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out.groupCount('a').by('name')).times(2).cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_unionXrepeatXoutX_timesX2X_groupCountXmX_byXlangXX__repeatXinX_timesX2X_groupCountXmX_byXnameXX_capXmX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
             g.V.union(
                     __.repeat(__.out).times(2).groupCount('m').by('lang'),
                     __.repeat(__.in).times(2).groupCount('m').by('name')).cap('m')
-            """, g)
+            """)
         }
 
         @Override
         public Traversal<Vertex, Map<Long, Long>> get_g_V_groupCount_byXbothE_countX() {
-            TraversalScriptHelper.compute("g.V.groupCount.by(bothE().count)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.groupCount.by(bothE().count)")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyGroupTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyGroupTest.groovy
@@ -19,10 +19,8 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
-
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.constant
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -33,62 +31,62 @@ public abstract class GroovyGroupTest {
 
         @Override
         public Traversal<Vertex, Map<String, Collection<Vertex>>> get_g_V_group_byXnameX() {
-            TraversalScriptHelper.compute("g.V.group.by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group.by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Collection<Vertex>>> get_g_V_group_byXnameX_by() {
-            TraversalScriptHelper.compute("g.V.group.by('name').by", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group.by('name').by")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Collection<Vertex>>> get_g_V_groupXaX_byXnameX_capXaX() {
-            TraversalScriptHelper.compute("g.V.group('a').by('name').cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group('a').by('name').cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Collection<String>>> get_g_V_hasXlangX_groupXaX_byXlangX_byXnameX_out_capXaX() {
-            TraversalScriptHelper.compute("g.V.has('lang').group('a').by('lang').by('name').out.cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('lang').group('a').by('lang').by('name').out.cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_hasXlangX_group_byXlangX_byXcountX() {
-            TraversalScriptHelper.compute("g.V.has('lang').group.by('lang').by(count())", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('lang').group.by('lang').by(count())")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXout_groupXaX_byXnameX_byXcountX_timesX2X_capXaX() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out.group('a').by('name').by(count())).times(2).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out.group('a').by('name').by(count())).times(2).cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<Long, Collection<String>>> get_g_V_group_byXoutE_countX_byXnameX() {
-            TraversalScriptHelper.compute("g.V.group.by(__.outE.count).by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group.by(__.outE.count).by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Number>> get_g_V_groupXaX_byXlabelX_byXoutE_weight_sumX_capXaX() {
-            TraversalScriptHelper.compute("g.V.group('a').by(label).by(outE().weight.sum).cap('a')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group('a').by(label).by(outE().weight.sum).cap('a')");
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothXfollowedByXX_timesX2X_group_byXsongTypeX_byXcountX() {
-            TraversalScriptHelper.compute("g.V.repeat(both('followedBy')).times(2).group.by('songType').by(count())", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both('followedBy')).times(2).group.by('songType').by(count())")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothXfollowedByXX_timesX2X_groupXaX_byXsongTypeX_byXcountX_capXaX() {
-            TraversalScriptHelper.compute("g.V.repeat(both('followedBy')).times(2).group('a').by('songType').by(count()).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both('followedBy')).times(2).group('a').by('songType').by(count()).cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_group_byXname_substring_1X_byXconstantX1XX() {
-            TraversalScriptHelper.compute("g.V.group.by{it.name[0]}.by(constant(1l))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group.by{it.name[0]}.by(constant(1l))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_groupXaX_byXname_substring_1X_byXconstantX1XX_capXaX() {
-            TraversalScriptHelper.compute("g.V.group('a').by{it.name[0]}.by(constant(1l)).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.group('a').by{it.name[0]}.by(constant(1l)).cap('a')")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyGroupTestV3d0.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyGroupTestV3d0.groovy
@@ -20,7 +20,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -33,42 +33,42 @@ public abstract class GroovyGroupTestV3d0 {
 
         @Override
         public Traversal<Vertex, Map<String, Collection<Vertex>>> get_g_V_group_byXnameX() {
-            TraversalScriptHelper.compute("g.V.groupV3d0.by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.groupV3d0.by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Collection<Vertex>>> get_g_V_groupXaX_byXnameX_capXaX() {
-            TraversalScriptHelper.compute("g.V.groupV3d0('a').by('name').cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.groupV3d0('a').by('name').cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Collection<String>>> get_g_V_hasXlangX_groupXaX_byXlangX_byXnameX_out_capXaX() {
-            TraversalScriptHelper.compute("g.V.has('lang').groupV3d0('a').by('lang').by('name').out.cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('lang').groupV3d0('a').by('lang').by('name').out.cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_hasXlangX_group_byXlangX_byX1X_byXcountXlocalXX() {
-            TraversalScriptHelper.compute("g.V.has('lang').groupV3d0.by('lang').by(__.inject(1)).by(__.count(Scope.local))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('lang').groupV3d0.by('lang').by(__.inject(1)).by(__.count(Scope.local))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXout_groupXaX_byXnameX_by_byXcountXlocalXX_timesX2X_capXaX() {
-            TraversalScriptHelper.compute("g.V.repeat(__.out.groupV3d0('a').by('name').by.by(__.count(Scope.local))).times(2).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.out.groupV3d0('a').by('name').by.by(__.count(Scope.local))).times(2).cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<Long, Collection<String>>> get_g_V_group_byXoutE_countX_byXnameX() {
-            TraversalScriptHelper.compute("g.V.groupV3d0.by(__.outE.count).by('name')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.groupV3d0.by(__.outE.count).by('name')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothXfollowedByXX_timesX2X_group_byXsongTypeX_byX1X_byXcountXlocalXX() {
-            TraversalScriptHelper.compute("g.V.repeat(both('followedBy')).times(2).groupV3d0.by('songType').by(inject(1)).by(count(local))", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both('followedBy')).times(2).groupV3d0.by('songType').by(inject(1)).by(count(local))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_repeatXbothXfollowedByXX_timesX2X_groupXaX_byXsongTypeX_byX1X_byXcountXlocalXX_capXaX() {
-            TraversalScriptHelper.compute("g.V.repeat(both('followedBy')).times(2).groupV3d0('a').by('songType').by(inject(1)).by(count(local)).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(both('followedBy')).times(2).groupV3d0('a').by('songType').by(inject(1)).by(count(local)).cap('a')")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyInjectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyInjectTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,12 +31,12 @@ public abstract class GroovyInjectTest {
     public static class Traversals extends InjectTest {
         @Override
         public Traversal<Vertex, String> get_g_VX1X_out_injectXv2X_name(final Object v1Id, final Object v2Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.inject(g.V(v2Id).next()).name", g, "v1Id", v1Id, "v2Id", v2Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.inject(g.V(v2Id).next()).name", "v1Id", v1Id, "v2Id", v2Id);
         }
 
         @Override
         public Traversal<Vertex, Path> get_g_VX1X_out_name_injectXdanielX_asXaX_mapXlengthX_path(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out().name.inject('daniel').as('a').map { it.length() }.path", g, "v1Id", v1Id);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out().name.inject('daniel').as('a').map { it.length() }.path", "v1Id", v1Id);
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyProfileTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyProfileTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,27 +31,27 @@ public abstract class GroovyProfileTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_out_out_profile() {
-            g.V.out.out.profile() // locked traversals
+            g.V.out.out.profile() // locked traversal
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_repeatXbothX_timesX3X_profile() {
-            TraversalScriptHelper.compute("g.V.repeat(__.both()).times(3).profile()", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.repeat(__.both()).times(3).profile()");
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_whereXinXcreatedX_count_isX1XX_valuesXnameX_profile() {
-            TraversalScriptHelper.compute("g.V().where(__.in('created').count().is(1l)).values('name').profile()", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().where(__.in('created').count().is(1l)).values('name').profile()");
         }
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_sideEffectXThread_sleepX10XX_sideEffectXThread_sleepX5XX_profile() {
-            TraversalScriptHelper.compute("g.V().sideEffect{Thread.sleep(10)}.sideEffect{Thread.sleep(5)}.profile()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().sideEffect{Thread.sleep(10)}.sideEffect{Thread.sleep(5)}.profile()")
         }
 
         @Override
         public Traversal<Vertex, Map<String, String>> get_g_V_matchXa_created_b__b_in_count_isXeqX1XXX_selectXa_bX_byXnameX_profile() {
-            TraversalScriptHelper.compute("g.V.match(__.as('a').out('created').as('b'), __.as('b').in.count.is(eq(1))).select('a', 'b').by('name').profile", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.match(__.as('a').out('created').as('b'), __.as('b').in.count.is(eq(1))).select('a', 'b').by('name').profile")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySackTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySackTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,48 +31,48 @@ public abstract class GroovySackTest {
 
         @Override
         public Traversal<Vertex, String> get_g_withSackXhellowX_V_outE_sackXassignX_byXlabelX_inV_sack() {
-            TraversalScriptHelper.compute("g.withSack('hello').V.outE.sack(assign).by(label).inV.sack", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack('hello').V.outE.sack(assign).by(label).inV.sack")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_withSackX0X_V_outE_sackXsumX_byXweightX_inV_sack_sum() {
-            TraversalScriptHelper.compute("g.withSack(0.0f).V.outE.sack(sum).by('weight').inV.sack.sum()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack(0.0f).V.outE.sack(sum).by('weight').inV.sack.sum()")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_withSackX0X_V_repeatXoutE_sackXsumX_byXweightX_inVX_timesX2X_sack() {
-            TraversalScriptHelper.compute("g.withSack(0.0f).V.repeat(__.outE.sack(sum).by('weight').inV).times(2).sack()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack(0.0f).V.repeat(__.outE.sack(sum).by('weight').inV).times(2).sack()")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_withSackX0X_V_outE_sackXsum_weightX_inV_sack_sum() {
-            TraversalScriptHelper.compute("g.withSack(0.0f).V().outE.sack(sum, 'weight').inV.sack.sum()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack(0.0f).V().outE.sack(sum, 'weight').inV.sack.sum()")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_withSackX0X_V_repeatXoutE_sackXsum_weightX_inVX_timesX2X_sack() {
-            TraversalScriptHelper.compute("g.withSack(0.0f).V.repeat(__.outE.sack(sum, 'weight').inV).times(2).sack", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack(0.0f).V.repeat(__.outE.sack(sum, 'weight').inV).times(2).sack")
         }
 
         @Override
         public Traversal<Vertex, Map> get_g_withSackXmap__map_cloneX_V_out_out_sackXmap_a_nameX_sack() {
-            TraversalScriptHelper.compute("g.withSack{[:]}{ it.clone() }.V.out().out().sack { m, v -> m['a'] = v.name; m }.sack()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack{[:]}{ it.clone() }.V.out().out().sack { m, v -> m['a'] = v.name; m }.sack()")
         }
 
         @Override
         public Traversal<Vertex, Double> get_g_withSackX1_sumX_VX1X_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.withSack(1.0d,sum).V(${v1Id}).local(out('knows').barrier(normSack)).in('knows').barrier.sack", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack(1.0d,sum).V(${v1Id}).local(out('knows').barrier(normSack)).in('knows').barrier.sack", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Integer> get_g_withBulkXfalseX_withSackX1_sumX_V_out_barrier_sack() {
-            TraversalScriptHelper.compute("g.withBulk(false).withSack(1, sum).V.out.barrier.sack", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withBulk(false).withSack(1, sum).V.out.barrier.sack")
         }
 
         @Override
         Traversal<Vertex, BigDecimal> get_g_withSackXBigInteger_TEN_powX1000X_assignX_V_localXoutXknowsX_barrierXnormSackXX_inXknowsX_barrier_sack() {
-            TraversalScriptHelper.compute("g.withSack(BigInteger.TEN.pow(1000), assign).V.local(out('knows').barrier(normSack)).in('knows').barrier.sack", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSack(BigInteger.TEN.pow(1000), assign).V.local(out('knows').barrier(normSack)).in('knows').barrier.sack")
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySideEffectCapTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySideEffectCapTest.groovy
@@ -19,7 +19,7 @@
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -30,16 +30,16 @@ public abstract class GroovySideEffectCapTest {
     public static class Traversals extends SideEffectCapTest {
         @Override
         public Traversal<Vertex, Map<String, Long>> get_g_V_hasXageX_groupCountXaX_byXnameX_out_capXaX() {
-            TraversalScriptHelper.compute("g.V.has('age').groupCount('a').by('name').out.cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('age').groupCount('a').by('name').out.cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Map<String, Map<Object, Long>>> get_g_V_chooseXlabel_person__age_groupCountXaX__name_groupCountXbXX_capXa_bX() {
-            TraversalScriptHelper.compute("""
+            new ScriptTraversal<>(g, "gremlin-groovy", """
             g.V.choose(__.has(T.label, 'person'),
                     __.age.groupCount('a'),
                     __.values("name").groupCount('b')).cap('a', 'b')
-            """, g)
+            """)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySideEffectTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySideEffectTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,24 +31,24 @@ public abstract class GroovySideEffectTest {
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_sideEffectXstore_aX_name(final Object v1Id) {
-            TraversalScriptHelper.compute("""g.withSideEffect('a') { [] }.V(v1Id).sideEffect {
+            new ScriptTraversal<>(g, "gremlin-groovy", """g.withSideEffect('a') { [] }.V(v1Id).sideEffect {
                 it.sideEffects('a').clear();
                 it.sideEffects('a').add(it.get());
-            }.name""", g, "v1Id", v1Id)
+            }.name""", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_out_sideEffectXincr_cX_name(final Object v1Id) {
-            TraversalScriptHelper.compute("""g.withSideEffect('c') { [0] }.V(v1Id).out.sideEffect {
+            new ScriptTraversal<>(g, "gremlin-groovy", """g.withSideEffect('c') { [0] }.V(v1Id).out.sideEffect {
                 temp = it.sideEffects('c')[0];
                 it.sideEffects('c').clear();
                 it.sideEffects('c').add(temp + 1);
-            }.name""", g, "v1Id", v1Id)
+            }.name""", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_out_sideEffectXX_name(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out().sideEffect {}.name", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out().sideEffect {}.name", "v1Id", v1Id)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyStoreTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyStoreTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -31,23 +31,23 @@ public abstract class GroovyStoreTest {
 
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXnameX_out_capXaX() {
-            TraversalScriptHelper.compute("g.V().store('a').by('name').out().cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V().store('a').by('name').out().cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Collection> get_g_VX1X_storeXaX_byXnameX_out_storeXaX_byXnameX_name_capXaX(
                 final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).store('a').by('name').out().store('a').by('name').name.cap('a')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).store('a').by('name').out().store('a').by('name').name.cap('a')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Set<String>> get_g_V_withSideEffectXa_setX_both_name_storeXaX_capXaX() {
-            TraversalScriptHelper.compute("g.withSideEffect('a'){[] as Set}.V.both.name.store('a').cap('a')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('a'){[] as Set}.V.both.name.store('a').cap('a')");
         }
 
         @Override
         public Traversal<Vertex, Collection> get_g_V_storeXaX_byXoutEXcreatedX_countX_out_out_storeXaX_byXinEXcreatedX_weight_sumX_capXaX() {
-            TraversalScriptHelper.compute("g.V.store('a').by(__.outE('created').count).out.out.store('a').by(__.inE('created').weight.sum).cap('a')", g);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.store('a').by(__.outE('created').count).out.out.store('a').by(__.inE('created').weight.sum).cap('a')");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySubgraphTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySubgraphTest.groovy
@@ -18,8 +18,8 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Graph
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
@@ -33,13 +33,13 @@ public abstract class GroovySubgraphTest {
         @Override
         public Traversal<Vertex, Graph> get_g_V_withSideEffectXsgX_outEXknowsX_subgraphXsgX_name_capXsgX(
                 final Object v1Id, final Graph subgraph) {
-            TraversalScriptHelper.compute("g.withSideEffect('sg') { subgraph }.V(v1Id).outE('knows').subgraph('sg').name.cap('sg')", g, "v1Id", v1Id, "subgraph", subgraph)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('sg') { subgraph }.V(v1Id).outE('knows').subgraph('sg').name.cap('sg')", "v1Id", v1Id, "subgraph", subgraph)
         }
 
         @Override
         public Traversal<Vertex, String> get_g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup(
                 final Graph subgraph) {
-            TraversalScriptHelper.compute("g.withSideEffect('sg') { subgraph }.V.repeat(__.bothE('created').subgraph('sg').outV).times(5).name.dedup", g, "subgraph", subgraph)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.withSideEffect('sg') { subgraph }.V.repeat(__.bothE('created').subgraph('sg').outV).times(5).name.dedup", "subgraph", subgraph)
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyTreeTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovyTreeTest.groovy
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalScriptHelper
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
 import org.apache.tinkerpop.gremlin.structure.Vertex
 
 /**
@@ -32,37 +32,37 @@ public abstract class GroovyTreeTest {
 
         @Override
         public Traversal<Vertex, Tree> get_g_V_out_out_tree_byXidX() {
-            TraversalScriptHelper.compute("g.V.out.out.tree.by(id)", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.out.tree.by(id)")
         }
 
         @Override
         public Traversal<Vertex, Tree> get_g_V_out_out_treeXaX_byXidX_capXaX() {
-            TraversalScriptHelper.compute("g.V.out.out.tree('a').by(id).cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.out.tree('a').by(id).cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Tree> get_g_V_out_out_tree() {
-            TraversalScriptHelper.compute("g.V.out.out.tree()", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.out.tree()")
         }
 
         @Override
         public Traversal<Vertex, Tree> get_g_V_out_out_treeXaX_capXaX() {
-            TraversalScriptHelper.compute("g.V.out.out.tree('a').cap('a')", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.out.tree('a').cap('a')")
         }
 
         @Override
         public Traversal<Vertex, Tree> get_g_VX1X_out_out_treeXaX_byXnameX_both_both_capXaX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.out.tree('a').by('name').both.both.cap('a')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.out.tree('a').by('name').both.both.cap('a')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Tree> get_g_VX1X_out_out_tree_byXnameX(final Object v1Id) {
-            TraversalScriptHelper.compute("g.V(v1Id).out.out.tree.by('name')", g, "v1Id", v1Id)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id).out.out.tree.by('name')", "v1Id", v1Id)
         }
 
         @Override
         public Traversal<Vertex, Tree> get_g_V_out_out_out_tree() {
-            TraversalScriptHelper.compute("g.V.out.out.out.tree", g)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.out.out.out.tree")
         }
 
     }

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -59,6 +59,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyMinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyOrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPageRankTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPathTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPeerPressureTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPropertiesTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySumTest;
@@ -143,6 +144,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
             GroovyOrderTest.Traversals.class,
             GroovyPageRankTest.Traversals.class,
             GroovyPathTest.Traversals.class,
+            GroovyPeerPressureTest.Traversals.class,
             GroovyPropertiesTest.Traversals.class,
             GroovySelectTest.Traversals.class,
             GroovySumTest.Traversals.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
@@ -62,6 +62,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.MinTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumTest;
@@ -152,6 +153,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             OrderTest.Traversals.class,
             PageRankTest.Traversals.class,
             PathTest.Traversals.class,
+            PeerPressureTest.Traversals.class,
             PropertiesTest.Traversals.class,
             SelectTest.Traversals.class,
             UnfoldTest.Traversals.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -1859,9 +1859,8 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
         assertEquals(6, graph2.traversal().V().values(PageRankVertexProgram.PAGE_RANK).count().next().intValue());
         assertEquals(6, graph2.traversal().V().values(PageRankVertexProgram.EDGE_COUNT).count().next().intValue());
         //
-        // TODO: Need to solve the chicken and the egg problem with how TraversalVertexPrograms and strategies play on each other.
         final ComputerResult result3 = graph2.compute(graphProvider.getGraphComputer(graph2).getClass())
-                .program(TraversalVertexProgram.build().traversal(__.V().groupCount("m").by(__.values(PageRankVertexProgram.PAGE_RANK).count()).label().asAdmin()).create(graph2)).persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW).submit().get();
+                .program(TraversalVertexProgram.build().traversal(g.V().groupCount("m").by(__.values(PageRankVertexProgram.PAGE_RANK).count()).label().asAdmin()).create(graph2)).persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW).submit().get();
         final Graph graph3 = result3.graph();
         final Memory memory3 = result3.memory();
         assertTrue(memory3.keys().contains("m"));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GraphTest.java
@@ -52,6 +52,8 @@ public abstract class GraphTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Edge> get_g_V_hasLabelXpersonX_asXpX_VXsoftwareX_addInEXuses_pX();
 
+    public abstract Traversal<Vertex, String> get_g_V_outXknowsX_V_name();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_VX1X_V_valuesXnameX() {
@@ -87,11 +89,24 @@ public abstract class GraphTest extends AbstractGremlinProcessTest {
         assertEquals(8, counter);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_outXknowsX_V_name() {
+        final Traversal<Vertex, String> traversal = get_g_V_outXknowsX_V_name();
+        printTraversalForm(traversal);
+        checkResults(Arrays.asList("marko", "marko", "josh", "josh", "vadas", "vadas", "peter", "peter", "lop", "lop", "ripple", "ripple"), traversal);
+    }
+
     public static class Traversals extends GraphTest {
 
         @Override
         public Traversal<Vertex, String> get_g_VX1X_V_valuesXnameX(final Object v1Id) {
             return g.V(v1Id).V().values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_outXknowsX_V_name() {
+            return g.V().out("knows").V().values("name");
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/OrderTest.java
@@ -82,6 +82,10 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX();
 
+    public abstract Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name();
+
+    public abstract Traversal<Vertex, String> get_g_V_properties_order_byXkey_decrX_key();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_name_order() {
@@ -319,6 +323,39 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         assertEquals(convertToVertex(graph, "peter"), list.get(3));
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name() {
+        final Traversal<Vertex, String> traversal = get_g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name();
+        printTraversalForm(traversal);
+        assertEquals("peter", traversal.next());
+        assertEquals("josh", traversal.next());
+        assertEquals("marko", traversal.next());
+        assertEquals("vadas", traversal.next());
+        assertFalse(traversal.hasNext());
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_properties_order_byXkey_decrX_key() {
+        final Traversal<Vertex, String> traversal = get_g_V_properties_order_byXkey_decrX_key();
+        printTraversalForm(traversal);
+        assertEquals("name", traversal.next());
+        assertEquals("name", traversal.next());
+        assertEquals("name", traversal.next());
+        assertEquals("name", traversal.next());
+        assertEquals("name", traversal.next());
+        assertEquals("name", traversal.next());
+        assertEquals("lang", traversal.next());
+        assertEquals("lang", traversal.next());
+        assertEquals("age", traversal.next());
+        assertEquals("age", traversal.next());
+        assertEquals("age", traversal.next());
+        assertEquals("age", traversal.next());
+        assertFalse(traversal.hasNext());
+    }
+
+
     public static class Traversals extends OrderTest {
 
         @Override
@@ -398,6 +435,16 @@ public abstract class OrderTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, List<Vertex>> get_g_V_hasLabelXpersonX_fold_orderXlocalX_byXageX() {
             return g.V().hasLabel("person").fold().order(Scope.local).by("age");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_hasLabelXpersonX_order_byXvalueXageX__decrX_name() {
+            return g.V().hasLabel("person").order().<Vertex>by(v -> v.value("age"), Order.decr).values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, String> get_g_V_properties_order_byXkey_decrX_key() {
+            return g.V().properties().order().by(T.key, Order.decr).key();
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -25,11 +25,13 @@ import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.junit.Assert.assertEquals;
@@ -46,6 +48,8 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name();
 
     public abstract Traversal<Vertex, String> get_g_V_pageRank_order_byXpageRank_decrX_name_limitX2X();
+
+    public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX();
 
     @Test
     @LoadGraphWith(MODERN)
@@ -78,6 +82,29 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    public void g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX() {
+        final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            final Map<String, List<Object>> map = traversal.next();
+            assertEquals(2, map.size());
+            assertEquals(1, map.get("name").size());
+            assertEquals(1, map.get("friendRank").size());
+            String name = (String) map.get("name").get(0);
+            Double friendRank = (Double) map.get("friendRank").get(0);
+            if (name.equals("lop") || name.equals("ripple") || name.equals("peter") || name.equals("marko"))
+                assertEquals(0.15, friendRank, 0.01);
+            else
+                assertEquals(0.21375, friendRank, 0.01);
+
+            counter++;
+        }
+        assertEquals(6, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
     public void g_V_pageRank_order_byXpageRank_decrX_name_limitX2X() {
         final Traversal<Vertex, String> traversal = get_g_V_pageRank_order_byXpageRank_decrX_name_limitX2X();
         printTraversalForm(traversal);
@@ -92,6 +119,11 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_pageRank() {
             return g.V().pageRank();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_pageRank_byXoutEXknowsXX_byXfriendRankX_valueMapXname_friendRankX() {
+            return g.V().pageRank().by(__.outE("knows")).by("friendRank").valueMap("name", "friendRank");
         }
 
         @Override

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -27,7 +27,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -165,7 +164,6 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
-    @Ignore
     public void g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX() {
         final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX();
         printTraversalForm(traversal);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -54,6 +54,8 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX();
 
+    public abstract Traversal<Vertex, Map<String, Object>> get_g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX();
+
     @Test
     @LoadGraphWith(MODERN)
     public void g_V_pageRank() {
@@ -139,6 +141,24 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
         assertEquals(4, counter);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX() {
+        final Traversal<Vertex, Map<String, Object>> traversal = get_g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            final Map<String, Object> map = traversal.next();
+            assertEquals(2, map.size());
+            Vertex vertex = (Vertex) map.get("a");
+            double pageRank = (Double) map.get("b");
+            assertEquals(convertToVertexId("marko"), vertex.id());
+            assertTrue(pageRank > 0.15d);
+            counter++;
+        }
+        assertEquals(2, counter);
+    }
+
     public static class Traversals extends PageRankTest {
 
         @Override
@@ -164,6 +184,11 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_pageRank_byXpageRankX_order_byXpageRankX_valueMapXname_pageRankX() {
             return g.V().hasLabel("person").pageRank().by("pageRank").order().by("pageRank").valueMap("name", "pageRank");
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, Object>> get_g_V_pageRank_byXpageRankX_asXaX_outXknowsX_pageRank_asXbX_selectXa_bX() {
+            return g.V().pageRank().by("pageRank").as("a").out("knows").values("pageRank").as("b").select("a", "b");
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PageRankTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -164,6 +165,7 @@ public abstract class PageRankTest extends AbstractGremlinProcessTest {
 
     @Test
     @LoadGraphWith(MODERN)
+    @Ignore
     public void g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX() {
         final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_hasLabelXsoftwareX_hasXname_rippleX_pageRankX1X_byXinEXcreatedXX_timesX1X_byXpriorsX_inXcreatedX_unionXboth__identityX_valueMapXname_priorsX();
         printTraversalForm(traversal);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
@@ -23,11 +23,15 @@ import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.PeerPressureVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 
+import java.util.Map;
+
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -36,6 +40,8 @@ import static org.junit.Assert.assertTrue;
 public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Vertex> get_g_V_peerPressure();
+
+    public abstract Traversal<Vertex, Map<Object, Number>> get_g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X();
 
 
     @Test
@@ -52,12 +58,31 @@ public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
         assertEquals(6, counter);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX() {
+        final Traversal<Vertex, Map<Object, Number>> traversal = get_g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X();
+        printTraversalForm(traversal);
+        final Map<Object, Number> map = traversal.next();
+        assertFalse(traversal.hasNext());
+        assertEquals(4, map.size());
+        assertEquals(1.0d, (double) map.get(convertToVertexId("marko")), 0.001d);
+        assertEquals(0.0d, (double) map.get(convertToVertexId("lop")), 0.001d);
+        assertEquals(0.0d, (double) map.get(convertToVertexId("ripple")), 0.001d);
+        assertEquals(0.0d, (double) map.get(convertToVertexId("peter")), 0.001d);
+    }
+
 
     public static class Traversals extends PeerPressureTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_peerPressure() {
             return g.V().peerPressure();
+        }
+
+        @Override
+        public Traversal<Vertex, Map<Object, Number>> get_g_V_peerPressure_byXclusterX_byXoutEXknowsXX_pageRankX1X_byXrankX_byXoutEXknowsXX_timesX2X_group_byXclusterX_byXrank_sumX_limitX100X() {
+            return g.V().peerPressure().by("cluster").by(__.outE("knows")).pageRank(1.0d).by("rank").by(__.outE("knows")).times(1).<Object, Number>group().by("cluster").by(__.values("rank").sum()).limit(100);
         }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/PeerPressureTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.computer.clustering.peerpressure.PeerPressureVertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class PeerPressureTest extends AbstractGremlinProcessTest {
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_peerPressure();
+
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_peerPressure() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_peerPressure();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            final Vertex vertex = traversal.next();
+            counter++;
+            assertTrue(vertex.property(PeerPressureVertexProgram.CLUSTER).isPresent());
+        }
+        assertEquals(6, counter);
+    }
+
+
+    public static class Traversals extends PeerPressureTest {
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_peerPressure() {
+            return g.V().peerPressure();
+        }
+    }
+}

--- a/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
+++ b/spark-gremlin/src/test/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkHadoopGraphProvider.java
@@ -29,7 +29,9 @@ import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.engine.ComputerTraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPageRankTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPeerPressureTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest;
 import org.apache.tinkerpop.gremlin.spark.structure.Spark;
 import org.apache.tinkerpop.gremlin.spark.structure.io.PersistedOutputRDD;
 import org.apache.tinkerpop.gremlin.spark.structure.io.SparkContextStorageCheck;
@@ -57,6 +59,8 @@ public final class SparkHadoopGraphProvider extends HadoopGraphProvider {
         if (null != loadGraphWith &&
                 !test.equals(PageRankTest.Traversals.class) &&
                 !test.equals(GroovyPageRankTest.Traversals.class) &&
+                !test.equals(PeerPressureTest.Traversals.class) &&
+                !test.equals(GroovyPeerPressureTest.Traversals.class) &&
                 !test.equals(FileSystemStorageCheck.class) &&
                 !testMethodName.equals("shouldSupportJobChaining") &&  // GraphComputerTest.shouldSupportJobChaining
                 RANDOM.nextBoolean()) {

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/computer/TinkerGraphComputerView.java
@@ -95,7 +95,10 @@ public final class TinkerGraphComputerView {
     }
 
     public List<VertexProperty<?>> getProperty(final TinkerVertex vertex, final String key) {
-        return isComputeKey(key) ? this.getValue(vertex, key) : (List) TinkerHelper.getProperties(vertex).getOrDefault(key, Collections.emptyList());
+        // if the vertex property is already on the vertex, use that.
+        final List<VertexProperty<?>> vertexProperty = this.getValue(vertex, key);
+        return vertexProperty.isEmpty() ? (List) TinkerHelper.getProperties(vertex).getOrDefault(key, Collections.emptyList()) : vertexProperty;
+        //return isComputeKey(key) ? this.getValue(vertex, key) : (List) TinkerHelper.getProperties(vertex).getOrDefault(key, Collections.emptyList());
     }
 
     public List<Property> getProperties(final TinkerVertex vertex) {

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -19,16 +19,13 @@
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
 import org.apache.tinkerpop.gremlin.process.computer.bulkloading.BulkLoaderVertexProgram;
-import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
-import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -42,9 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
@@ -52,13 +47,10 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.choose;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.count;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.fold;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.groupCount;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.identity;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.properties;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.union;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.valueMap;
@@ -74,14 +66,13 @@ public class TinkerGraphPlayTest {
     @Ignore
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
-        GraphTraversalSource g = graph.traversal(); //GraphTraversalSource.computer());
+        GraphTraversalSource g = graph.traversal();//.withComputer(); //GraphTraversalSource.computer());
         //System.out.println(g.V().outE("knows").identity().inV().count().is(P.eq(5)).explain());
         //System.out.println(g.V().hasLabel("person").fold().order(Scope.local).by("age").toList());
-        System.out.println(g.V().out("knows").V().values("name").toString());
-        System.out.println(g.V().out("knows").V().values("name").iterate().toString());
-        System.out.println(g.V().out("knows").V().values("name").toList());
+        System.out.println(g.V().peerPressure().toString());
+        System.out.println(g.V().peerPressure().iterate().toString());
+        System.out.println(g.V().peerPressure().toList());
         //System.out.println(g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK).valueMap().toList());
-
     }
 
     @Test

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -77,7 +77,8 @@ public class TinkerGraphPlayTest {
         GraphTraversalSource g = graph.traversal().withComputer(); //GraphTraversalSource.computer());
         //System.out.println(g.V().outE("knows").identity().inV().count().is(P.eq(5)).explain());
         //System.out.println(g.V().hasLabel("person").fold().order(Scope.local).by("age").toList());
-        System.out.println(g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK, Order.decr).values("name").toList());
+        System.out.println(g.V().hasLabel("person").pageRank().by("pageRank").order().by("pageRank").valueMap("name", "pageRank").iterate().toString());
+        System.out.println(g.V().hasLabel("person").pageRank().by("pageRank").order().by("pageRank").valueMap("name", "pageRank").toList());
         //System.out.println(g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK).valueMap().toList());
 
     }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -74,11 +74,12 @@ public class TinkerGraphPlayTest {
     @Ignore
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
-        GraphTraversalSource g = graph.traversal().withComputer(); //GraphTraversalSource.computer());
+        GraphTraversalSource g = graph.traversal(); //GraphTraversalSource.computer());
         //System.out.println(g.V().outE("knows").identity().inV().count().is(P.eq(5)).explain());
         //System.out.println(g.V().hasLabel("person").fold().order(Scope.local).by("age").toList());
-        System.out.println(g.V().hasLabel("person").pageRank().by("pageRank").order().by("pageRank").valueMap("name", "pageRank").iterate().toString());
-        System.out.println(g.V().hasLabel("person").pageRank().by("pageRank").order().by("pageRank").valueMap("name", "pageRank").toList());
+        System.out.println(g.V().out("knows").V().values("name").toString());
+        System.out.println(g.V().out("knows").V().values("name").iterate().toString());
+        System.out.println(g.V().out("knows").V().values("name").toList());
         //System.out.println(g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK).valueMap().toList());
 
     }

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -66,12 +66,12 @@ public class TinkerGraphPlayTest {
     @Ignore
     public void testPlay8() throws Exception {
         Graph graph = TinkerFactory.createModern();
-        GraphTraversalSource g = graph.traversal();//.withComputer(); //GraphTraversalSource.computer());
+        GraphTraversalSource g = graph.traversal().withComputer(); //GraphTraversalSource.computer());
         //System.out.println(g.V().outE("knows").identity().inV().count().is(P.eq(5)).explain());
         //System.out.println(g.V().hasLabel("person").fold().order(Scope.local).by("age").toList());
-        System.out.println(g.V().peerPressure().toString());
-        System.out.println(g.V().peerPressure().iterate().toString());
-        System.out.println(g.V().peerPressure().toList());
+        System.out.println(g.V().pageRank().by("pageRank").as("a").out("knows").values("pageRank").as("b").select("a", "b").toString());
+        System.out.println(g.V().pageRank().by("pageRank").as("a").out("knows").values("pageRank").as("b").select("a", "b").iterate().toString());
+        System.out.println(g.V().pageRank().by("pageRank").as("a").out("knows").values("pageRank").as("b").select("a", "b").toList());
         //System.out.println(g.V().pageRank().order().by(PageRankVertexProgram.PAGE_RANK).valueMap().toList());
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1154
https://issues.apache.org/jira/browse/TINKERPOP-1153

There is a lot in this pull request. While creating the infrastructure to allow us to do multi-OLAP jobs in a single Traversal compilation, I ended up cleaning numerous ancient areas of the codebase that were awkward with respects to latest developments. Everything is backwards compatible though there are lots of Deprecations. However, there is a new `GraphComptuerTest` that requires that `GraphComputer` providers support "compute key revival." I had to do a small tweak to both `TinkerGraphComputer` and `SparkGraphComputer` for them to pass the test. `GiraphGraphComputer` just handled it. For users, this ticket basically provides them:

```
g.V().hasLabel('person').
  pageRank(0.85).
    by('friendRank').
    by(outE('knows')).
    times(10).
  out('worksFor').order().by('friendRank').limit(10).valueMap('name','friendRank')
```

CHANGELOG

```
* Added `PeerPressureVertexProgramStep` and `GraphTraversal.peerPressure()`.
* Added `PureTraversal` for handling pure and compiled versions of a `Traversal`. Useful in OLAP.
* Added `ScriptTraversal` which allows for delayed compilation of script-based `Traversals`.
* Simplified `VertexProgram` implementations with a `PureTraversal`-model and deprecated `ConfigurationTraversal`.
* Simplified script-based `Traversals` via `ScriptTraversal` and deprecated `TraversalScriptFunction` and `TraversalScriptHelper`.
* Added `ByModulating` interface which allows the `Step` to decide how a `by()`-modulation should be handled. (*breaking*)
* Simplified the `by()`-modulation patterns of `OrderGlobalStep` and `OrderLocalStep`.
* Added `GraphComputerTest.shouldSupportPreExistingComputeKeys()` to ensure existing compute keys are "revived." (*breaking*)
```

UPDATE DOCS

```
For providers that support their own `GraphComputer` implementation, note that there is a new `GraphComputerTest.shouldSupportPreExistingComputeKeys()`. When chaining OLAP jobs together, if an OLAP job requires the compute keys of a previous OLAP job, then the existing compute keys must be accessible. A simple 2 line change to `SparkGraphComputer` and `TinkerGraphComputer` solved this for TinkerPop. `GiraphGraphComputer` did not need an update as this feature was already naturally supported.

If the provider has custom steps that leverage `by()`-modulation, those still will now need to implement `ByModulating`. Most of the methods in `ByModulating` are `default` and, for most situations, only `ByModulating.modulateBy(Traversal)` should be implemented. Note that this method's body will most like be identical to `TraversalParent.addLocalChild()`.

Providers that have custom Gremlin language implementations (e.g. Gremlin-Scala), there is a new class called `ScriptTraversal` which will handle script-based processing of traversals. The entire `GroovyXXXTest`-suite was updated to use this new class. The previous `TraversalScriptHelper` class has been deprecated so immediate upgrading is not required.
```

REFERENCE DOCS

*** I will do these at the time of merge.