### PR TITLE
TINKERPOP-1096 TINKERPOP-1097 Session Aliases, Console Sessions and Remote Console

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added the `:remote console` option which flips the Gremlin Console into a remote-only mode where all script evaluation is routed to the currently configured remote, which removes the need to use the `:>` command.
 * Added `allowRemoteConsole()` to the `RemoteAcceptor` interface.
 * The `:remote` for `tinkerpop.server` now includes an option to establish the connection as a "session".
 * Provided an implementation for calls to `SessionedClient.alias()`, which formerly threw an `UnsupportedOperationException`.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,8 +26,10 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* The `:remote` for `tinkerpop.server` now includes an option to establish the connection as a "session".
+* Provided an implementation for calls to `SessionedClient.alias()`, which formerly threw an `UnsupportedOperationException`.
+* Bumped to commons-collections 3.2.2.
 * Fixed a bug where `OrderGlobalStep` and `OrderLocalStep` were not incorporating their children's traverser requirements.
-* Bump to commons-collections 3.2.2.
 * Fixed a compilation bug in `TraversalExplanation`.
 * Fixed bug where a session explicitly closed was being closed again by session expiration.
 * Improved the recovery options for Gremlin Driver after failed requests to Gremlin Server.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.2 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added `allowRemoteConsole()` to the `RemoteAcceptor` interface.
 * The `:remote` for `tinkerpop.server` now includes an option to establish the connection as a "session".
 * Provided an implementation for calls to `SessionedClient.alias()`, which formerly threw an `UnsupportedOperationException`.
 * Bumped to commons-collections 3.2.2.

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -499,7 +499,7 @@ a `Graph` that passes the full Test Suite, should be compliant with Gremlin Serv
 occur is in serialization.  Always ensure that IO is properly implemented, that custom serializers are tested fully
 and ultimately integration test the `Graph` with an actual Gremlin Server instance.
 
-CAUTION: Configuring tests to run in parallel might result in errors that are difficult to debug as there is some
+WARNING: Configuring tests to run in parallel might result in errors that are difficult to debug as there is some
 shared state in test execution around graph configuration.  It is therefore recommended that parallelism be turned
 off for the test suite (the Maven SureFire Plugin is configured this way by default).  It may also be important to
 include this setting, `<reuseForks>false</reuseForks>`, in the SureFire configuration if tests are failing in an

--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -33,6 +33,7 @@ This document attempts to address the needs of the different providers that have
 ** Graph Processor Provider
 * Graph Driver Provider
 * Graph Language Provider
+* Graph Plugin Provider
 
 [[graph-system-provider-requirements]]
 Graph System Provider Requirements

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -304,12 +304,12 @@ on how to develop a driver for Gremlin Server.
 By default, communication with Gremlin Server occurs over link:http://en.wikipedia.org/wiki/WebSocket[WebSockets] and
 exposes a custom sub-protocol for interacting with the server.
 
-[[connecting-via-console]]
-Connecting via Console
-~~~~~~~~~~~~~~~~~~~~~~
+[[starting-gremlin-server]]
+Starting Gremlin Server
+~~~~~~~~~~~~~~~~~~~~~~~
 
-The most direct way to get started with Gremlin Server is to issue it some remote Gremlin scripts from the Gremlin
-Console.  To do that, first start Gremlin Server:
+Gremlin Server comes packaged with a script called `bin/gremlin-server.sh` to get it started (use `gremlin-server.bat`
+on Windows):
 
 [source,text]
 ----
@@ -374,7 +374,12 @@ are global to all requests. In addition, any functions that are defined will be 
 WARNING: Transactions on graphs in initialization scripts are not closed automatically after the script finishes
 executing.  It is up to the script to properly commit or rollback transactions in the script itself.
 
-With Gremlin Server running it is now possible to issue some scripts to it for processing.  Start Gremlin Console as follows:
+[[connecting-via-console]]
+Connecting via Console
+~~~~~~~~~~~~~~~~~~~~~~
+
+With Gremlin Server running it is now possible to issue some scripts to it for processing.  Start Gremlin Console as
+follows:
 
 [source,text]
 ----
@@ -467,6 +472,10 @@ The Gremlin Server `:remote` command has the following configuration options:
 |timeout |Specifies the length of time in milliseconds that the remote will wait for a response from the server.
 |=========================================================
 
+[[console-aliases]]
+Aliases
+^^^^^^^
+
 The `alias` configuration command for the Gremlin Server `:remote` can be useful in situations where there are
 multiple `Graph` or `TraversalSource` instances on the server, as it becomes possible to rename them from the client
 for purposes of execution within the context of a script.  Therefore, it becomes possible to submit commands this way:
@@ -477,6 +486,35 @@ for purposes of execution within the context of a script.  Therefore, it becomes
 :remote config alias x g
 :> x.E().label().groupCount()
 ----
+
+[[console-sessions]]
+Sessions
+^^^^^^^^
+
+A `:remote` created in the following fashion will be "sessionless", meaning each script issued to the server with
+`:>` will be encased in a transaction and no state will be maintained from one request to the next.
+
+[gremlin-groovy]
+----
+:remote connect tinkerpop.server conf/remote-objects.yaml
+----
+
+In other words, the transaction will be automatically committed (or rolledback on error) and any variables declared
+in that script will be forgotten for the next request. See the section on <<sessions, "Considering Sessions">>
+for more information on that topic.
+
+To enable the remote to connect with a session the `connect` argument takes another argument as follows:
+
+[gremlin-groovy]
+----
+:remote connect tinkerpop.server conf/remote.yaml session
+:> x = 1
+:> y = 2
+:> x + y
+----
+
+With the above command a session gets created with a random UUID for a session identifier. It is also possible to
+assign a custom session identifier by adding it as the last argument to `:remote` command above.
 
 [[connecting-via-java]]
 Connecting via Java

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -456,7 +456,7 @@ submitting `:> graph` will return a `Graph` instance and in most cases those are
 and will return a serialization error.  It should be noted that `TinkerGraph`, as a convenience for shipping around
 small sub-graphs, is serializable from Gremlin Server.
 
-The Gremlin Server `:remote` command has the following configuration options:
+The Gremlin Server `:remote config` command for the driver has the following configuration options:
 
 [width="100%",cols="3,10a",options="header"]
 |=========================================================
@@ -469,7 +469,7 @@ The Gremlin Server `:remote` command has the following configuration options:
 !`reset` !Clears any aliases that were supplied in previous configurations of the remote.
 !`show` !Shows the current set of aliases which is returned as a `Map`
 !=========================================================
-|timeout |Specifies the length of time in milliseconds that the remote will wait for a response from the server.
+|timeout |Specifies the length of time in milliseconds a will wait for a response from the server.
 |=========================================================
 
 [[console-aliases]]
@@ -515,6 +515,36 @@ To enable the remote to connect with a session the `connect` argument takes anot
 
 With the above command a session gets created with a random UUID for a session identifier. It is also possible to
 assign a custom session identifier by adding it as the last argument to `:remote` command above.
+
+Remote Console
+^^^^^^^^^^^^^^
+
+Previous examples have shown usage of the `:>` command to send scripts to Gremlin Server. The Gremlin Console also
+supports an additional method for doing this which can be more convenient when the intention is to exclusively
+work with a remote connection to the server.
+
+[gremlin-groovy]
+----
+:remote connect tinkerpop.server conf/remote.yaml session
+:remote console
+x = 1
+y = 2
+x + y
+:remote console
+----
+
+In the above example, the `:remote console` command is executed. It places the console in a state where the `:>` is
+no longer required. Each script line is actually automatically submitted to Gremlin Server for evalaution. The
+variables `x` and `y` that were defined actually don't exist locally - they only exist on the server! In this sense,
+putting the console in this mode is basically like creating a window to a session on Gremlin Server.
+
+TIP: When using `:remote console` there is not much point to using a configuration that uses a serializer that returns
+actual data. In other words, using a configuration like the one inside of `conf/remote-objects.yaml` isn't typically
+useful as in this mode the result will only ever be displayed but not used. Using a serializer configuration like
+the one in `conf/remote.yaml` should perform better.
+
+NOTE: Console commands, those that begin with a colon (e.g. `:x`, `:remote`) do not execute remotely when in this mode.
+They are all still evaluated locally.
 
 [[connecting-via-java]]
 Connecting via Java

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -70,7 +70,7 @@ Plugins.  Consider adding the "local" reference first in the set of `<ibilio>` r
 "apache-snapshots" will likely resolve dependencies from that repository before looking locally.  If it does that,
 then it's possible that the artifact from the newer local build will not be used.
 
-CAUTION: If building TinkerPop from source, be sure to clear TinkerPop-related jars from the `~/.groovy/grapes`
+WARNING: If building TinkerPop from source, be sure to clear TinkerPop-related jars from the `~/.groovy/grapes`
 directory as they can become stale on some systems and not re-import properly from the local `.m2` after fresh rebuilds.
 
 [[gremlin-console]]
@@ -214,7 +214,7 @@ the Console classpath.  Plugins need to be "active" for their features to be ava
 <5> Again, to use the "tinkerpop.neo4j" plugin, it must be made "active" with `:plugin use`.
 <6> Now when the plugin list is displayed, the "tinkerpop.neo4j" plugin is displayed as "active".
 
-CAUTION: Plugins must be compatible with the version of the Gremlin Console (or Gremlin Server) being used.  Attempts
+WARNING: Plugins must be compatible with the version of the Gremlin Console (or Gremlin Server) being used.  Attempts
 to use incompatible versions cannot be guaranteed to work.  Moreover, be prepared for dependency conflicts in
 third-party plugins, that may only be resolved via manual jar removal from the `ext/{plugin}` directory.
 
@@ -761,7 +761,7 @@ curl -X POST -d "{\"gremlin\":\"100-x\", \"language\":\"gremlin-groovy\", \"bind
 By default this value is set to `gremlin-groovy`.  If using a `GET` operation, this value can be set as a query
 string argument with by setting the `language` key.
 
-CAUTION: Consider the size of the result of a submitted script being returned from the REST endpoint.  A script
+WARNING: Consider the size of the result of a submitted script being returned from the REST endpoint.  A script
 that iterates thousands of results will serialize each of those in memory into a single JSON result set.  It is
 quite possible that such a script will generate `OutOfMemoryError` exceptions on the server.  Consider the default
 WebSockets configuration, which supports streaming, if that type of use case is required.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -516,6 +516,7 @@ To enable the remote to connect with a session the `connect` argument takes anot
 With the above command a session gets created with a random UUID for a session identifier. It is also possible to
 assign a custom session identifier by adding it as the last argument to `:remote` command above.
 
+[[console-remote-console]]
 Remote Console
 ^^^^^^^^^^^^^^
 

--- a/docs/src/reference/implementations-hadoop.asciidoc
+++ b/docs/src/reference/implementations-hadoop.asciidoc
@@ -150,7 +150,7 @@ However, realize that the underlying HDFS files are not random access and thus, 
 is required. OLTP operations are useful for peeking into the graph prior to executing a long running OLAP job -- e.g.
 `g.V().valueMap().limit(10)`.
 
-CAUTION: OLTP operations on `HadoopGraph` are not efficient. They require linear scans to execute and are unreasonable
+WARNING: OLTP operations on `HadoopGraph` are not efficient. They require linear scans to execute and are unreasonable
 for large graphs. In such large graph situations, make use of <<traversalvertexprogram,TraversalVertexProgram>>
 which is the OLAP Gremlin machine.
 
@@ -229,7 +229,7 @@ etc.). Unfortunately, typically these dependencies are not to the same versions 
 it is best to *not* have both Spark and Giraph plugins loaded in the same console session nor in the same Java
 project (though intelligent `<exclusion>`-usage can help alleviate conflicts in a Java project).
 
-CAUTION: It is important to note that when doing an OLAP traversal, any resulting vertices, edges, or properties will be
+WARNING: It is important to note that when doing an OLAP traversal, any resulting vertices, edges, or properties will be
 attached to the source graph. For Hadoop-based graphs, this may lead to linear search times on massive graphs. Thus,
 if vertex, edge, or property objects are to be returns (as a final result), it is best to `.id()` to get the id
 of the object and not the actual attached object.

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -35,7 +35,7 @@ Neo4j-Gremlin
 
 link:http://neotechnology.com[Neo Technology] are the developers of the OLTP-based link:http://neo4j.org[Neo4j graph database].
 
-CAUTION: Unless under a commercial agreement with Neo Technology, Neo4j is licensed
+WARNING: Unless under a commercial agreement with Neo Technology, Neo4j is licensed
 link:http://en.wikipedia.org/wiki/Affero_General_Public_License[AGPL]. The `neo4j-gremlin` module is licensed Apache2
 because it only references the Apache2-licensed Neo4j API (not its implementation). Note that neither the
 <<gremlin-console,Gremlin Console>> nor <<gremlin-server,Gremlin Server>> distribute with the Neo4j implementation

--- a/docs/src/reference/intro.asciidoc
+++ b/docs/src/reference/intro.asciidoc
@@ -119,7 +119,7 @@ In the above code all the vertices are created first and then their respective e
 `Graph.addVertex(Object...)` or `Vertex.addEdge(String,Vertex,Object...)`, the respective element is created along
 with the provided key/value pair properties appended to it.
 
-CAUTION: Many graph systems do not allow the user to specify an element ID and in such cases, an exception is thrown.
+WARNING: Many graph systems do not allow the user to specify an element ID and in such cases, an exception is thrown.
 
 NOTE: In TinkerPop3, vertices are allowed a single immutable string label (similar to an edge label). This
 functionality did not exist in TinkerPop2. Element ids are still immutable in TinkerPop3 as they were in TinkerPop2.
@@ -133,7 +133,7 @@ in favor of a syntax that is more aligned with the syntax of Gremlin-Groovy in T
 and Gremlin-Groovy are nearly identical due to the inclusion of Java 8 lambdas, a big effort was made to ensure that
 both languages are as similar as possible.
 
-CAUTION: In the code examples presented throughout this documentation, either Gremlin-Java8 or Gremlin-Groovy is used.
+WARNING: In the code examples presented throughout this documentation, either Gremlin-Java8 or Gremlin-Groovy is used.
 It is possible to determine which derivative of Gremlin is being used by mousing over the code block.  The word "JAVA"
 or "GROOVY" will appear in the top right corner of the code block.
 
@@ -322,7 +322,7 @@ the current object being traversed, etc. Traverser metadata may be accessed by a
 g.V(marko).out('knows').values('name').path()
 ----
 
-CAUTION: Path calculation is costly in terms of space as an array of previously seen objects is stored in each path
+WARNING: Path calculation is costly in terms of space as an array of previously seen objects is stored in each path
 of the respective traverser. Thus, a traversal strategy analyzes the traversal to determine if path metadata is
 required. If not, then path calculations are turned off.
 
@@ -334,7 +334,7 @@ has gone through a particular section of the traversal expression (i.e. a loop).
 g.V(marko).repeat(out()).times(2).values('name')
 ----
 
-CAUTION: A Traversal's result are never ordered unless explicitly by means of <<order-step,`order()`>>-step. Thus,
+WARNING: A Traversal's result are never ordered unless explicitly by means of <<order-step,`order()`>>-step. Thus,
 never rely on the iteration order between TinkerPop3 releases and even within a release (as traversal optimizations
 may alter the flow).
 

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -408,10 +408,10 @@ applications outside of TinkerPop, GraphML may be the best choice to do that. Co
 As GraphML is a specification for the serialization of an entire graph and not the individual elements of a graph,
 methods that support input and output of single vertices, edges, etc. are not supported.
 
-CAUTION: GraphML is a "lossy" format in that it only supports primitive values for properties and does not have
+WARNING: GraphML is a "lossy" format in that it only supports primitive values for properties and does not have
 support for `Graph` variables.  It will use `toString` to serialize property values outside of those primitives.
 
-CAUTION: GraphML as a specification allows for `<edge>` and `<node>` elements to appear in any order.  Most software
+WARNING: GraphML as a specification allows for `<edge>` and `<node>` elements to appear in any order.  Most software
 that writes GraphML (including as TinkerPop's `GraphMLWriter`) write `<node>` elements before `<edge>` elements.  However it
 is important to note that `GraphMLReader` will read this data in order and order can matter.  This is because TinkerPop
 does not allow the vertex label to be changed after the vertex has been created.  Therefore, if an `<edge>` element
@@ -665,7 +665,7 @@ with graph data inside of the TinkerPop stack. A list of common use cases is pre
 * Serialization of individual graph elements to be sent over the network to another JVM.
 * Backups of in-memory graphs or subgraphs.
 
-CAUTION: When migrating between Gremlin Structure implementations, Kryo may not lose data, but it is important to
+WARNING: When migrating between Gremlin Structure implementations, Kryo may not lose data, but it is important to
 consider the features of each `Graph` and whether or not the data types supported in one will be supported in the
 other.  Failure to do so, may result in errors.
 

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -59,7 +59,7 @@ the verbose syntax `__.in()` and `__.as()` to avoid collisions.
 Lambda Steps
 ~~~~~~~~~~~~
 
-CAUTION: Lambda steps are presented for educational purposes as they represent the foundational constructs of the
+WARNING: Lambda steps are presented for educational purposes as they represent the foundational constructs of the
 Gremlin language. In practice, lambda steps should be avoided and traversal verification strategies exist to disallow t
 heir use unless explicitly "turned off." For more information on the problems with lambdas, please read
 <<a-note-on-lambdas,A Note on Lambdas>>.
@@ -1611,7 +1611,7 @@ g.V().hasLabel('song').out('sungBy').groupCount().by('name').select(values).unfo
 <2> Get an anonymized set of song repertoire sizes.
 <3> What are the 5 most common song repertoire sizes?
 
-CAUTION: Note that `by()`-modulation is not supported with `select(keys)` and `select(values)`.
+WARNING: Note that `by()`-modulation is not supported with `select(keys)` and `select(values)`.
 
 [[using-where-with-select]]
 Using Where with Select
@@ -2245,7 +2245,7 @@ t.iterate(); null
 t.toString()
 ----
 
-CAUTION: The reason that `OptimizationStrategy` and `ProviderOptimizationStrategy` are two different categories is
+WARNING: The reason that `OptimizationStrategy` and `ProviderOptimizationStrategy` are two different categories is
 that optimization strategies should only rewrite the traversal using TinkerPop3 steps. This ensures that the
 optimizations executed at the end of the optimization strategy round are TinkerPop3 compliant. From there, provider
 optimizations can analyze the traversal and rewrite the traversal as desired using graph system specific steps (e.g.
@@ -2324,7 +2324,7 @@ where the removed edge count is accounted for after the event is raised.  The st
 `TransactionalEventQueue` that captures the changes within a transaction and does not allow them to fire until the
 transaction is committed.
 
-CAUTION: `EventStrategy` is not meant for usage in tracking global mutations across separate processes.  In other
+WARNING: `EventStrategy` is not meant for usage in tracking global mutations across separate processes.  In other
 words, a mutation in one JVM process is not raised as an event in a different JVM process.  In addition, events are
 not raised when mutations occur outside of the `Traversal` context.
 

--- a/docs/src/upgrade/index.asciidoc
+++ b/docs/src/upgrade/index.asciidoc
@@ -33,6 +33,7 @@ These providers include:
 ** Graph Processor Provider
 * Graph Driver Provider
 * Graph Language Provider
+* Graph Plugin Provider
 
 include::release-3.1.x-incubating.asciidoc[]
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -135,6 +135,20 @@ this value as `false`, so there is no change to the protocol for this feature.
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1039[TINKERPOP-1039],
 link:http://tinkerpop.apache.org/docs/3.1.2-incubating/reference/#sessions[Reference Documentation - Considering Sessions]
 
+Plugin Providers
+^^^^^^^^^^^^^^^^
+
+RemoteAcceptor allowRemoteConsole
++++++++++++++++++++++++++++++++++
+
+The `RemoteAcceptor` now has a new method called `allowRemoteConsole()`.  It has a default implementation that
+returns `false` and should thus be a non-breaking change for current implementations.  This value should only be set
+to `true` if the implementation expects the user to always use `:>` to interact with it.  For example, the
+`tinkerpop.server` plugin expects all user interaction through `:>`, where the line is sent to Gremlin Server.  In
+that case, that `RemoteAcceptor` implementation can return `true`.  On the other hand, the `tinkerpop.gephi` plugin,
+expects that the user sometimes call `:>` and sometimes work with local evaluation as well. It interacts with the
+local variable bindings in the console itself. For `tinkerpop.gephi`, this method returns `false`.
+
 TinkerPop 3.1.1
 ---------------
 

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -40,6 +40,15 @@ use that capability with a session. That method is now properly implemented and 
 
 See: link:https://issues.apache.org/jira/browse/TINKERPOP-1096[TINKERPOP-1096]
 
+Remote Console
+^^^^^^^^^^^^^^
+
+The `:remote console` command provides a way to avoid having to prefix the `:>` command to scripts when remoting. This
+mode of console usage can be convenient when working exclusively with a remote like Gremlin Server and there is only a
+desire to view the returned data and not to actually work with it locally in any way.
+
+See: link:http://tinkerpop.apache.org/docs/3.1.2-incubating/reference/#console-remote-console[Reference Documentation - Remote Console]
+
 Console Remote Sessions
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -148,6 +157,8 @@ to `true` if the implementation expects the user to always use `:>` to interact 
 that case, that `RemoteAcceptor` implementation can return `true`.  On the other hand, the `tinkerpop.gephi` plugin,
 expects that the user sometimes call `:>` and sometimes work with local evaluation as well. It interacts with the
 local variable bindings in the console itself. For `tinkerpop.gephi`, this method returns `false`.
+
+See: link:http://tinkerpop.apache.org/docs/3.1.2-incubating/reference/#console-remote-console[Reference Documentation - Remote Console]
 
 TinkerPop 3.1.1
 ---------------

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -32,6 +32,23 @@ Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.1.2-inc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Aliasing Sessions
+^^^^^^^^^^^^^^^^^
+
+Calls to `SessionedClient.alias()` used to throw `UnsupportedOperationException` and it was therefore not possible to
+use that capability with a session. That method is now properly implemented and aliasing is allowed.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1096[TINKERPOP-1096]
+
+Console Remote Sessions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The `:remote tinkerpop.server` command now allows for a "session" argument to be passed to `connect`. This argument,
+tells the remote to configure it with a Gremlin Server session. In this way, the console can act as a window to script
+exception on the server and behave more like a standard "local" console when it comes to script execution.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1097[TINKERPOP-1097]
+
 TinkerPop Archetypes
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -70,7 +70,7 @@ class Console {
     private Iterator tempIterator = Collections.emptyIterator()
 
     private final IO io = new IO(System.in, System.out, System.err)
-    private final Groovysh groovy = new GremlinGroovysh()
+    private final Groovysh groovy
 
     public Console(final String initScriptFile) {
         io.out.println()
@@ -88,6 +88,8 @@ class Console {
         })
 
         final Mediator mediator = new Mediator(this)
+        groovy = new GremlinGroovysh(mediator)
+
         def commandsToRemove = groovy.getRegistry().commands().findAll{it instanceof SetCommand}
         commandsToRemove.each {groovy.getRegistry().remove(it)}
         groovy.register(new GremlinSetCommand(groovy))

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
@@ -30,8 +30,10 @@ class Mediator {
     public final Map<String, PluggedIn> availablePlugins = [:]
     public final List<RemoteAcceptor> remotes = []
     public int position
+    public boolean localEvaluation = true
 
     private final Console console
+
 
     private static String FILE_SEP = System.getProperty("file.separator")
     private static String LINE_SEP = System.getProperty("line.separator")
@@ -72,8 +74,6 @@ class Mediator {
     def showShellEvaluationOutput(final boolean show) {
         console.showShellEvaluationOutput(show)
     }
-
-    def submit(final List<String> args) throws Exception { return currentRemote().submit(args) }
 
     def writePluginState() {
         def file = new File(PLUGIN_CONFIG_FILE)

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -117,6 +117,8 @@ class RemoteCommand extends ComplexCommandSupport {
 
     def Object do_console = {
         if (mediator.remotes.size() == 0) return "Please add a remote first with [connect]"
+        if (!mediator.currentRemote().allowRemoteConsole()) return "The ${mediator.currentRemote()} is not compatible with 'connect' - use ':>' instead"
+
         mediator.localEvaluation = !mediator.localEvaluation
         if (mediator.localEvaluation)
             return "Exited remote console - all commands will be evaluated locally"

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -113,7 +113,7 @@ class RemoteCommand extends ComplexCommandSupport {
 
         // the console is in remote evaluation mode.  closing at this point will needs to exit that mode and then
         // kill the remote itself
-        def line = !mediator.localEvaluation ? swapEvalautionMode() : ""
+        def line = !mediator.localEvaluation ? swapEvaluationMode() : ""
 
         def removed = mediator.removeCurrent()
         removed.close()
@@ -123,10 +123,10 @@ class RemoteCommand extends ComplexCommandSupport {
     def Object do_console = {
         if (mediator.remotes.size() == 0) return "Please add a remote first with [connect]"
         if (!mediator.currentRemote().allowRemoteConsole()) return "The ${mediator.currentRemote()} is not compatible with 'connect' - use ':>' instead"
-        return swapEvalautionMode()
+        return swapEvaluationMode()
     }
 
-    private String swapEvalautionMode() {
+    private String swapEvaluationMode() {
         mediator.localEvaluation = !mediator.localEvaluation
         if (mediator.localEvaluation)
             return "Exited remote console - all scripts will now be evaluated locally"

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -33,7 +33,7 @@ class RemoteCommand extends ComplexCommandSupport {
     private final Mediator mediator
 
     public RemoteCommand(final Groovysh shell, final Mediator mediator) {
-        super(shell, ":remote", ":rem", ["current", "connect", "config", "list", "next", "prev", "choose", "close"], "current")
+        super(shell, ":remote", ":rem", ["current", "connect", "config", "list", "next", "prev", "choose", "close", "console"], "current")
         this.mediator = mediator
     }
 
@@ -113,5 +113,14 @@ class RemoteCommand extends ComplexCommandSupport {
         def removed = mediator.removeCurrent()
         removed.close()
         return "Removed - $removed"
+    }
+
+    def Object do_console = {
+        if (mediator.remotes.size() == 0) return "Please add a remote first with [connect]"
+        mediator.localEvaluation = !mediator.localEvaluation
+        if (mediator.localEvaluation)
+            return "Exited remote console - all commands will be evaluated locally"
+        else
+            return "All commands will now be sent to ${mediator.currentRemote()} - type ':remote console' to exit"
     }
 }

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -110,15 +110,23 @@ class RemoteCommand extends ComplexCommandSupport {
 
     def Object do_close = {
         if (mediator.remotes.size() == 0) return "Please add a remote first with [connect]"
+
+        // the console is in remote evaluation mode.  closing at this point will needs to exit that mode and then
+        // kill the remote itself
+        def line = !mediator.localEvaluation ? swapEvalautionMode() : ""
+
         def removed = mediator.removeCurrent()
         removed.close()
-        return "Removed - $removed"
+        return line.isEmpty() ? "Removed - $removed" : "$line and removed - $removed"
     }
 
     def Object do_console = {
         if (mediator.remotes.size() == 0) return "Please add a remote first with [connect]"
         if (!mediator.currentRemote().allowRemoteConsole()) return "The ${mediator.currentRemote()} is not compatible with 'connect' - use ':>' instead"
+        return swapEvalautionMode()
+    }
 
+    private String swapEvalautionMode() {
         mediator.localEvaluation = !mediator.localEvaluation
         if (mediator.localEvaluation)
             return "Exited remote console - all commands will be evaluated locally"

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/RemoteCommand.groovy
@@ -129,8 +129,8 @@ class RemoteCommand extends ComplexCommandSupport {
     private String swapEvalautionMode() {
         mediator.localEvaluation = !mediator.localEvaluation
         if (mediator.localEvaluation)
-            return "Exited remote console - all commands will be evaluated locally"
+            return "Exited remote console - all scripts will now be evaluated locally"
         else
-            return "All commands will now be sent to ${mediator.currentRemote()} - type ':remote console' to exit"
+            return "All scripts will now be sent to ${mediator.currentRemote()} - type ':remote console' to exit"
     }
 }

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptor.java
@@ -187,6 +187,11 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
     }
 
     @Override
+    public boolean allowRemoteConsole() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "Gremlin Server - [" + this.currentCluster + "]" + getSessionStringSegment();
     }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
@@ -118,4 +118,22 @@ public class DriverRemoteAcceptorIntegrateTest extends AbstractGremlinServerInte
         assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("g.traversal().V().drop().iterate();null")))), contains("null"));
         assertThat(((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).stream().map(Result::getObject).collect(Collectors.toList()), contains("null"));
     }
+
+    @Test
+    public void shouldConnectAndSubmitInSession() throws Exception {
+        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath(), "session")).toString(), startsWith("Connected - "));
+        assertEquals("2", ((Iterator) acceptor.submit(Arrays.asList("x=1+1"))).next());
+        assertEquals("2", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
+        assertEquals("4", ((Iterator) acceptor.submit(Arrays.asList("x+2"))).next());
+        assertEquals("4", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
+    }
+
+    @Test
+    public void shouldConnectAndSubmitInNamedSession() throws Exception {
+        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath(), "session", "AAA")).toString(), startsWith("Connected - "));
+        assertEquals("2", ((Iterator) acceptor.submit(Arrays.asList("x=1+1"))).next());
+        assertEquals("2", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
+        assertEquals("4", ((Iterator) acceptor.submit(Arrays.asList("x+2"))).next());
+        assertEquals("4", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
+    }
 }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorIntegrateTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,60 +81,68 @@ public class DriverRemoteAcceptorIntegrateTest extends AbstractGremlinServerInte
 
     @Test
     public void shouldConnect() throws Exception {
-        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+    }
+
+    @Test
+    public void shouldConnectAndSubmitSession() throws Exception {
+        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath(), "session")).toString(), startsWith("Connected - "));
+        assertEquals("1", ((Iterator) acceptor.submit(Collections.singletonList("x = 1"))).next());
+        assertEquals("0", ((Iterator) acceptor.submit(Collections.singletonList("x - 1"))).next());
+        assertEquals("0", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
     }
 
     @Test
     public void shouldConnectAndSubmitSimple() throws Exception {
-        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
-        assertEquals("2", ((Iterator) acceptor.submit(Arrays.asList("1+1"))).next());
+        assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        assertEquals("2", ((Iterator) acceptor.submit(Collections.singletonList("1+1"))).next());
         assertEquals("2", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
     }
 
     @Test
     public void shouldConnectAndSubmitSimpleList() throws Exception {
-        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
-        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("[1,2,3,4,5]")))), contains("1", "2", "3", "4", "5"));
+        assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Collections.singletonList("[1,2,3,4,5]")))), contains("1", "2", "3", "4", "5"));
         assertThat(((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).stream().map(Result::getString).collect(Collectors.toList()), contains("1", "2", "3", "4", "5"));
     }
 
     @Test
     public void shouldConnectAndReturnVertices() throws Exception {
-        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
-        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("g.addVertex('name','stephen');g.addVertex('name','marko');g.traversal().V()")))), hasSize(2));
+        assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Collections.singletonList("g.addVertex('name','stephen');g.addVertex('name','marko');g.traversal().V()")))), hasSize(2));
         assertThat(((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).stream().map(Result::getString).collect(Collectors.toList()), hasSize(2));
     }
 
     @Test
     public void shouldConnectAndReturnVerticesWithAnAlias() throws Exception {
-        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
         acceptor.configure(Arrays.asList("alias", "x", "g"));
-        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("x.addVertex('name','stephen');x.addVertex('name','marko');x.traversal().V()")))), hasSize(2));
+        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Collections.singletonList("x.addVertex('name','stephen');x.addVertex('name','marko');x.traversal().V()")))), hasSize(2));
         assertThat(((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).stream().map(Result::getString).collect(Collectors.toList()), hasSize(2));
     }
 
     @Test
     public void shouldConnectAndSubmitForNull() throws Exception {
-        assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
-        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Arrays.asList("g.traversal().V().drop().iterate();null")))), contains("null"));
+        assertThat(acceptor.connect(Collections.singletonList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath())).toString(), startsWith("Connected - "));
+        assertThat(IteratorUtils.list(((Iterator<String>) acceptor.submit(Collections.singletonList("g.traversal().V().drop().iterate();null")))), contains("null"));
         assertThat(((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).stream().map(Result::getObject).collect(Collectors.toList()), contains("null"));
     }
 
     @Test
     public void shouldConnectAndSubmitInSession() throws Exception {
         assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath(), "session")).toString(), startsWith("Connected - "));
-        assertEquals("2", ((Iterator) acceptor.submit(Arrays.asList("x=1+1"))).next());
+        assertEquals("2", ((Iterator) acceptor.submit(Collections.singletonList("x=1+1"))).next());
         assertEquals("2", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
-        assertEquals("4", ((Iterator) acceptor.submit(Arrays.asList("x+2"))).next());
+        assertEquals("4", ((Iterator) acceptor.submit(Collections.singletonList("x+2"))).next());
         assertEquals("4", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
     }
 
     @Test
     public void shouldConnectAndSubmitInNamedSession() throws Exception {
         assertThat(acceptor.connect(Arrays.asList(TestHelper.generateTempFileFromResource(this.getClass(), "remote.yaml", ".tmp").getAbsolutePath(), "session", "AAA")).toString(), startsWith("Connected - "));
-        assertEquals("2", ((Iterator) acceptor.submit(Arrays.asList("x=1+1"))).next());
+        assertEquals("2", ((Iterator) acceptor.submit(Collections.singletonList("x=1+1"))).next());
         assertEquals("2", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
-        assertEquals("4", ((Iterator) acceptor.submit(Arrays.asList("x+2"))).next());
+        assertEquals("4", ((Iterator) acceptor.submit(Collections.singletonList("x+2"))).next());
         assertEquals("4", ((List<Result>) groovysh.getInterp().getContext().getProperty(DriverRemoteAcceptor.RESULT)).iterator().next().getString());
     }
 }

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/GephiRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/GephiRemoteAcceptorIntegrateTest.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.console.groovy.plugin;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.tinkerpop.gremlin.console.GremlinGroovysh;
+import org.apache.tinkerpop.gremlin.console.Mediator;
 import org.apache.tinkerpop.gremlin.console.plugin.GephiRemoteAcceptor;
 import org.apache.tinkerpop.gremlin.groovy.plugin.RemoteException;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -55,7 +56,7 @@ import static org.junit.Assert.assertThat;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GephiRemoteAcceptorIntegrateTest {
-    private static final Groovysh groovysh = new GremlinGroovysh();
+    private static final Groovysh groovysh = new GremlinGroovysh(new Mediator(null));
     private static int port = pickOpenPort();
 
     private GephiRemoteAcceptor acceptor;

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -91,8 +91,9 @@ public abstract class Client {
      * @deprecated As of release 3.1.0, replaced by {@link #alias(String)}
      */
     @Deprecated
-    public abstract Client rebind(final String graphOrTraversalSource);
-
+    public Client rebind(final String graphOrTraversalSource) {
+        return alias(graphOrTraversalSource);
+    }
 
     /**
      * Create a new {@code Client} that aliases the specified {@link Graph} or {@link TraversalSource} name on the
@@ -100,7 +101,28 @@ public abstract class Client {
      *
      * @param graphOrTraversalSource rebinds the specified global Gremlin Server variable to "g"
      */
-    public abstract Client alias(final String graphOrTraversalSource);
+    public Client alias(String graphOrTraversalSource) {
+        return new AliasClusteredClient(this, graphOrTraversalSource);
+    }
+
+    /**
+     * Creates a {@code Client} that supplies the specified set of aliases, thus allowing the user to re-name
+     * one or more globally defined {@link Graph} or {@link TraversalSource} server bindings for the context of
+     * the created {@code Client}.
+     */
+    @Deprecated
+    public Client rebind(final Map<String,String> rebindings) {
+        return alias(rebindings);
+    }
+
+    /**
+     * Creates a {@code Client} that supplies the specified set of aliases, thus allowing the user to re-name
+     * one or more globally defined {@link Graph} or {@link TraversalSource} server bindings for the context of
+     * the created {@code Client}.
+     */
+    public Client alias(final Map<String,String> aliases) {
+        return new AliasClusteredClient(this, aliases);
+    }
 
     /**
      * Initializes the client which typically means that a connection is established to the server.  Depending on the
@@ -175,6 +197,52 @@ public abstract class Client {
     }
 
     /**
+     * The asynchronous version of {@link #submit(String, Map)}} where the returned future will complete when the
+     * write of the request completes.
+     *
+     * @param gremlin the gremlin script to execute
+     * @param parameters a map of parameters that will be bound to the script on execution
+     * @param graphOrTraversalSource rebinds the specified global Gremlin Server variable to "g"
+     */
+    public CompletableFuture<ResultSet> submitAsync(final String gremlin, final String graphOrTraversalSource,
+                                                    final Map<String, Object> parameters) {
+        final RequestMessage.Builder request = RequestMessage.build(Tokens.OPS_EVAL)
+                .add(Tokens.ARGS_GREMLIN, gremlin)
+                .add(Tokens.ARGS_BATCH_SIZE, cluster.connectionPoolSettings().resultIterationBatchSize);
+
+        Optional.ofNullable(parameters).ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, parameters));
+
+        if (graphOrTraversalSource != null && !graphOrTraversalSource.isEmpty())
+            request.addArg(Tokens.ARGS_ALIASES, makeAliases(graphOrTraversalSource));
+
+        return submitAsync(buildMessage(request));
+    }
+
+    /**
+     * The asynchronous version of {@link #submit(String, Map)}} where the returned future will complete when the
+     * write of the request completes.
+     *
+     * @param gremlin the gremlin script to execute
+     * @param parameters a map of parameters that will be bound to the script on execution
+     * @param aliases aliases the specified global Gremlin Server variable some other name that then be used in the
+     *                script where the key is the alias name and the value represents the global variable on the
+     *                server
+     */
+    public CompletableFuture<ResultSet> submitAsync(final String gremlin, final Map<String,String> aliases,
+                                                    final Map<String, Object> parameters) {
+        final RequestMessage.Builder request = RequestMessage.build(Tokens.OPS_EVAL)
+                .add(Tokens.ARGS_GREMLIN, gremlin)
+                .add(Tokens.ARGS_BATCH_SIZE, cluster.connectionPoolSettings().resultIterationBatchSize);
+
+        Optional.ofNullable(parameters).ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, parameters));
+
+        if (aliases != null && !aliases.isEmpty())
+            request.addArg(Tokens.ARGS_ALIASES, aliases);
+
+        return submitAsync(buildMessage(request));
+    }
+
+    /**
      * A low-level method that allows the submission of a manually constructed {@link RequestMessage}.
      */
     public CompletableFuture<ResultSet> submitAsync(final RequestMessage msg) {
@@ -207,6 +275,12 @@ public abstract class Client {
      */
     public void close() {
         closeAsync().join();
+    }
+
+    private Map<String,String> makeAliases(final String graphOrTraversalSource) {
+        final Map<String,String> aliases = new HashMap<>();
+        aliases.put("g", graphOrTraversalSource);
+        return aliases;
     }
 
     /**
@@ -248,88 +322,6 @@ public abstract class Client {
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
-        }
-
-        /**
-         * The asynchronous version of {@link #submit(String, Map)}} where the returned future will complete when the
-         * write of the request completes.
-         *
-         * @param gremlin the gremlin script to execute
-         * @param parameters a map of parameters that will be bound to the script on execution
-         * @param graphOrTraversalSource rebinds the specified global Gremlin Server variable to "g"
-         */
-        public CompletableFuture<ResultSet> submitAsync(final String gremlin, final String graphOrTraversalSource,
-                                                        final Map<String, Object> parameters) {
-            final RequestMessage.Builder request = RequestMessage.build(Tokens.OPS_EVAL)
-                    .add(Tokens.ARGS_GREMLIN, gremlin)
-                    .add(Tokens.ARGS_BATCH_SIZE, cluster.connectionPoolSettings().resultIterationBatchSize);
-
-            Optional.ofNullable(parameters).ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, parameters));
-
-            if (graphOrTraversalSource != null && !graphOrTraversalSource.isEmpty())
-                request.addArg(Tokens.ARGS_ALIASES, makeRebindings(graphOrTraversalSource));
-
-            return submitAsync(buildMessage(request));
-        }
-
-        /**
-         * The asynchronous version of {@link #submit(String, Map)}} where the returned future will complete when the
-         * write of the request completes.
-         *
-         * @param gremlin the gremlin script to execute
-         * @param parameters a map of parameters that will be bound to the script on execution
-         * @param aliases aliases the specified global Gremlin Server variable some other name that then be used in the
-         *                script where the key is the alias name and the value represents the global variable on the
-         *                server
-         */
-        public CompletableFuture<ResultSet> submitAsync(final String gremlin, final Map<String,String> aliases,
-                                                        final Map<String, Object> parameters) {
-            final RequestMessage.Builder request = RequestMessage.build(Tokens.OPS_EVAL)
-                    .add(Tokens.ARGS_GREMLIN, gremlin)
-                    .add(Tokens.ARGS_BATCH_SIZE, cluster.connectionPoolSettings().resultIterationBatchSize);
-
-            Optional.ofNullable(parameters).ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, parameters));
-
-            if (aliases != null && !aliases.isEmpty())
-                request.addArg(Tokens.ARGS_ALIASES, aliases);
-
-            return submitAsync(buildMessage(request));
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        @Deprecated
-        public Client rebind(final String graphOrTraversalSource) {
-            return alias(graphOrTraversalSource);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public Client alias(String graphOrTraversalSource) {
-            return new AliasClusteredClient(this, graphOrTraversalSource);
-        }
-
-        /**
-         * Creates a {@code Client} that supplies the specified set of aliases, thus allowing the user to re-name
-         * one or more globally defined {@link Graph} or {@link TraversalSource} server bindings for the context of
-         * the created {@code Client}.
-         */
-        @Deprecated
-        public Client rebind(final Map<String,String> rebindings) {
-            return alias(rebindings);
-        }
-
-        /**
-         * Creates a {@code Client} that supplies the specified set of aliases, thus allowing the user to re-name
-         * one or more globally defined {@link Graph} or {@link TraversalSource} server bindings for the context of
-         * the created {@code Client}.
-         */
-        public Client alias(final Map<String,String> aliases) {
-            return new AliasClusteredClient(this, aliases);
         }
 
         /**
@@ -378,12 +370,6 @@ public abstract class Client {
             hostConnectionPools.values().stream().map(ConnectionPool::closeAsync).collect(Collectors.toList()).toArray(poolCloseFutures);
             return CompletableFuture.allOf(poolCloseFutures);
         }
-
-        private Map<String,String> makeRebindings(final String graphOrTraversalSource) {
-            final Map<String,String> rebindings = new HashMap<>();
-            rebindings.put("g", graphOrTraversalSource);
-            return rebindings;
-        }
     }
 
     /**
@@ -391,11 +377,11 @@ public abstract class Client {
      * specified {@link Graph} or {@link TraversalSource} instances on the server-side.
      */
     public final static class AliasClusteredClient extends ReboundClusteredClient {
-        public AliasClusteredClient(ClusteredClient clusteredClient, String graphOrTraversalSource) {
+        public AliasClusteredClient(Client clusteredClient, String graphOrTraversalSource) {
             super(clusteredClient, graphOrTraversalSource);
         }
 
-        public AliasClusteredClient(ClusteredClient clusteredClient, Map<String, String> rebindings) {
+        public AliasClusteredClient(Client clusteredClient, Map<String, String> rebindings) {
             super(clusteredClient, rebindings);
         }
     }
@@ -408,19 +394,19 @@ public abstract class Client {
      */
     @Deprecated
     public static class ReboundClusteredClient extends Client {
-        private final ClusteredClient clusteredClient;
+        private final Client client;
         private final Map<String,String> aliases = new HashMap<>();
         final CompletableFuture<Void> close = new CompletableFuture<>();
 
-        ReboundClusteredClient(final ClusteredClient clusteredClient, final String graphOrTraversalSource) {
-            super(clusteredClient.cluster);
-            this.clusteredClient = clusteredClient;
+        ReboundClusteredClient(final Client client, final String graphOrTraversalSource) {
+            super(client.cluster);
+            this.client = client;
             aliases.put("g", graphOrTraversalSource);
         }
 
-        ReboundClusteredClient(final ClusteredClient clusteredClient, final Map<String,String> rebindings) {
-            super(clusteredClient.cluster);
-            this.clusteredClient = clusteredClient;
+        ReboundClusteredClient(final Client client, final Map<String,String> rebindings) {
+            super(client.cluster);
+            this.client = client;
             this.aliases.putAll(rebindings);
         }
 
@@ -429,7 +415,7 @@ public abstract class Client {
             if (close.isDone()) throw new IllegalStateException("Client is closed");
 
             // the underlying client may not have been init'd
-            clusteredClient.init();
+            client.init();
 
             return this;
         }
@@ -455,7 +441,7 @@ public abstract class Client {
         @Override
         protected Connection chooseConnection(final RequestMessage msg) throws TimeoutException, ConnectionException {
             if (close.isDone()) throw new IllegalStateException("Client is closed");
-            return clusteredClient.chooseConnection(msg);
+            return client.chooseConnection(msg);
         }
 
         /**
@@ -483,7 +469,7 @@ public abstract class Client {
         @Override
         public Client alias(String graphOrTraversalSource) {
             if (close.isDone()) throw new IllegalStateException("Client is closed");
-            return new AliasClusteredClient(clusteredClient, graphOrTraversalSource);
+            return new AliasClusteredClient(client, graphOrTraversalSource);
         }
     }
 
@@ -506,28 +492,6 @@ public abstract class Client {
 
         String getSessionId() {
             return sessionId;
-        }
-
-        /**
-         * The sessioned client does not support this feature.
-         *
-         * @throws UnsupportedOperationException
-         * @deprecated As of release 3.1.0, replaced by {@link #alias(String)}
-         */
-        @Deprecated
-        @Override
-        public Client rebind(final String graphOrTraversalSourceName){
-            throw new UnsupportedOperationException("Sessioned client does not support aliasing");
-        }
-
-        /**
-         * The sessioned client does not support this feature.
-         *
-         * @throws UnsupportedOperationException
-         */
-        @Override
-        public Client alias(String graphOrTraversalSource) {
-            throw new UnsupportedOperationException("Sessioned client does not support aliasing");
         }
 
         /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Client.java
@@ -61,11 +61,10 @@ public abstract class Client {
     /**
      * Makes any final changes to the builder and returns the constructed {@link RequestMessage}.  Implementers
      * may choose to override this message to append data to the request before sending.  By default, this method
-     * will simply call the {@link org.apache.tinkerpop.gremlin.driver.message.RequestMessage.Builder#create()} and return
-     * the {@link RequestMessage}.
+     * will simply return the {@code builder} passed in by the caller.
      */
-    public RequestMessage buildMessage(final RequestMessage.Builder builder) {
-        return builder.create();
+    public RequestMessage.Builder buildMessage(final RequestMessage.Builder builder) {
+        return builder;
     }
 
     /**
@@ -193,7 +192,7 @@ public abstract class Client {
 
         Optional.ofNullable(parameters).ifPresent(params -> request.addArg(Tokens.ARGS_BINDINGS, parameters));
 
-        return submitAsync(buildMessage(request));
+        return submitAsync(buildMessage(request).create());
     }
 
     /**
@@ -215,7 +214,7 @@ public abstract class Client {
         if (graphOrTraversalSource != null && !graphOrTraversalSource.isEmpty())
             request.addArg(Tokens.ARGS_ALIASES, makeAliases(graphOrTraversalSource));
 
-        return submitAsync(buildMessage(request));
+        return submitAsync(buildMessage(request).create());
     }
 
     /**
@@ -239,7 +238,7 @@ public abstract class Client {
         if (aliases != null && !aliases.isEmpty())
             request.addArg(Tokens.ARGS_ALIASES, aliases);
 
-        return submitAsync(buildMessage(request));
+        return submitAsync(buildMessage(request).create());
     }
 
     /**
@@ -421,12 +420,12 @@ public abstract class Client {
         }
 
         @Override
-        public RequestMessage buildMessage(final RequestMessage.Builder builder) {
+        public RequestMessage.Builder buildMessage(final RequestMessage.Builder builder) {
             if (close.isDone()) throw new IllegalStateException("Client is closed");
             if (!aliases.isEmpty())
                 builder.addArg(Tokens.ARGS_ALIASES, aliases);
 
-            return builder.create();
+            return client.buildMessage(builder);
         }
 
         @Override
@@ -498,11 +497,11 @@ public abstract class Client {
          * Adds the {@link Tokens#ARGS_SESSION} value to every {@link RequestMessage}.
          */
         @Override
-        public RequestMessage buildMessage(final RequestMessage.Builder builder) {
+        public RequestMessage.Builder buildMessage(final RequestMessage.Builder builder) {
             builder.processor("session");
             builder.addArg(Tokens.ARGS_SESSION, sessionId);
             builder.addArg(Tokens.ARGS_MANAGE_TRANSACTION, manageTransactions);
-            return builder.create();
+            return builder;
         }
 
         /**

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -257,7 +257,7 @@ final class Connection {
         if (shutdownInitiated.compareAndSet(false, true)) {
             if (client instanceof Client.SessionedClient) {
                 // maybe this should be delegated back to the Client implementation???
-                final RequestMessage closeMessage = client.buildMessage(RequestMessage.build(Tokens.OPS_CLOSE));
+                final RequestMessage closeMessage = client.buildMessage(RequestMessage.build(Tokens.OPS_CLOSE)).create();
                 final CompletableFuture<ResultSet> closed = new CompletableFuture<>();
                 write(closeMessage, closed);
 

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/plugin/RemoteAcceptor.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/plugin/RemoteAcceptor.java
@@ -66,6 +66,22 @@ public interface RemoteAcceptor extends Closeable {
     public Object submit(final List<String> args) throws RemoteException;
 
     /**
+     * If the {@code RemoteAcceptor} is used in the Gremlin Console, then this method might be called to determine
+     * if it can be used in a fashion that supports the {@code :remote console} command.  By default, this value is
+     * set to {@code false}.
+     * <p/>
+     * A {@code RemoteAcceptor} should only return {@code true} for this method if it expects that all activities it
+     * supports are executed through the {@code :sumbit} command. If the users interaction with the remote requires
+     * working with both local and remote evaluation at the same time, it is likely best to keep this method return
+     * {@code false}. A good example of this type of plugin would be the Gephi Plugin which uses {@code :remote config}
+     * to configure a local {@code TraversalSource} to be used and expects calls to {@code :submit} for the same body
+     * of analysis.
+     */
+    public default boolean allowRemoteConsole() {
+        return false;
+    }
+
+    /**
      * Retrieve a script as defined in the shell context.  This allows for multi-line scripts to be submitted.
      */
     public static String getScript(final String submittedScript, final Groovysh shell) {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -1070,12 +1070,14 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
         }
 
         // keep the testing here until "rebind" is completely removed
-        final Client reboundLegacy = cluster.connect().rebind("graph");
-        final Vertex vLegacy = reboundLegacy.submit("g.addVertex('name','stephen')").all().get().get(0).getVertex();
+        final Client reboundLegacy = client.rebind("graph");
+        assertEquals("stephen", reboundLegacy.submit("n='stephen'").all().get().get(0).getString());
+        final Vertex vLegacy = reboundLegacy.submit("g.addVertex('name',n)").all().get().get(0).getVertex();
         assertEquals("stephen", vLegacy.value("name"));
 
-        final Client rebound = cluster.connect().alias("graph");
-        final Vertex v = rebound.submit("g.addVertex('name','jason')").all().get().get(0).getVertex();
+        final Client aliased = client.alias("graph");
+        assertEquals("jason", reboundLegacy.submit("n='jason'").all().get().get(0).getString());
+        final Vertex v = aliased.submit("g.addVertex('name',n)").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
 
         cluster.close();
@@ -1098,11 +1100,13 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
         // keep the testing here until "rebind" is completely removed
         final Client clientLegacy = client.rebind("g1");
-        final Vertex vLegacy = clientLegacy.submit("g.addV('name','stephen')").all().get().get(0).getVertex();
+        assertEquals("stephen", clientLegacy.submit("n='stephen'").all().get().get(0).getString());
+        final Vertex vLegacy = clientLegacy.submit("g.addV('name',n)").all().get().get(0).getVertex();
         assertEquals("stephen", vLegacy.value("name"));
 
         final Client clientAliased = client.alias("g1");
-        final Vertex v = clientAliased.submit("g.addV('name','jason')").all().get().get(0).getVertex();
+        assertEquals("jason", clientAliased.submit("n='jason'").all().get().get(0).getString());
+        final Vertex v = clientAliased.submit("g.addV('name',n)").all().get().get(0).getVertex();
         assertEquals("jason", v.value("name"));
 
         cluster.close();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinDriverIntegrateTest.java
@@ -89,6 +89,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
         switch (nameOfTest) {
             case "shouldAliasTraversalSourceVariables":
+            case "shouldAliasTraversalSourceVariablesInSession":
                 try {
                     final String p = TestHelper.generateTempFileFromResource(
                             GremlinDriverIntegrateTest.class, "generate-shouldRebindTraversalSourceVariables.groovy", "").getAbsolutePath();
@@ -672,6 +673,7 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
 
         cluster.close();
     }
+
     @Test
     public void shouldNotThrowNoSuchElementException() throws Exception {
         final Cluster cluster = Cluster.open();
@@ -1029,6 +1031,60 @@ public class GremlinDriverIntegrateTest extends AbstractGremlinServerIntegration
     public void shouldAliasTraversalSourceVariables() throws Exception {
         final Cluster cluster = Cluster.build().create();
         final Client client = cluster.connect();
+
+        try {
+            client.submit("g.addV('name','stephen')").all().get().get(0).getVertex();
+            fail("Should have tossed an exception because \"g\" is readonly in this context");
+        } catch (Exception ex) {
+            final Throwable root = ExceptionUtils.getRootCause(ex);
+            assertThat(root, instanceOf(ResponseException.class));
+            final ResponseException re = (ResponseException) root;
+            assertEquals(ResponseStatusCode.SERVER_ERROR, re.getResponseStatusCode());
+        }
+
+        // keep the testing here until "rebind" is completely removed
+        final Client clientLegacy = client.rebind("g1");
+        final Vertex vLegacy = clientLegacy.submit("g.addV('name','stephen')").all().get().get(0).getVertex();
+        assertEquals("stephen", vLegacy.value("name"));
+
+        final Client clientAliased = client.alias("g1");
+        final Vertex v = clientAliased.submit("g.addV('name','jason')").all().get().get(0).getVertex();
+        assertEquals("jason", v.value("name"));
+
+        cluster.close();
+    }
+
+    @Test
+    public void shouldAliasGraphVariablesInSession() throws Exception {
+        final Cluster cluster = Cluster.build().create();
+        final Client client = cluster.connect(name.getMethodName());
+
+        try {
+            client.submit("g.addVertex('name','stephen');").all().get().get(0).getVertex();
+            fail("Should have tossed an exception because \"g\" does not have the addVertex method under default config");
+        } catch (Exception ex) {
+            final Throwable root = ExceptionUtils.getRootCause(ex);
+            assertThat(root, instanceOf(ResponseException.class));
+            final ResponseException re = (ResponseException) root;
+            assertEquals(ResponseStatusCode.SERVER_ERROR_SCRIPT_EVALUATION, re.getResponseStatusCode());
+        }
+
+        // keep the testing here until "rebind" is completely removed
+        final Client reboundLegacy = cluster.connect().rebind("graph");
+        final Vertex vLegacy = reboundLegacy.submit("g.addVertex('name','stephen')").all().get().get(0).getVertex();
+        assertEquals("stephen", vLegacy.value("name"));
+
+        final Client rebound = cluster.connect().alias("graph");
+        final Vertex v = rebound.submit("g.addVertex('name','jason')").all().get().get(0).getVertex();
+        assertEquals("jason", v.value("name"));
+
+        cluster.close();
+    }
+
+    @Test
+    public void shouldAliasTraversalSourceVariablesInSession() throws Exception {
+        final Cluster cluster = Cluster.build().create();
+        final Client client = cluster.connect(name.getMethodName());
 
         try {
             client.submit("g.addV('name','stephen')").all().get().get(0).getVertex();

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/groovy/plugin/HadoopRemoteAcceptor.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/groovy/plugin/HadoopRemoteAcceptor.java
@@ -108,6 +108,11 @@ public final class HadoopRemoteAcceptor implements RemoteAcceptor {
     }
 
     @Override
+    public boolean allowRemoteConsole() {
+        return true;
+    }
+
+    @Override
     public void close() throws IOException {
         this.hadoopGraph.close();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1096
https://issues.apache.org/jira/browse/TINKERPOP-1097

This PR introduces several things:

1. `SessionedClient.alias()` is now implemented so that you can do aliases on a session-based connection
1. The console's `:remote connect` now allows you to append "session" to the end of it so that it starts that remote with a session
1. The console now has `:remote console` which allows the console to be put into a mode where all scripts are sent to remote and the `:>` is no longer required

Tested the console manually in an abundance of ways but here's an example:

```text
gremlin> :remote connect tinkerpop.server conf/remote.yaml session
==>Connected - localhost/127.0.0.1:8182-[98bc7cf9-1c7b-451a-acbd-124a53a811d3]
gremlin> :remote config alias a g
==>a=g
gremlin> :remote console
==>All commands will now be sent to Gremlin Server - [localhost/127.0.0.1:8182]-[98bc7cf9-1c7b-451a-acbd-124a53a811d3] - type ':remote console' to exit
gremlin> x = 1
==>1
gremlin> y = 2
==>2
gremlin> x + y
==>3
gremlin> a.V()
==>v[0]
==>v[1]
==>v[3]
gremlin> :remote config alias b g
==>b=g
gremlin> b.V()
==>v[0]
==>v[1]
==>v[3]
```

Note that this is a non-breaking change. It is completely compatible with what we had before and the `:>` still works as it did before. This might yet be useful for some users as they might want to work with remote data in a local way and mix local/remote evaluations. Also, some plugins won't work well without it - like the gephi plugin.

Builds/tests nicely with: `mvn clean install && mvn verify -pl gremlin-server,gremlin-console -DskipIntegrationTests=false -DincludeNeo4j`

VOTE +1