### PR TITLE
Fix HTTP keepalive support

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpGremlinEndpointHandler.java
@@ -180,7 +180,7 @@ public class HttpGremlinEndpointHandler extends ChannelInboundHandlerAdapter {
             }
 
             final String origin = req.headers().get(ORIGIN);
-            final boolean keepAlive = !isKeepAlive(req);
+            final boolean keepAlive = isKeepAlive(req);
 
             // not using the req any where below here - assume it is safe to release at this point.
             ReferenceCountUtil.release(msg);


### PR DESCRIPTION
This commit[1] broke HTTP keepalive support by introducing a
double-negation on the call to Netty's isKeepAlive.

[1]: https://github.com/apache/incubator-tinkerpop/commit/c0121aae8266e9ff2c70c1517e809b5ecf1dd07a