### PR TITLE
TINKERPOP-1172 Fixed bug with driver connecting to an initially dead server.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Fixed a condition where `ConnectionPool` initialization in the driver would present a `NullPointerException` on initialization if there were errors constructing the pool in full.
+* Fixed a bug in the round-robin load balancing strategy in the driver would waste requests potentially sending messages to dead hosts.
 * Fixed a bug where multiple "close" requests were being sent by the driver on `Client.close()`.
 * Fixed an `Property` attach bug that shows up in serialization-based `GraphComputer` implementations.
 * Fixed a pom.xml bug where Gremlin Console/Server were not pulling the latest Neo4j 2.3.2.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ConnectionPool.java
@@ -89,19 +89,18 @@ final class ConnectionPool {
         this.maxSimultaneousUsagePerConnection = settings.maxSimultaneousUsagePerConnection;
         this.minInProcess = settings.minInProcessPerConnection;
 
-        final List<Connection> l = new ArrayList<>(minPoolSize);
+        this.connections = new CopyOnWriteArrayList<>();
 
         try {
             for (int i = 0; i < minPoolSize; i++)
-                l.add(new Connection(host.getHostUri(), this, settings.maxInProcessPerConnection));
+                this.connections.add(new Connection(host.getHostUri(), this, settings.maxInProcessPerConnection));
         } catch (ConnectionException ce) {
             // ok if we don't get it initialized here - when a request is attempted in a connection from the
             // pool it will try to create new connections as needed.
-            logger.debug("Could not initialize connections in pool for {} - pool size at {}", host, l.size());
+            logger.debug("Could not initialize connections in pool for {} - pool size at {}", host, this.connections.size());
             considerUnavailable();
         }
 
-        this.connections = new CopyOnWriteArrayList<>(l);
         this.open = new AtomicInteger(connections.size());
 
         logger.info("Opening connection pool on {} with core size of {}", host, minPoolSize);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/LoadBalancingStrategy.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/LoadBalancingStrategy.java
@@ -20,6 +20,7 @@ package org.apache.tinkerpop.gremlin.driver;
 
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -61,7 +62,14 @@ public interface LoadBalancingStrategy extends Host.Listener {
 
         @Override
         public Iterator<Host> select(final RequestMessage msg) {
-            final List<Host> hosts = (List<Host>) availableHosts.clone();
+            final List<Host> hosts = new ArrayList<>();
+
+            // a host could be marked as dead in which case we dont need to send messages to it - just skip it for
+            // now. it might come back online later
+            availableHosts.iterator().forEachRemaining(host -> {
+                if (host.isAvailable()) hosts.add(host);
+            });
+
             final int startIndex = index.getAndIncrement();
 
             if (startIndex > Integer.MAX_VALUE - 10000)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1172

The `ConnectionPool` wasn't getting initialized properly when the host was dead which then lead to a null pointer exception when trying to reconnect.  Also fixed the possibility of a connection leak if the pool was partially initialized but the host died in the middle of that. Those partial connections were never properly closed.

I performed multiple successful runs of `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false`.

VOTE +1