### PR TITLE
TINKERPOP-1147 Added serialization support for TraversalExplanation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,7 +38,7 @@ TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 * Better handled errors that occurred on commits and serialization in Gremlin Server to first break the result iteration loop and to ensure commit errors were reported to the client.
 * Added GraphSON serializers for the `java.time.*` classes.
 * Improved the logging of the Gremlin Server REST endpoint as it pertained to script execution failures.
-* `TraversalExplanation` is now `Serializable` and registered with `GryoMapper`.
+* `TraversalExplanation` is now `Serializable` and compatible with GraphSON and Gryo serialization.
 * Fixed a problem with global bindings in Gremlin Server which weren't properly designed to handle concurrent modification.
 * Deprecated `ScriptElementFactory` and made the local `StarGraph` globally available for `ScriptInputFormat`'s `parse()` method.
 * Improved reusability of unique test directory creation in `/target` for `AbstractGraphProvider`, which was formerly only available to Neo4j, by adding `makeTestDirectory()`.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanation.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/TraversalExplanation.java
@@ -31,10 +31,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * A TraversalExplanation takes a {@link Traversal} and, for each registered {@link TraversalStrategy}, it creates a mapping reflecting how each strategy alters the traversal.
- * This is useful for understanding how each traversal strategy mutates the traversal.
- * This is useful in debugging and analysis of traversal compilation.
- * The {@link TraversalExplanation#toString()} has a pretty-print representation that is useful in the Gremlin Console.
+ * A TraversalExplanation takes a {@link Traversal} and, for each registered {@link TraversalStrategy}, it creates a
+ * mapping reflecting how each strategy alters the traversal. This is useful for understanding how each traversal
+ * strategy mutates the traversal. This is useful in debugging and analysis of traversal compilation. The
+ * {@link TraversalExplanation#toString()} has a pretty-print representation that is useful in the Gremlin Console.
  *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
@@ -19,6 +19,7 @@
 package org.apache.tinkerpop.gremlin.structure.io.graphson;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Property;
@@ -74,6 +75,7 @@ abstract class GraphSONModule extends SimpleModule {
             addSerializer(VertexProperty.class, new GraphSONSerializers.VertexPropertyJacksonSerializer(normalize));
             addSerializer(Property.class, new GraphSONSerializers.PropertyJacksonSerializer());
             addSerializer(TraversalMetrics.class, new GraphSONSerializers.TraversalMetricsJacksonSerializer());
+            addSerializer(TraversalExplanation.class, new GraphSONSerializers.TraversalExplanationJacksonSerializer());
             addSerializer(Path.class, new GraphSONSerializers.PathJacksonSerializer());
             addSerializer(StarGraphGraphSONSerializer.DirectionalStarGraph.class, new StarGraphGraphSONSerializer(normalize));
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTokens.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONTokens.java
@@ -44,6 +44,15 @@ public final class GraphSONTokens {
     public static final String OBJECTS = "objects";
     public static final String IN_LABEL = "inVLabel";
     public static final String OUT_LABEL = "outVLabel";
+
+    // TraversalExplanation Tokens
+    public static final String ORIGINAL = "original";
+    public static final String FINAL = "final";
+    public static final String INTERMEDIATE = "intermediate";
+    public static final String CATEGORY = "category";
+    public static final String TRAVERSAL = "traversal";
+    public static final String STRATEGY = "strategy";
+
     // TraversalMetrics Tokens
     public static final String METRICS = "metrics";
     public static final String DURATION = "dur";

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapper.java
@@ -62,6 +62,7 @@ import org.apache.tinkerpop.shaded.kryo.ClassResolver;
 import org.apache.tinkerpop.shaded.kryo.Kryo;
 import org.apache.tinkerpop.shaded.kryo.KryoSerializable;
 import org.apache.tinkerpop.shaded.kryo.Serializer;
+import org.apache.tinkerpop.shaded.kryo.serializers.JavaSerializer;
 import org.apache.tinkerpop.shaded.kryo.util.DefaultStreamFactory;
 import org.apache.tinkerpop.shaded.kryo.util.MapReferenceResolver;
 import org.javatuples.Pair;
@@ -296,7 +297,7 @@ public final class GryoMapper implements Mapper<Kryo> {
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(AtomicLong.class, null, 79));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(DependantMutableMetrics.class, null, 80));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(Pair.class, kryo -> new PairSerializer(), 88));
-            add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(TraversalExplanation.class, null, 106)); // ***LAST ID**
+            add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(TraversalExplanation.class, kryo -> new JavaSerializer(), 106)); // ***LAST ID**
 
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(Duration.class, kryo -> new JavaTimeSerializers.DurationSerializer(), 93));
             add(Triplet.<Class, Function<Kryo, Serializer>, Integer>with(Instant.class, kryo -> new JavaTimeSerializers.InstantSerializer(), 94));

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoSerializers.java
@@ -130,6 +130,5 @@ final class GryoSerializers {
         public Path read(final Kryo kryo, final Input input, final Class<Path> pathClass) {
             return (Path) kryo.readClassAndObject(input);
         }
-
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONMapperTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.io.graphson;
 
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
@@ -35,10 +36,18 @@ import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__;
 import static org.junit.Assert.assertEquals;
 
 public class GraphSONMapperTest {
     private final ObjectMapper mapper = GraphSONMapper.build().embedTypes(false).create().createMapper();
+
+    @Test
+    public void shouldHandleTraversalExplanation() throws Exception {
+        final TraversalExplanation te = __().out().outV().outE().explain();
+        final String json = mapper.writeValueAsString(te);
+        assertEquals("{\"original\":[\"InjectStep([])\",\"VertexStep(OUT,vertex)\",\"EdgeVertexStep(OUT)\",\"VertexStep(OUT,edge)\"],\"intermediate\":[],\"final\":[\"InjectStep([])\",\"VertexStep(OUT,vertex)\",\"EdgeVertexStep(OUT)\",\"VertexStep(OUT,edge)\"]}", json);
+    }
 
     @Test
     public void shouldHandleDuration()throws Exception  {

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapperTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/structure/io/gryo/GryoMapperTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.structure.io.gryo;
 
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.IoX;
 import org.apache.tinkerpop.gremlin.structure.io.IoXIoRegistry;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
@@ -293,6 +295,12 @@ public class GryoMapperTest {
     public void shouldHandleZonedOffset()throws Exception  {
         final ZoneOffset o  = ZonedDateTime.now().getOffset();
         assertEquals(o, serializeDeserialize(o, ZoneOffset.class));
+    }
+
+    @Test
+    public void shouldHandleTraversalExplanation()throws Exception  {
+        final TraversalExplanation te = __().out().outV().outE().explain();
+        assertEquals(te.toString(), serializeDeserialize(te, TraversalExplanation.class).toString());
     }
 
     public <T> T serializeDeserialize(final Object o, final Class<T> clazz) throws Exception {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1147

Covers both gryo and graphson. Gryo uses standard Java serialization as the object graph is mighty deep and building a native kryo serializer would have been a lot. GraphSON serializes to a JSON format which pretty much just allows you to get the data required to build what would have come from TraversalExplanation.toString().  It's mostly just for display purposes. Basically looks like this:

```js
{
	"original": ["GraphStep([],vertex)", "VertexStep(OUT,edge)", "EdgeVertexStep(IN)", "VertexStep(OUT,vertex)"],
	"intermediate": [{
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,edge)", "EdgeVertexStep(IN)", "VertexStep(OUT,vertex)"],
		"strategy": "ConnectiveStrategy",
		"category": "DecorationStrategy"
	}, {
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,edge)", "EdgeVertexStep(IN)", "VertexStep(OUT,vertex)"],
		"strategy": "IdentityRemovalStrategy",
		"category": "OptimizationStrategy"
	}, {
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,edge)", "EdgeVertexStep(IN)", "VertexStep(OUT,vertex)"],
		"strategy": "FilterRankingStrategy",
		"category": "OptimizationStrategy"
	}, {
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "IncidentToAdjacentStrategy",
		"category": "OptimizationStrategy"
	}, {
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "AdjacentToIncidentStrategy",
		"category": "OptimizationStrategy"
	}, {
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "MatchPredicateStrategy",
		"category": "OptimizationStrategy"
	}, {
		"traversal": ["GraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "RangeByIsCountStrategy",
		"category": "OptimizationStrategy"
	}, {
		"traversal": ["TinkerGraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "TinkerGraphStepStrategy",
		"category": "ProviderOptimizationStrategy"
	}, {
		"traversal": ["TinkerGraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "ProfileStrategy",
		"category": "FinalizationStrategy"
	}, {
		"traversal": ["TinkerGraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "EngineDependentStrategy",
		"category": "FinalizationStrategy"
	}, {
		"traversal": ["TinkerGraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "ComputerVerificationStrategy",
		"category": "VerificationStrategy"
	}, {
		"traversal": ["TinkerGraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"],
		"strategy": "StandardVerificationStrategy",
		"category": "VerificationStrategy"
	}],
	"final": ["TinkerGraphStep([],vertex)", "VertexStep(OUT,vertex)", "VertexStep(OUT,vertex)"]
}
```

VOTE +1