### PR TITLE
TINKERPOP-1180: Add more optimized binary operators to Operator

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Operator.java
@@ -76,5 +76,11 @@ public enum Operator implements BinaryOperator<Object> {
             ((Collection) a).addAll((Collection) b);
             return a;
         }
+    },
+    //////
+    sumLong {
+        public Object apply(final Object a, final Object b) {
+            return (long) a + (long) b;
+        }
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountGlobalStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/CountGlobalStep.java
@@ -39,7 +39,7 @@ public final class CountGlobalStep<S> extends ReducingBarrierStep<S, Long> {
     public CountGlobalStep(final Traversal.Admin traversal) {
         super(traversal);
         this.setSeedSupplier(new ConstantSupplier<>(0L));
-        this.setReducingBiOperator((BinaryOperator) Operator.sum);
+        this.setReducingBiOperator((BinaryOperator) Operator.sumLong);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupCountStep.java
@@ -53,7 +53,7 @@ public final class GroupCountStep<S, E> extends ReducingBarrierStep<S, Map<E, Lo
 
     @Override
     public Map<E, Long> projectTraverser(final Traverser.Admin<S> traverser) {
-        final Map<E, Long> map = new HashMap<>();
+        final Map<E, Long> map = new HashMap<>(1);
         map.put(TraversalUtil.applyNullable(traverser, this.keyTraversal), traverser.bulk());
         return map;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroupStep.java
@@ -92,7 +92,7 @@ public final class GroupStep<S, K, V> extends ReducingBarrierStep<S, Map<K, V>> 
 
     @Override
     public Map<K, V> projectTraverser(final Traverser.Admin<S> traverser) {
-        final Map<K, V> map = new HashMap<>();
+        final Map<K, V> map = new HashMap<>(1);
         final K key = TraversalUtil.applyNullable(traverser, this.keyTraversal);
         if (this.onGraphComputer) {
             final TraverserSet traverserSet = new TraverserSet();

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupCountSideEffectStep.java
@@ -51,7 +51,7 @@ public final class GroupCountSideEffectStep<S, E> extends SideEffectStep<S> impl
 
     @Override
     protected void sideEffect(final Traverser.Admin<S> traverser) {
-        final Map<E, Long> map = new HashMap<>();
+        final Map<E, Long> map = new HashMap<>(1);
         map.put(TraversalUtil.applyNullable(traverser.asAdmin(), this.keyTraversal), traverser.bulk());
         this.getTraversal().getSideEffects().add(this.sideEffectKey, map);
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroupSideEffectStep.java
@@ -77,7 +77,7 @@ public final class GroupSideEffectStep<S, K, V> extends SideEffectStep<S> implem
 
     @Override
     protected void sideEffect(final Traverser.Admin<S> traverser) {
-        final Map<K, Object> map = new HashMap<>();
+        final Map<K, Object> map = new HashMap<>(1);
         final K key = TraversalUtil.applyNullable(traverser, keyTraversal);
         if (this.onGraphComputer) {
             final TraverserSet traverserSet = new TraverserSet();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1180

This is simple. Added `Operator.sumLong` which bypasses using `NumberHelper`. Smart when you know you are summing longs as in `CountGlobalStep`. I also tweaked the initial capacity of the singleton maps of the `GroupXXXSteps`. As we need more Operators, we can just CTR add them. Its trivial.

`mvn clean install`.

VOTE +1.