### PR TITLE
Make the GraphManager instance injectable into ServerGremlinExecutor

### DIFF
--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -517,8 +517,8 @@ CompletableFuture<List<Result>> results = client.submit("[1,2,3,4]").all();  <3>
 
 CompletableFuture<ResultSet> future = client.submitAsync("[1,2,3,4]"); <4>
 
-Map<String,Object> params = new HashMap<>()
-params.put("x",4)
+Map<String,Object> params = new HashMap<>();
+params.put("x",4);
 client.submit("[1,2,3,x]", params); <5>
 ----
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1162,6 +1162,16 @@ all scripts that are passed to it.  The cache is keyed based on the a hash of th
 where `x` is passed as a parameter from the client, there will be no additional compilation cost for future requests
 on that script.  Compilation of a script should be considered "expensive" and avoided when possible.
 
+[source,java]
+----
+Cluster cluster = Cluster.open();
+Client client = cluster.connect();
+
+Map<String,Object> params = new HashMap<>();
+params.put("x",4);
+client.submit("[1,2,3,x]", params);
+----
+
 Cache Management
 ^^^^^^^^^^^^^^^^
 
@@ -1277,6 +1287,67 @@ The aliases are then used to determine which graphs will have their transactions
 Gremlin Server in this configuration should be more efficient when there are multiple graphs being hosted as
 Gremlin Server will only close transactions on the graphs specified by the `aliases`. Keeping this setting `false`,
 will simply have Gremlin Server close transactions on all graphs for every request.
+
+[[considering-state]]
+Considering State
+^^^^^^^^^^^^^^^^^
+
+With REST and any sessionless requests, there is no variable state maintained between requests.  Therefore,
+when <<connecting-via-console,connecting with the console>>, for example, it is not possible to create a variable in
+one command and then expect to access it in the next:
+
+[source,groovy]
+----
+gremlin> :remote connect tinkerpop.server conf/remote.yaml
+==>Connected - localhost/127.0.0.1:8182
+gremlin> :> x = 2
+==>2
+gremlin> :> 2 + x
+No such property: x for class: Script4
+Display stack trace? [yN] n
+----
+
+The same behavior would be seen with REST or when using sessionless requests through one of the Gremlin Server drivers.
+If having this behavior is desireable, then <<considering-sessions,consider sessions>>.
+
+There is an exception to this notion of state not existing between requests and that is globally defined functions.
+All functions created via scripts are global to the server.
+
+[source,groovy]
+----
+gremlin> :> def subtractIt(int x, int y) { x - y }
+==>null
+gremlin> :> subtractIt(8,7)
+==>1
+----
+
+If this behavior is not desirable there are several options.  A first option would be to consider using sessions. Each
+session gets its own `ScriptEngine`, which maintains its own isolated cache of global functions, whereas sessionless
+requests uses a single function cache. A second option would be to define functions as closures:
+
+[source,groovy]
+----
+gremlin> :> multiplyIt = { int x, int y -> x * y }
+==>Script7$_run_closure1@6b24f3ab
+gremlin> :> multiplyIt(7, 8)
+No signature of method: org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.multiplyIt() is applicable for argument types: (java.lang.Integer, java.lang.Integer) values: [7, 8]
+Display stack trace? [yN]
+----
+
+When the function is declared this way, the function is viewed by the `ScriptEngine` as a variable rather than a global
+function and since sessionless requests don't maintain state, the function is forgotten for the next request. A final
+option would be to manage the `ScriptEngine` cache manually:
+
+[source,bourne]
+----
+$ curl -X POST -d "{\"gremlin\":\"def divideIt(int x, int y){ x / y }\",\"bindings\":{\"#jsr223.groovy.engine.keep.globals\":\"phantom\"}}" "http://localhost:8182"
+{"requestId":"97fe1467-a943-45ea-8fd6-9e889a6c9381","status":{"message":"","code":200,"attributes":{}},"result":{"data":[null],"meta":{}}}
+$ curl -X POST -d "{\"gremlin\":\"divideIt(8, 2)\"}" "http://localhost:8182"
+{"message":"Error encountered evaluating script: divideIt(8, 2)"}
+----
+
+In the above REST-based requests, the bindings contain a special parameter that tells the `ScriptEngine` cache to
+immediately forget the script after execution. In this way, the function does not end up being globally available.
 
 [[gremlin-plugins]]
 Gremlin Plugins

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
@@ -74,10 +74,10 @@ public final class Host {
         // only do a connection re-attempt if one is not already in progress
         if (retryInProgress.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
             retryThread = this.cluster.executor().scheduleAtFixedRate(() -> {
-                                                                          logger.debug("Trying to reconnect to dead host at {}", this);
-                                                                          if (reconnect.apply(this)) reconnected();
-                                                                      }, cluster.connectionPoolSettings().reconnectInitialDelay,
-                                                                      cluster.connectionPoolSettings().reconnectInterval, TimeUnit.MILLISECONDS);
+                    logger.debug("Trying to reconnect to dead host at {}", this);
+                    if (reconnect.apply(this)) reconnected();
+                }, cluster.connectionPoolSettings().reconnectInitialDelay,
+                cluster.connectionPoolSettings().reconnectInterval, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/ServerGremlinExecutor.java
@@ -70,7 +70,14 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
     public ServerGremlinExecutor(final Settings settings, final Class<T> scheduleExecutorServiceClass) {
         this(settings, null, null, scheduleExecutorServiceClass);
     }
-
+    public ServerGremlinExecutor(final Settings settings, final ExecutorService gremlinExecutorService,
+                                 final T scheduledExecutorService, final Class<T> scheduleExecutorServiceClass) {
+        this(settings,
+             gremlinExecutorService,
+             scheduledExecutorService,
+             scheduleExecutorServiceClass,
+             new GraphManager(settings));
+    }
     /**
      * Create a new object from {@link Settings} where thread pools are externally assigned. Note that if the
      * {@code scheduleExecutorServiceClass} is set to {@code null} it will be created via
@@ -78,7 +85,8 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
      * instances are supplied, the {@link Settings#gremlinPool} value will be ignored for the pool size.
      */
     public ServerGremlinExecutor(final Settings settings, final ExecutorService gremlinExecutorService,
-                                 final T scheduledExecutorService, final Class<T> scheduleExecutorServiceClass) {
+                                 final T scheduledExecutorService, final Class<T> scheduleExecutorServiceClass,
+                                 final GraphManager graphManager) {
         this.settings = settings;
 
         if (null == gremlinExecutorService) {
@@ -97,17 +105,17 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
         }
 
         // initialize graphs from configuration
-        graphManager = new GraphManager(settings);
+        this.graphManager = graphManager;
 
         logger.info("Initialized Gremlin thread pool.  Threads in pool named with pattern gremlin-*");
 
         final GremlinExecutor.Builder gremlinExecutorBuilder = GremlinExecutor.build()
                 .scriptEvaluationTimeout(settings.scriptEvaluationTimeout)
-                .afterFailure((b, e) -> graphManager.rollbackAll())
-                .beforeEval(b -> graphManager.rollbackAll())
-                .afterTimeout(b -> graphManager.rollbackAll())
+                .afterFailure((b, e) -> this.graphManager.rollbackAll())
+                .beforeEval(b -> this.graphManager.rollbackAll())
+                .afterTimeout(b -> this.graphManager.rollbackAll())
                 .enabledPlugins(new HashSet<>(settings.plugins))
-                .globalBindings(graphManager.getAsBindings())
+                .globalBindings(this.graphManager.getAsBindings())
                 .executorService(this.gremlinExecutorService)
                 .scheduledExecutorService(this.scheduledExecutorService);
 
@@ -126,14 +134,14 @@ public class ServerGremlinExecutor<T extends ScheduledExecutorService> {
         // re-apply those references back
         gremlinExecutor.getGlobalBindings().entrySet().stream()
                 .filter(kv -> kv.getValue() instanceof Graph)
-                .forEach(kv -> graphManager.getGraphs().put(kv.getKey(), (Graph) kv.getValue()));
+                .forEach(kv -> this.graphManager.getGraphs().put(kv.getKey(), (Graph) kv.getValue()));
 
         // script engine init may have constructed the TraversalSource bindings - store them in Graphs object
         gremlinExecutor.getGlobalBindings().entrySet().stream()
                 .filter(kv -> kv.getValue() instanceof TraversalSource)
                 .forEach(kv -> {
                     logger.info("A {} is now bound to [{}] with {}", kv.getValue().getClass().getSimpleName(), kv.getKey(), kv.getValue());
-                    graphManager.getTraversalSources().put(kv.getKey(), (TraversalSource) kv.getValue());
+                    this.graphManager.getTraversalSources().put(kv.getKey(), (TraversalSource) kv.getValue());
                 });
 
         // determine if the initialization scripts introduced LifeCycleHook objects - if so we need to gather them

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthIntegrateTest.java
@@ -82,7 +82,7 @@ public class GremlinServerAuthIntegrateTest extends AbstractGremlinServerIntegra
         } catch(Exception ex) {
             final Throwable root = ExceptionUtils.getRootCause(ex);
             assertEquals(TimeoutException.class, root.getClass());
-            assertEquals("Timed out waiting for an available host.", root.getMessage());
+            assertThat(root.getMessage(), startsWith("Timed out while waiting for an available host"));
         } finally {
             cluster.close();
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthOldIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerAuthOldIntegrateTest.java
@@ -85,7 +85,7 @@ public class GremlinServerAuthOldIntegrateTest extends AbstractGremlinServerInte
         } catch(Exception ex) {
             final Throwable root = ExceptionUtils.getRootCause(ex);
             assertEquals(TimeoutException.class, root.getClass());
-            assertEquals("Timed out waiting for an available host.", root.getMessage());
+            assertThat(root.getMessage(), startsWith("Timed out while waiting for an available host"));
         } finally {
             cluster.close();
         }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
@@ -267,17 +268,16 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
-    @org.junit.Ignore("This test hangs - not sure why")
     public void shouldEnableSslButFailIfClientConnectsWithoutIt() {
-        // todo: need to get this to pass somehow - should just error out.
         final Cluster cluster = Cluster.build().enableSsl(false).create();
         final Client client = cluster.connect();
 
         try {
-            // this should return "nothing" - there should be no exception
-            assertEquals("test", client.submit("'test'").one().getString());
+            client.submit("'test'").one();
+            fail("Should throw exception because ssl is enabled on the server but not on client");
         } catch(Exception x) {
-            x.printStackTrace();
+            final Throwable root = ExceptionUtils.getRootCause(x);
+            assertThat(root, instanceOf(TimeoutException.class));
         } finally {
             cluster.close();
         }


### PR DESCRIPTION
This refers to a discussion from the gremlin-users mailing list:
[https://groups.google.com/forum/#!topic/gremlin-users/xYzCAQExvvM](https://groups.google.com/forum/#!topic/gremlin-users/xYzCAQExvvM)

It is currently not possible to use a standard way to inject a
fully configured graph. The way presented in this gist is only
a hack and should not be taken as the default way.
[https://gist.github.com/xenji/e469abde2e0b80aadc4e](https://gist.github.com/xenji/e469abde2e0b80aadc4e)

Adding a new constructor parameter is, from my point of view,
the most flexible and compatible change to enable the injection
without breaking old code.

I've run the whole test suite of the server before pushing without
failures.