### PR TITLE
When hosts configured incorrectly, causing problems not connect services

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Host.java
@@ -93,7 +93,7 @@ public final class Host {
     private static URI makeUriFromAddress(final InetSocketAddress addy, final boolean ssl) {
         try {
             final String scheme = ssl ? "wss" : "ws";
-            return new URI(scheme, null, addy.getHostName(), addy.getPort(), "/gremlin", null, null);
+            return new URI(scheme, null, addy.getAddress().getHostAddress(), addy.getPort(), "/gremlin", null, null);
         } catch (URISyntaxException use) {
             throw new RuntimeException(String.format("URI for host could not be constructed from: %s", addy), use);
         }

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/HostTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/HostTest.java
@@ -35,7 +35,12 @@ public class HostTest {
         final InetSocketAddress addy = new InetSocketAddress("localhost", 8182);
         final Host host = new Host(addy, Cluster.open());
         final URI webSocketUri = host.getHostUri();
-        assertEquals("ws://localhost:8182/gremlin", webSocketUri.toString());
+        assertEquals("ws://127.0.0.1:8182/gremlin", webSocketUri.toString());
+
+        final InetSocketAddress addyByIP = new InetSocketAddress("127.0.0.1", 8182);
+        final Host hostByIP = new Host(addyByIP, Cluster.open());
+        final URI webSocketUriByIP = hostByIP.getHostUri();
+        assertEquals("ws://127.0.0.1:8182/gremlin", webSocketUriByIP.toString());
     }
 
 }


### PR DESCRIPTION
Mainly to solve the following problem:

I have two machines, machine name and ip as follows:

```
           ip                             hostname
192.168.1.1                         host11
192.168.1.2                         host12

```
I start gremlin-server on 192.168.1.1, and then access on 192.168.1.2.

But for some reason, the hosts file on the 192.168.1.2 is not configured correctly, as follows:

`192.168.1.1   host33`

So I'm on the 192.168.1.2, it will report an error when accessing the gremlin-server. My statement is as follows access

```
  Builder builder = Cluster.build ( "192.168.1.1");
  Cluster cluster = builder.create ();
  Client client = cluster.connect ();
  ResultSet results = client.submit ( "[1,2,3,4]");
  results.stream () forEach (System.out :: println).;
```

It reported the following error:

```
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: java.util.concurrent.TimeoutException: Timed out waiting for an available host.
at org.apache.tinkerpop.gremlin.driver.Client.submit (Client.java:146)
at org.apache.tinkerpop.gremlin.driver.Client.submit (Client.java:130)
at com.okuc.graph.hello.remote.main (remote.java:27)
Caused by: java.lang.RuntimeException: java.util.concurrent.TimeoutException: Timed out waiting for an available host.
at org.apache.tinkerpop.gremlin.driver.Client.submitAsync (Client.java:194)
at org.apache.tinkerpop.gremlin.driver.Client.submitAsync (Client.java:174)
at org.apache.tinkerpop.gremlin.driver.Client.submit (Client.java:144)
... 2 more
Caused by: java.util.concurrent.TimeoutException: Timed out waiting for an available host.
at org.apache.tinkerpop.gremlin.driver.Client $ ClusteredClient.chooseConnection (Client.java:342)
at org.apache.tinkerpop.gremlin.driver.Client.submitAsync (Client.java:189)
... 4 more
```