### PR TITLE
TINKERPOP-1165:Tooling Support: Compile with -parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,9 @@ limitations under the License.
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1165

Add -parameters to maven compile args.

This can be manually verified w/ something like this
```
System.out.println(GraphTraversal.class.getDeclaredMethods()[0].getParameters()[0].getName());
```
This used to print "arg0", but should now print "column".