### PR TITLE
TINKERPOP-1160 Add timeout configuration for time to wait for connection close

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `maxWaitForSessionClose` to the settings for Gremlin Driver.
 * Bumped to Netty 4.0.34.Final.
 * Added "interpreter mode" for the `ScriptEngine` and Gremlin Server which allows variables defined with `def` or a type to be recognized as "global".
 * Bumped to Apache Groovy 2.4.6.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -532,6 +532,43 @@ In this case, they are streamed from the server as they arrive.
 <5> Parameterized request are considered the most efficient way to send Gremlin to the server as they can be cached,
 which will boost performance and reduce resources required on the server.
 
+Configuration
+^^^^^^^^^^^^^
+
+The following table describes the various configuration options for the Gremlin Driver:
+
+[width="100%",cols="3,10,^2",options="header"]
+|=========================================================
+|Key |Description |Default
+|connectionPool.channelizer |The fully qualified classname of the client `Channelizer` that defines how to connect to the server. |`Channelizer.WebSocketChannelizer`
+|connectionPool.enableSsl |Determines if SSL should be enabled or not. If enabled on the server then it must be enabled on the client. |false
+|connectionPool.maxContentLength |The maximum length in bytes that a message can be sent to the server. This number can be no greater than the setting of the same name in the server configuration. |65536
+|connectionPool.maxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |4
+|connectionPool.maxSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |16
+|connectionPool.maxSize |The maximum size of a connection pool for a host. |8
+|connectionPool.maxWaitForConnection |The amount of time in milliseconds to wait for a new connection before timing out. |3000
+|connectionPool.maxWaitForSessionClose |The amount of time in milliseconds to wait for a session to close before timing out (does not apply to sessionless connections). |3000
+|connectionPool.minInProcessPerConnection |The minimum number of in-flight requests that can occur on a connection. |1
+|connectionPool.minSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |8
+|connectionPool.minSize |The minimum size of a connection pool for a host. |2
+|connectionPool.reconnectInitialDelay |The amount of time in milliseconds to wait before trying to reconnect to a dead host for the first time. |1000
+|connectionPool.reconnectInterval |The amount of time in milliseconds to wait before trying to reconnect to a dead host. This interval occurs after the time specified by the `reconnectInitialDelay`. |1000
+|connectionPool.resultIterationBatchSize |The override value for the size of the result batches to be returned from the server. |64
+|connectionPool.trustCertChainFile |File location for a SSL Certificate Chain to use when SSL is enabled. If this value is not provided and SSL is enabled, the `TrustManager` will be established with a self-signed certificate which is NOT suitable for production purposes. |_none_
+|hosts |The list of hosts that the driver will connect to. |localhost
+|jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
+|nioPoolSize |Size of the pool for handling request/response operations. |available processors
+|password |The password to submit on requests that require authentication. |_none_
+|port |The port of the Gremlin Server to connect to. The same port will be applied for all hosts. |8192
+|protocol |Sets the `AuthProperties.Property.PROTOCOL` properties for authentication to Gremlin Server. |_none_
+|serializer.className |The fully qualified class name of the `MessageSerializer` that will be used to communicate with the server. Note that the serializer configured on the client should be supported by the server configuration. |`GryoMessageSerializerV1d0`
+|serializer.config |A `Map` of configuration settings for the serializer. |_none_
+|username |The username to submit on requests that require authentication. |_none_
+|workerPoolSize |Size of the pool for handling background work. |available processors * 2
+|=========================================================
+
+Please see the link:http://tinkerpop.apache.org/javadocs/x.y.z/core/org/apache/tinkerpop/gremlin/driver/Cluster.Builder.html[Cluster.Builder javadoc] to get more information on these settings.
+
 Aliases
 ^^^^^^^
 
@@ -693,7 +730,7 @@ The following table describes the various configuration options that Gremlin Ser
 |Key |Description |Default
 |authentication.className |The fully qualified classname of an `Authenticator` implementation to use.  If this setting is not present, then authentication is effectively disabled. |`AllowAllAuthenticator`
 |authentication.config |A `Map` of configuration settings to be passes to the `Authenticator` when it is constructed.  The settings available are dependent on the implementation. |_none_
-|channelizer |The fully qualified classname of the `Channelizer` implementation to use.  A `Channelizer` is a "channel initializer" which Gremlin Server uses to define the type of processing pipeline to use.  By allowing different `Channelizer` implementations, Gremlin Server can support different communication protocols (e.g. Websockets, Java NIO, etc.). |WebSocketChannelizer
+|channelizer |The fully qualified classname of the `Channelizer` implementation to use.  A `Channelizer` is a "channel initializer" which Gremlin Server uses to define the type of processing pipeline to use.  By allowing different `Channelizer` implementations, Gremlin Server can support different communication protocols (e.g. Websockets, Java NIO, etc.). |`WebSocketChannelizer`
 |graphs |A `Map` of `Graph` configuration files where the key of the `Map` becomes the name to which the `Graph` will be bound and the value is the file name of a `Graph` configuration file. |_none_
 |gremlinPool |The number of "Gremlin" threads available to execute actual scripts in a `ScriptEngine`. This pool represents the workers available to handle blocking operations in Gremlin Server. |8
 |host |The name of the host to bind the server to. |localhost

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -63,6 +63,15 @@ in a transaction. With this configuration of `client` there is no need to close 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1039[TINKERPOP-1039],
 link:http://tinkerpop.apache.org/docs/3.1.2-incubating/reference/#sessions[Reference Documentation - Considering Sessions]
 
+Session Timeout Setting
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The `gremlin-driver` now has a setting called `maxWaitForSessionClose` that allows control of how long it will wait for
+an in-session connection to respond to a close request before it simply times-out and moves on.  When that happens,
+the server will either eventually close the connection via at session expiration or at the time of shutdown.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1160[TINKERPOP-1160]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -22,7 +22,6 @@ import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -278,6 +278,7 @@ public final class Cluster {
         private int maxInProcessPerConnection = Connection.MAX_IN_PROCESS;
         private int minInProcessPerConnection = Connection.MIN_IN_PROCESS;
         private int maxWaitForConnection = Connection.MAX_WAIT_FOR_CONNECTION;
+        private int maxWaitForSessionClose = Connection.MAX_WAIT_FOR_SESSION_CLOSE;
         private int maxContentLength = Connection.MAX_CONTENT_LENGTH;
         private int reconnectInitialDelay = Connection.RECONNECT_INITIAL_DELAY;
         private int reconnectInterval = Connection.RECONNECT_INTERVAL;
@@ -442,6 +443,16 @@ public final class Cluster {
         }
 
         /**
+         * If the connection is using a "session" this setting represents the amount of time in milliseconds to wait
+         * for that session to close before timing out where the default value is 3000. Note that the server will
+         * eventually clean up dead sessions itself on expiration of the session or during shutdown.
+         */
+        public Builder maxWaitForSessionClose(final int maxWait) {
+            this.maxWaitForSessionClose = maxWait;
+            return this;
+        }
+
+        /**
          * The maximum size in bytes of any request sent to the server.   This number should not exceed the same
          * setting defined on the server.
          */
@@ -569,6 +580,7 @@ public final class Cluster {
             connectionPoolSettings.maxSize = this.maxConnectionPoolSize;
             connectionPoolSettings.minSize = this.minConnectionPoolSize;
             connectionPoolSettings.maxWaitForConnection = this.maxWaitForConnection;
+            connectionPoolSettings.maxWaitForSessionClose = this.maxWaitForSessionClose;
             connectionPoolSettings.maxContentLength = this.maxContentLength;
             connectionPoolSettings.reconnectInitialDelay = this.reconnectInitialDelay;
             connectionPoolSettings.reconnectInterval = this.reconnectInterval;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,6 +57,7 @@ final class Connection {
     public static final int MAX_IN_PROCESS = 4;
     public static final int MIN_IN_PROCESS = 1;
     public static final int MAX_WAIT_FOR_CONNECTION = 3000;
+    public static final int MAX_WAIT_FOR_SESSION_CLOSE = 3000;
     public static final int MAX_CONTENT_LENGTH = 65536;
     public static final int RECONNECT_INITIAL_DELAY = 1000;
     public static final int RECONNECT_INTERVAL = 1000;
@@ -215,7 +218,7 @@ final class Connection {
 
     private void shutdown(final CompletableFuture<Void> future) {
         // shutdown can be called directly from closeAsync() or after write() and therefore this method should only
-        // be called once. once shutdown is initiated, it shoudln't be executed a second time or else it sends more
+        // be called once. once shutdown is initiated, it shouldn't be executed a second time or else it sends more
         // messages at the server and leads to ugly log messages over there.
         if (shutdownInitiated.compareAndSet(false, true)) {
             if (client instanceof Client.SessionedClient) {
@@ -228,10 +231,15 @@ final class Connection {
                     // make sure we get a response here to validate that things closed as expected.  on error, we'll let
                     // the server try to clean up on its own.  the primary error here should probably be related to
                     // protocol issues which should not be something a user has to fuss with.
-                    closed.get();
+                    closed.get(cluster.connectionPoolSettings().maxWaitForSessionClose, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException ex) {
+                    final String msg = String.format(
+                            "Timeout while trying to close connection on %s - force closing - server will close session on shutdown or expiration.",
+                            ((Client.SessionedClient) client).getSessionId());
+                    logger.warn(msg, ex);
                 } catch (Exception ex) {
                     final String msg = String.format(
-                            "Encountered an error trying to close connection on %s - force closing - server will close session on shutdown or timeout.",
+                            "Encountered an error trying to close connection on %s - force closing - server will close session on shutdown or expiration.",
                             ((Client.SessionedClient) client).getSessionId());
                     logger.warn(msg, ex);
                 }

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -31,28 +31,62 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
+ * Settings for the {@link Cluster} and its related components.
+ *
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 final class Settings {
 
+    /**
+     * The port of the Gremlin Server to connect to which defaults to {@code 8192}. The same port will be applied for
+     * all {@link #hosts}.
+     */
     public int port = 8182;
 
+    /**
+     * The list of hosts that the driver will connect to.
+     */
     public List<String> hosts = new ArrayList<>();
 
+    /**
+     * The serializer that will be used when communicating with the server. Note that serializer settings should match
+     * what is available on the server.
+     */
     public SerializerSettings serializer = new SerializerSettings();
 
+    /**
+     * Settings for connections and connection pool.
+     */
     public ConnectionPoolSettings connectionPool = new ConnectionPoolSettings();
 
+    /**
+     * The size of the thread pool defaulted to the number of available processors.
+     */
     public int nioPoolSize = Runtime.getRuntime().availableProcessors();
 
+    /**
+     * The number of worker threads defaulted to the number of available processors * 2.
+     */
     public int workerPoolSize = Runtime.getRuntime().availableProcessors() * 2;
 
+    /**
+     * The username to submit on requests that require authentication.
+     */
     public String username = null;
 
+    /**
+     * The password to submit on requests that require authentication.
+     */
     public String password = null;
 
+    /**
+     * The JAAS to submit on requests that require authentication.
+     */
     public String jaasEntry = null;
 
+    /**
+     * The JAAS protocol to submit on requests that require authentication.
+     */
     public String protocol = null;
 
     /**
@@ -74,19 +108,93 @@ final class Settings {
     }
 
     static class ConnectionPoolSettings {
+        /**
+         * Determines if SSL should be enabled or not. If enabled on the server then it must be enabled on the client.
+         */
         public boolean enableSsl = false;
+
+        /**
+         * The trusted certificate in PEM format.
+         */
         public String trustCertChainFile = null;
+
+        /**
+         * The minimum size of a connection pool for a {@link Host}. By default this is set to 2.
+         */
         public int minSize = ConnectionPool.MIN_POOL_SIZE;
+
+        /**
+         * The maximum size of a connection pool for a {@link Host}. By default this is set to 8.
+         */
         public int maxSize = ConnectionPool.MAX_POOL_SIZE;
+
+        /**
+         * A connection under low use can be destroyed. This setting determines the threshold for determining when
+         * that connection can be released and is defaulted to 8.
+         */
         public int minSimultaneousUsagePerConnection = ConnectionPool.MIN_SIMULTANEOUS_USAGE_PER_CONNECTION;
+
+        /**
+         * If a connection is over used, then it might mean that is necessary to expand the pool by adding a new
+         * connection.  This setting determines the threshold for a connections over use and is defaulted to 16
+         */
         public int maxSimultaneousUsagePerConnection = ConnectionPool.MAX_SIMULTANEOUS_USAGE_PER_CONNECTION;
+
+        /**
+         * The maximum number of requests in flight on a connection where the default is 4.
+         */
         public int maxInProcessPerConnection = Connection.MAX_IN_PROCESS;
+
+        /**
+         * A connection has available in-process requests which is calculated by subtracting the number of current
+         * in-flight requests on a connection and subtracting that from the {@link #maxInProcessPerConnection}. When
+         * that number drops below this configuration setting, the connection is recommended for replacement. The
+         * default for this setting is 1.
+         */
         public int minInProcessPerConnection = Connection.MIN_IN_PROCESS;
+
+        /**
+         * The amount of time in milliseconds to wait for a new connection before timing out where the default value
+         * is 3000.
+         */
         public int maxWaitForConnection = Connection.MAX_WAIT_FOR_CONNECTION;
+
+        /**
+         * If the connection is using a "session" this setting represents the amount of time in milliseconds to wait
+         * for that session to close before timing out where the default value is 3000. Note that the server will
+         * eventually clean up dead sessions itself on expiration of the session or during shutdown.
+         */
+        public int maxWaitForSessionClose = Connection.MAX_WAIT_FOR_SESSION_CLOSE;
+
+        /**
+         * The maximum length in bytes that a message can be sent to the server. This number can be no greater than
+         * the setting of the same name in the server configuration. The default value is 65536.
+         */
         public int maxContentLength = Connection.MAX_CONTENT_LENGTH;
+
+        /**
+         * The amount of time in milliseconds to wait before trying to reconnect to a dead host. The default value is
+         * 1000. This interval occurs after the time specified by the {@link #reconnectInitialDelay}.
+         */
         public int reconnectInterval = Connection.RECONNECT_INTERVAL;
+
+        /**
+         * The amount of time in milliseconds to wait before trying to reconnect to a dead host for the first time.
+         * The default value is 1000.
+         */
         public int reconnectInitialDelay = Connection.RECONNECT_INITIAL_DELAY;
+
+        /**
+         * The override value for the size of the result batches to be returned from the server. This value is set to
+         * 64 by default.
+         */
         public int resultIterationBatchSize = Connection.RESULT_ITERATION_BATCH_SIZE;
+
+        /**
+         * The constructor for the channel that connects to the server. This value should be the fully qualified
+         * class name of a Gremlin Driver {@link Channelizer} implementation.  By default this value is set to
+         * {@link org.apache.tinkerpop.gremlin.driver.Channelizer.WebSocketChannelizer}.
+         */
         public String channelizer = Channelizer.WebSocketChannelizer.class.getName();
 
         /**
@@ -107,7 +215,15 @@ final class Settings {
     }
 
     public static class SerializerSettings {
+        /**
+         * The fully qualified class name of the {@link MessageSerializer} that will be used to communicate with the
+         * server. Note that the serializer configured on the client should be supported by the server configuration.
+         */
         public String className = GraphSONMessageSerializerV1d0.class.getCanonicalName();
+
+        /**
+         * The configuration for the specified serializer with the {@link #className}.
+         */
         public Map<String, Object> config = null;
 
         public MessageSerializer create() throws Exception {

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.driver;
 
-import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0;
+import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -219,7 +219,7 @@ final class Settings {
          * The fully qualified class name of the {@link MessageSerializer} that will be used to communicate with the
          * server. Note that the serializer configured on the client should be supported by the server configuration.
          */
-        public String className = GraphSONMessageSerializerV1d0.class.getCanonicalName();
+        public String className = GryoMessageSerializerV1d0.class.getCanonicalName();
 
         /**
          * The configuration for the specified serializer with the {@link #className}.

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Settings.java
@@ -102,13 +102,13 @@ public class Settings {
     /**
      * Time in milliseconds to wait for a script to complete execution.  Defaults to 30000.
      */
-    public long scriptEvaluationTimeout = 30000l;
+    public long scriptEvaluationTimeout = 30000L;
 
     /**
      * Time in milliseconds to wait while an evaluated script serializes its results. This value represents the
      * total serialization time for the request.  Defaults to 30000.
      */
-    public long serializedResponseTimeout = 30000l;
+    public long serializedResponseTimeout = 30000L;
 
     /**
      * Number of items in a particular resultset to iterate and serialize prior to pushing the data down the wire


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1160

Added the new `maxWaitForSessionClose` configuration option to the driver.  For all the code changes here, the only one that matters is this:

https://github.com/apache/incubator-tinkerpop/compare/tp31...TINKERPOP-1160?expand=1#diff-9aa3bff55e6c3f840ceded2dd2ad2d88R234

where I replaced an indefinitely blocking {{get()}} call on a future to one with a timeout that uses the new setting. 

all good with: `mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false` 

VOTE +1