### PR TITLE
TINKERPOP-1219: Create a test case that ensures the provider's compilation of g.V(x) and g.V().hasId(x) is identical

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -125,4 +125,9 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
         super.setTraversal(parentTraversal);
         this.integrateChild(this.edgeTraversal.get());
     }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.edgeTraversal.hashCode() ^ this.pageRankProperty.hashCode() ^ this.times;
+    }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
@@ -56,6 +56,11 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
     }
 
     @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.edgeTraversal.hashCode() ^ this.clusterProperty.hashCode() ^ this.times;
+    }
+
+    @Override
     public void modulateBy(final Traversal.Admin<?, ?> edgeTraversal) {
         this.edgeTraversal = new PureTraversal<>((Traversal.Admin<Vertex, Edge>) edgeTraversal);
         this.integrateChild(this.edgeTraversal.get());

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -101,4 +101,9 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
         this.integrateChild(this.computerTraversal.get());
     }
 
+    /*@Override
+    public int hashCode() {
+        return super.hashCode() ^ this.computerTraversal.hashCode();
+    }*/
+
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PureTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/PureTraversal.java
@@ -56,6 +56,16 @@ public final class PureTraversal<S, E> implements Serializable, Cloneable {
         }
     }
 
+    @Override
+    public int hashCode() {
+        return this.pureTraversal.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return other instanceof PureTraversal && this.pureTraversal.equals(((PureTraversal) other).pureTraversal);
+    }
+
     ////////////
 
     public static <S, E> void storeState(final Configuration configuration, final String configurationKey, final Traversal.Admin<S, E> traversal) {

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/filter/GroovyHasTest.groovy
@@ -134,5 +134,25 @@ public abstract class GroovyHasTest {
         public Traversal<Vertex, Vertex> get_g_V_hasXlocationX() {
             new ScriptTraversal<>(g, "gremlin-groovy", "g.V.has('location')")
         }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_VX1X(final Object v1Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id)", "v1Id", v1Id)
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasIdX1X(final Object v1Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(v1Id)", "v1Id", v1Id)
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_VX1_2X(final Object v1Id, final Object v2Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V(v1Id, v2Id)", "v1Id", v1Id, "v2Id", v2Id)
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasIdX1_2X(final Object v1Id, final Object v2Id) {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasId(v1Id, v2Id)", "v1Id", v1Id, "v2Id", v2Id)
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/filter/HasTest.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -37,6 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
@@ -44,6 +46,7 @@ import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -95,6 +98,14 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Vertex> get_g_VX1X_outE_hasXweight_inside_0_06X_inV(final Object v1Id);
 
     public abstract Traversal<Vertex, Vertex> get_g_V_hasXlocationX();
+
+    public abstract Traversal<Vertex, Vertex> get_g_VX1X(final Object v1Id);
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasIdX1X(final Object v1Id);
+
+    public abstract Traversal<Vertex, Vertex> get_g_VX1_2X(final Object v1Id, final Object v2Id);
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_hasIdX1_2X(final Object v1Id, final Object v2Id);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -162,10 +173,10 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_VX1X_hasXage_gt_30X() {
-        final Traversal<Vertex,Vertex> traversalMarko = get_g_VX1X_hasXage_gt_30X(convertToVertexId("marko"));
+        final Traversal<Vertex, Vertex> traversalMarko = get_g_VX1X_hasXage_gt_30X(convertToVertexId("marko"));
         printTraversalForm(traversalMarko);
         assertFalse(traversalMarko.hasNext());
-        final Traversal<Vertex,Vertex> traversalJosh = get_g_VX1X_hasXage_gt_30X(convertToVertexId("josh"));
+        final Traversal<Vertex, Vertex> traversalJosh = get_g_VX1X_hasXage_gt_30X(convertToVertexId("josh"));
         printTraversalForm(traversalJosh);
         assertTrue(traversalJosh.hasNext());
     }
@@ -173,10 +184,10 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
     @Test
     @LoadGraphWith(MODERN)
     public void g_VXv1X_hasXage_gt_30X() {
-        final Traversal<Vertex,Vertex> traversalMarko = get_g_VXv1X_hasXage_gt_30X(convertToVertexId("marko"));
+        final Traversal<Vertex, Vertex> traversalMarko = get_g_VXv1X_hasXage_gt_30X(convertToVertexId("marko"));
         printTraversalForm(traversalMarko);
         assertFalse(traversalMarko.hasNext());
-        final Traversal<Vertex,Vertex> traversalJosh = get_g_VXv1X_hasXage_gt_30X(convertToVertexId("josh"));
+        final Traversal<Vertex, Vertex> traversalJosh = get_g_VXv1X_hasXage_gt_30X(convertToVertexId("josh"));
         printTraversalForm(traversalJosh);
         assertTrue(traversalJosh.hasNext());
     }
@@ -354,6 +365,33 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         checkResults(Arrays.asList(convertToVertex(graph, "marko"), convertToVertex(graph, "stephen"), convertToVertex(graph, "daniel"), convertToVertex(graph, "matthias")), traversal);
     }
 
+    @Test
+    @LoadGraphWith(MODERN)
+    @IgnoreEngine(TraversalEngine.Type.COMPUTER) // only validate for OLTP
+    public void g_V_hasId_compilationEquality() {
+        final Traversal<Vertex, Vertex> traversala1 = get_g_VX1X(convertToVertexId("marko"));
+        final Traversal<Vertex, Vertex> traversala2 = get_g_V_hasIdX1X(convertToVertexId("marko"));
+        final Traversal<Vertex, Vertex> traversalb1 = get_g_VX1_2X(convertToVertexId("marko"), convertToVertexId("vadas"));
+        final Traversal<Vertex, Vertex> traversalb2 = get_g_V_hasIdX1_2X(convertToVertexId("marko"), convertToVertexId("vadas"));
+        printTraversalForm(traversala1);
+        printTraversalForm(traversala2);
+        printTraversalForm(traversalb1);
+        printTraversalForm(traversala2);
+        checkResults(Collections.singletonList(convertToVertex(graph, "marko")), traversala1);
+        checkResults(Collections.singletonList(convertToVertex(graph, "marko")), traversala2);
+        checkResults(Arrays.asList(convertToVertex(graph, "marko"), convertToVertex(graph, "vadas")), traversalb1);
+        checkResults(Arrays.asList(convertToVertex(graph, "marko"), convertToVertex(graph, "vadas")), traversalb2);
+        // if providers don't have their own custom GraphStep, then ignore validating compilation equality
+        if (!traversala1.asAdmin().getStartStep().getClass().equals(GraphStep.class)) {
+            assertEquals(traversala1, traversala2);
+            assertEquals(traversalb1, traversalb2);
+            assertNotEquals(traversala1, traversalb1);
+            assertNotEquals(traversala1, traversalb2);
+            assertNotEquals(traversala2, traversalb1);
+            assertNotEquals(traversala2, traversalb2);
+        }
+    }
+
     private void assert_g_EX11X(final Object edgeId, final Traversal<Edge, Edge> traversal) {
         printTraversalForm(traversal);
         assertTrue(traversal.hasNext());
@@ -466,6 +504,26 @@ public abstract class HasTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Vertex> get_g_V_hasXlocationX() {
             return g.V().has("location");
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_VX1X(final Object v1Id) {
+            return g.V(v1Id);
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasIdX1X(final Object v1Id) {
+            return g.V().hasId(v1Id);
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_VX1_2X(final Object v1Id, final Object v2Id) {
+            return g.V(v1Id, v2Id);
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_hasIdX1_2X(final Object v1Id, final Object v2Id) {
+            return g.V().hasId(v1Id, v2Id);
         }
     }
 }

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/Neo4jGraphStep.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/step/sideEffect/Neo4jGraphStep.java
@@ -77,4 +77,9 @@ public final class Neo4jGraphStep<S, E extends Element> extends GraphStep<S, E> 
     public void addHasContainer(final HasContainer hasContainer) {
         this.hasContainers.add(hasContainer);
     }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.hasContainers.hashCode();
+    }
 }

--- a/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/strategy/optimization/Neo4jGraphStepStrategy.java
+++ b/neo4j-gremlin/src/main/java/org/apache/tinkerpop/gremlin/neo4j/process/traversal/strategy/optimization/Neo4jGraphStepStrategy.java
@@ -45,7 +45,10 @@ public final class Neo4jGraphStepStrategy extends AbstractTraversalStrategy<Trav
             TraversalHelper.replaceStep(originalGraphStep, (Step) neo4jGraphStep, traversal);
             Step<?, ?> currentStep = neo4jGraphStep.getNextStep();
             while (currentStep instanceof HasContainerHolder) {
-                ((HasContainerHolder) currentStep).getHasContainers().forEach(neo4jGraphStep::addHasContainer);
+                ((HasContainerHolder) currentStep).getHasContainers().forEach(hasContainer -> {
+                    if (!GraphStep.processHasContainerIds(neo4jGraphStep, hasContainer))
+                        neo4jGraphStep.addHasContainer(hasContainer);
+                });
                 currentStep.getLabels().forEach(neo4jGraphStep::addLabel);
                 traversal.removeStep(currentStep);
                 currentStep = currentStep.getNextStep();

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -121,4 +121,9 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
     public void addHasContainer(final HasContainer hasContainer) {
         this.hasContainers.add(hasContainer);
     }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.hasContainers.hashCode();
+    }
 }

--- a/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphStepStrategy.java
+++ b/tinkergraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/strategy/optimization/TinkerGraphStepStrategy.java
@@ -47,7 +47,10 @@ public final class TinkerGraphStepStrategy extends AbstractTraversalStrategy<Tra
             TraversalHelper.replaceStep(originalGraphStep, (Step) tinkerGraphStep, traversal);
             Step<?, ?> currentStep = tinkerGraphStep.getNextStep();
             while (currentStep instanceof HasContainerHolder) {
-                ((HasContainerHolder) currentStep).getHasContainers().forEach(tinkerGraphStep::addHasContainer);
+                ((HasContainerHolder) currentStep).getHasContainers().forEach(hasContainer -> {
+                    if (!GraphStep.processHasContainerIds(tinkerGraphStep, hasContainer))
+                        tinkerGraphStep.addHasContainer(hasContainer);
+                });
                 currentStep.getLabels().forEach(tinkerGraphStep::addLabel);
                 traversal.removeStep(currentStep);
                 currentStep = currentStep.getNextStep();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1219

OLTP providers that have custom `GraphStep` implementations should have `g.V(1)` and `g.V().hasId(1)` compile to the same representation. Likewise for `g.V(1,2)` and `g.V().hasId(1,2)` and `g.V().has(T.id,within(1,2))`. This ensures that random-access databases are using not using linear scans with `g.V().hasId(…)`. I added `GraphStep.processHasContainerIds()` which makes it easy for providers to update their respective `XXXGraphStepStrategy` to `GraphStep.addIds()` is appropriate.

I found a few `hashCode()`-bugs in the process and fixed them up. 

CHANGELOG

```
* Added `GraphStep.addIds()` which is useful for `HasContainer` "fold ins."
* Added a static `GraphStep.processHashContainerIds()` helper for handling id-based `HasContainers`.
* `GraphStep` implementations should have `g.V().hasId(x)` and `g.V(x)` compile equivalently. (*breaking*)
```

UPDATE

```
GraphStep Compilation Requirement
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

OLTP graph providers that have a custom `GraphStep` implementation should ensure that `g.V().hasId(x)` and `g.V(x)` compile to the same representation. This ensures a consistent user experience around random access of elements based on ids (as opposed to potentially the former doing a linear scan). A static helper method called `GraphStep.processHasContainerIds()` has been added. `TinkerGraphStepStrategy` was updated as such:


((HasContainerHolder) currentStep).getHasContainers().forEach(tinkerGraphStep::addHasContainer);


is now


((HasContainerHolder) currentStep).getHasContainers().forEach(hasContainer -> {
  if (!GraphStep.processHasContainerIds(tinkerGraphStep, hasContainer))
    tinkerGraphStep.addHasContainer(hasContainer);
});
```