### PR TITLE
TINKERPOP-1179

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 os: Windows Server 2012
 
 install:
-  - cmd: choco install maven -y -f
+  - cmd: choco install maven -y -f --version 3.2.5
   - cmd: refreshenv
 
 build_script:


### PR DESCRIPTION
 Archetypes modules won't compile
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:2.4:integration-test (default) on project gremlin-archetype-tinkergraph: 
[ERROR] Archetype IT 'standard' failed: Cannot run additions goals. 
[ERROR] -> [Help 1] 
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archety
```

Due to https://issues.apache.org/jira/browse/ARCHETYPE-488

workaround is to run using maven 3.2