### PR TITLE
TINKERPOP-1217: Repeated Logging of "The HadoopPools has not been initialized, using the default pool"

### DIFF
--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/HadoopPools.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/HadoopPools.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.hadoop.structure.io;
 
+import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.hadoop.structure.util.ConfUtil;
@@ -51,8 +52,10 @@ public final class HadoopPools {
     }
 
     public static GryoPool getGryoPool() {
-        if (!INITIALIZED)
+        if (!INITIALIZED) {
             HadoopGraph.LOGGER.warn("The " + HadoopPools.class.getSimpleName() + " has not been initialized, using the default pool");     // TODO: this is necessary because we can't get the pool intialized in the Merger code of the Hadoop process.
+            initialize(new BaseConfiguration());
+        }
         return GRYO_POOL;
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1217

This is a simple fix. However, the more troubling thing for me (and what could be another ticket) is why are you (@rspitzer) getting that? I don't know where in Spark the pool isn't being initialized and I haven't seen that in my experiments with Friendster/etc. 

Perhaps we can discuss on the mailing list about where in Spark this WARN is popping up for you.

For this issue VOTE +1. 