### PR TITLE
Fix HTTP keepalive support

### DIFF
--- a/docs/src/dev/developer/contributing.asciidoc
+++ b/docs/src/dev/developer/contributing.asciidoc
@@ -217,6 +217,19 @@ Contributors should examine the current code base to determine what the code sty
 style to what is already present. Of specific note however, TinkerPop does not use "import wildcards" - IDEs should
 be adjusted accordingly to not auto-wildcard the imports.
 
+Build Server
+~~~~~~~~~~~~
+
+TinkerPop uses both link:https://travis-ci.com/[Travis] and link:https://www.appveyor.com/[AppVeyor] for
+link:https://en.wikipedia.org/wiki/Continuous_integration[CI] services. Travis validates builds on Ubuntu, while
+AppVeyor validates builds on Windows.  The build statuses can be found here:
+
+* link:https://travis-ci.org/apache/incubator-tinkerpop[Travis Build Status]
+* link:https://ci.appveyor.com/project/ApacheSoftwareFoundation/incubator-tinkerpop[AppVeyor Build Status]
+
+Note that the CI process does not run integration tests or include Neo4j-related tests as those tests would likely
+exceed the allowable times for builds on these servers.
+
 Deprecation
 ~~~~~~~~~~~
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/ScriptEngines.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/engine/ScriptEngines.java
@@ -388,7 +388,7 @@ public class ScriptEngines implements AutoCloseable {
                         providers.add((CompilerCustomizerProvider) providerClass.newInstance());
                     }
                 } catch(Exception ex) {
-                    logger.warn("Could not instantiate CompilerCustomizerProvider implementation [{}].  It will not be applied.", k);
+                    logger.warn(String.format("Could not instantiate CompilerCustomizerProvider implementation [%s].  It will not be applied.", k), ex);
                 }
             });
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -180,7 +180,7 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
             }
 
             final String origin = req.headers().get(ORIGIN);
-            final boolean keepAlive = !isKeepAlive(req);
+            final boolean keepAlive = isKeepAlive(req);
 
             // not using the req any where below here - assume it is safe to release at this point.
             ReferenceCountUtil.release(msg);


### PR DESCRIPTION
[This commit][1] broke HTTP keepalive support by introducing a
double-negation on the call to Netty's isKeepAlive.

[1]: https://github.com/apache/incubator-tinkerpop/commit/c0121aae8266e9ff2c70c1517e809b5ecf1dd07a