### PR TITLE
TINKERPOP-1069: Support Spark 1.6.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ TinkerPop 3.2.0 (XXX)
 TinkerPop 3.2.0 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Bumped to Spark 1.6.1.
 * Added `Operator.sumLong` as a optimized binary operator intended to be used by `Memory` reducers that know they are dealing with longs.
 * Traversers from `ComputerResultStep` are no longer attached. Attaching is only used in TinkerPop's test suite via `System.getProperties()`.
 * Fixed a `hashCode()`/`equals()` bug in `MessageScope`.

--- a/bin/init-tp-spark.sh
+++ b/bin/init-tp-spark.sh
@@ -27,7 +27,7 @@ if [ -z $2 ]; then
   echo
   echo "Example:"
   echo
-  echo "  $0 /usr/local/spark-1.5.2-bin-hadoop2.6 spark@master spark@slave1 spark@slave2 spark@slave3"
+  echo "  $0 /usr/local/spark-1.6.1-bin-hadoop2.6 spark@master spark@slave1 spark@slave2 spark@slave3"
   echo
   exit 1
 fi

--- a/docs/src/reference/implementations-hadoop.asciidoc
+++ b/docs/src/reference/implementations-hadoop.asciidoc
@@ -229,11 +229,6 @@ etc.). Unfortunately, typically these dependencies are not to the same versions 
 it is best to *not* have both Spark and Giraph plugins loaded in the same console session nor in the same Java
 project (though intelligent `<exclusion>`-usage can help alleviate conflicts in a Java project).
 
-WARNING: It is important to note that when doing an OLAP traversal, any resulting vertices, edges, or properties will be
-attached to the source graph. For Hadoop-based graphs, this may lead to linear search times on massive graphs. Thus,
-if vertex, edge, or property objects are to be returns (as a final result), it is best to `.id()` to get the id
-of the object and not the actual attached object.
-
 [[mapreducegraphcomputer]]
 MapReduceGraphComputer
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/spark-gremlin/pom.xml
+++ b/spark-gremlin/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
-            <version>1.5.2</version>
+            <version>1.6.1</version>
             <exclusions>
                 <!-- self conflicts -->
                 <exclusion>

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/WrappedArraySerializer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/structure/io/gryo/WrappedArraySerializer.java
@@ -34,7 +34,7 @@ public final class WrappedArraySerializer<T> extends Serializer<WrappedArray<T>>
     @Override
     public void write(final Kryo kryo, final Output output, final WrappedArray<T> iterable) {
         output.writeVarInt(iterable.size(), true);
-        JavaConversions.asJavaList(iterable).forEach(t -> {
+        JavaConversions.asJavaCollection(iterable).forEach(t -> {
             kryo.writeClassAndObject(output, t);
             output.flush();
         });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1069

Bumped.

* Integration tests passed.
* Tested manually with `local[4]`.
* Tested manually against SparkServer.
* Docs built successfully (and publishing right now...).

VOTE +1.