### PR TITLE
TINKERPOP-732 .tree() serialization in GraphSON

### DIFF
--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -57,3 +57,4 @@ Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 Netty
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
+

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -57,27 +57,3 @@ Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 Netty
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
-
-------------------------------------------------------------------------
-Jackson databind - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.jackson
-------------------------------------------------------------------------
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-
-## Licensing
-
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-
-## Credits
-
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.

--- a/gremlin-console/src/main/static/NOTICE
+++ b/gremlin-console/src/main/static/NOTICE
@@ -57,3 +57,27 @@ Copyright (c) 2010, The JAVATUPLES team (http://www.javatuples.org)
 Netty
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
+
+------------------------------------------------------------------------
+Jackson databind - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.jackson
+------------------------------------------------------------------------
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may be licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
@@ -78,9 +78,9 @@ abstract class GraphSONModule extends SimpleModule {
             addSerializer(TraversalMetrics.class, new GraphSONSerializers.TraversalMetricsJacksonSerializer());
             addSerializer(TraversalExplanation.class, new GraphSONSerializers.TraversalExplanationJacksonSerializer());
             addSerializer(Path.class, new GraphSONSerializers.PathJacksonSerializer());
-            addSerializer(Tree.class, new GraphSONSerializers.TreeJacksonSerializer());
             addSerializer(StarGraphGraphSONSerializer.DirectionalStarGraph.class, new StarGraphGraphSONSerializer(normalize));
-
+            addSerializer(Tree.class, new GraphSONSerializers.TreeJacksonSerializer());
+           
             // java.util
             addSerializer(Map.Entry.class, new JavaUtilSerializers.MapEntryJacksonSerializer());
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONModule.java
@@ -42,6 +42,7 @@ import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 
 /**
  * The set of serializers that handle the core graph interfaces.  These serializers support normalization which
@@ -77,6 +78,7 @@ abstract class GraphSONModule extends SimpleModule {
             addSerializer(TraversalMetrics.class, new GraphSONSerializers.TraversalMetricsJacksonSerializer());
             addSerializer(TraversalExplanation.class, new GraphSONSerializers.TraversalExplanationJacksonSerializer());
             addSerializer(Path.class, new GraphSONSerializers.PathJacksonSerializer());
+            addSerializer(Tree.class, new GraphSONSerializers.TreeJacksonSerializer());
             addSerializer(StarGraphGraphSONSerializer.DirectionalStarGraph.class, new StarGraphGraphSONSerializer(normalize));
 
             // java.util

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializers.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
-import org.apache.tinkerpop.gremlin.structure.T;
 
 /**
  * GraphSON serializers for graph-based objects such as vertices, edges, properties, and paths. These serializers
@@ -282,12 +281,13 @@ final class GraphSONSerializers {
         private static void ser(final Tree tree, final JsonGenerator jsonGenerator, final TypeSerializer typeSerializer)
                 throws IOException {
             jsonGenerator.writeStartObject(); // {
+            if (typeSerializer != null) jsonGenerator.writeStringField(GraphSONTokens.CLASS, HashMap.class.getName());
             
-            Set<Map.Entry<Element, Tree<T>>> set = tree.entrySet();
-            for(Map.Entry<Element, Tree<T>> entry : set)
+            Set<Map.Entry<Element, Tree>> set = tree.entrySet();
+            for(Map.Entry<Element, Tree> entry : set)
             {
-                jsonGenerator.writeObjectFieldStart(entry.getKey().id().toString()); 
-                if (typeSerializer != null) jsonGenerator.writeStringField(GraphSONTokens.CLASS, HashMap.class.getName()); 
+                jsonGenerator.writeObjectFieldStart(entry.getKey().id().toString());
+                if (typeSerializer != null) jsonGenerator.writeStringField(GraphSONTokens.CLASS, HashMap.class.getName());
                 jsonGenerator.writeObjectField(GraphSONTokens.KEY, entry.getKey()); 
                 jsonGenerator.writeObjectField(GraphSONTokens.VALUE, entry.getValue());
                 jsonGenerator.writeEndObject();
@@ -295,7 +295,7 @@ final class GraphSONSerializers {
             jsonGenerator.writeEndObject();
         }
     } 
-
+    
     /**
      * Maps in the JVM can have {@link Object} as a key, but in JSON they must be a {@link String}.
      */

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializers.java
@@ -48,7 +48,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
+import org.apache.tinkerpop.gremlin.structure.T;
 
 /**
  * GraphSON serializers for graph-based objects such as vertices, edges, properties, and paths. These serializers
@@ -257,6 +260,41 @@ final class GraphSONSerializers {
         }
 
     }
+    
+    final static class TreeJacksonSerializer extends StdSerializer<Tree> {
+
+        public TreeJacksonSerializer() {
+            super(Tree.class);
+        }
+
+        @Override
+        public void serialize(final Tree tree, final JsonGenerator jsonGenerator, final SerializerProvider serializerProvider) throws IOException, JsonGenerationException {
+            ser(tree, jsonGenerator, null);
+        }
+        
+        @Override
+        public void serializeWithType(final Tree tree, final JsonGenerator jsonGenerator,
+                                      final SerializerProvider serializerProvider, final TypeSerializer typeSerializer)
+                throws IOException, JsonProcessingException {
+            ser(tree, jsonGenerator, typeSerializer);
+        }
+        
+        private static void ser(final Tree tree, final JsonGenerator jsonGenerator, final TypeSerializer typeSerializer)
+                throws IOException {
+            jsonGenerator.writeStartObject(); // {
+            
+            Set<Map.Entry<Element, Tree<T>>> set = tree.entrySet();
+            for(Map.Entry<Element, Tree<T>> entry : set)
+            {
+                jsonGenerator.writeObjectFieldStart(entry.getKey().id().toString()); 
+                if (typeSerializer != null) jsonGenerator.writeStringField(GraphSONTokens.CLASS, HashMap.class.getName()); 
+                jsonGenerator.writeObjectField(GraphSONTokens.KEY, entry.getKey()); 
+                jsonGenerator.writeObjectField(GraphSONTokens.VALUE, entry.getValue());
+                jsonGenerator.writeEndObject();
+            }
+            jsonGenerator.writeEndObject();
+        }
+    } 
 
     /**
      * Maps in the JVM can have {@link Object} as a key, but in JSON they must be a {@link String}.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializers.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/io/graphson/GraphSONSerializers.java
@@ -280,7 +280,7 @@ final class GraphSONSerializers {
         
         private static void ser(final Tree tree, final JsonGenerator jsonGenerator, final TypeSerializer typeSerializer)
                 throws IOException {
-            jsonGenerator.writeStartObject(); // {
+            jsonGenerator.writeStartObject(); 
             if (typeSerializer != null) jsonGenerator.writeStringField(GraphSONTokens.CLASS, HashMap.class.getName());
             
             Set<Map.Entry<Element, Tree>> set = tree.entrySet();

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerGremlinV1d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerGremlinV1d0Test.java
@@ -259,7 +259,6 @@ public class GraphSONMessageSerializerGremlinV1d0Test {
     public void shouldSerializeToJsonTree() throws Exception {
         final TinkerGraph graph = TinkerFactory.createClassic();
         final GraphTraversalSource g = graph.traversal();
-        //final Iterable<Tree> iterable = IteratorUtils.list(g.V(1).out().properties("name").tree());
         final Map t = g.V(1).out().properties("name").tree().next();
 
         final ResponseMessage response = convert(t);

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0Test.java
@@ -413,7 +413,6 @@ public class GraphSONMessageSerializerV1d0Test {
     public void shouldSerializeToJsonTree() throws Exception {
         final TinkerGraph graph = TinkerFactory.createClassic();
         final GraphTraversalSource g = graph.traversal();
-        //final Iterable<Tree> iterable = IteratorUtils.list(g.V(1).out().properties("name").tree());
         final Tree t = g.V(1).out().properties("name").tree().next();
 
         

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0Test.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ser/GraphSONMessageSerializerV1d0Test.java
@@ -57,6 +57,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -406,6 +407,48 @@ public class GraphSONMessageSerializerV1d0Test {
         assertEquals(2, deserialized.getStatus().getAttributes().get("two"));
         assertEquals(ResponseStatusCode.SUCCESS.getValue(), deserialized.getStatus().getCode().getValue());
         assertEquals("worked", deserialized.getStatus().getMessage());
+    }
+    
+    @Test
+    public void shouldSerializeToJsonTree() throws Exception {
+        final TinkerGraph graph = TinkerFactory.createClassic();
+        final GraphTraversalSource g = graph.traversal();
+        //final Iterable<Tree> iterable = IteratorUtils.list(g.V(1).out().properties("name").tree());
+        final Tree t = g.V(1).out().properties("name").tree().next();
+
+        
+        final String results = SERIALIZER.serializeResponseAsString(ResponseMessage.build(msg).result(t).create());
+
+        final JsonNode json = mapper.readTree(results);
+
+        assertNotNull(json);
+        assertEquals(msg.getRequestId().toString(), json.get(SerTokens.TOKEN_REQUEST).asText());
+        final JsonNode converted = json.get(SerTokens.TOKEN_RESULT).get(SerTokens.TOKEN_DATA);
+        assertNotNull(converted);
+        
+        //check the first object and it's properties
+        assertEquals(1, converted.get("1").get("key").get("id").asInt());
+        assertEquals("marko", converted.get("1").get("key").get("properties").get("name").get(0).get("value").asText());
+        
+        //check objects tree structure
+        //check Vertex property
+        assertEquals("vadas", converted.get("1")
+                                 .get("value")
+                                 .get("2")
+                                 .get("value")
+                                 .get("3").get("key").get("value").asText());
+        assertEquals("name", converted.get("1")
+                                 .get("value")
+                                 .get("2")
+                                 .get("value")
+                                 .get("3").get("key").get("label").asText());
+        
+        // check subitem
+        assertEquals("lop", converted.get("1")
+                                 .get("value")
+                                 .get("3")
+                                 .get("key")
+                                 .get("properties").get("name").get(0).get("value").asText());
     }
 
     private class FunObject {

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -58,3 +58,27 @@ LongAdder), which was released with the following comments:
 Netty
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
+
+------------------------------------------------------------------------
+Jackson databind - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.jackson
+------------------------------------------------------------------------
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may be licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/gremlin-server/src/main/static/NOTICE
+++ b/gremlin-server/src/main/static/NOTICE
@@ -58,27 +58,3 @@ LongAdder), which was released with the following comments:
 Netty
 ------------------------------------------------------------------------
 Copyright 2014 The Netty Project
-
-------------------------------------------------------------------------
-Jackson databind - shaded in gremlin-shaded to org.apache.tinkerpop.shaded.jackson
-------------------------------------------------------------------------
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-
-## Licensing
-
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-
-## Credits
-
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <!-- Update the shade plugin config whenever you change this version -->
-            <version>2.5.3</version>
+            <version>2.7.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/gremlin-shaded/pom.xml
+++ b/gremlin-shaded/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <!-- Update the shade plugin config whenever you change this version -->
-            <version>2.7.0</version>
+            <version>2.7.2</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/SerializationTest.java
@@ -240,7 +240,7 @@ public class SerializationTest {
             final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
             final Tree after = gryoReader.readObject(inputStream, Tree.class);
             assertNotNull(after);
-            //Seeing as Tree implements Serializable the following assertions should be sufficent.
+            //The following assertions should be sufficent.
             assertThat("Type does not match", after, instanceOf(Tree.class));
             assertEquals("The objects differ", after, before);
         }


### PR DESCRIPTION
I've had to upgrade jackson in `gremlin-shaded` to version `2.7.2` for this fix. I've made the appropriate changes to the `NOTICE` files.

This makes `tree()` work with the `GraphSON` serializers. I've added tests for `GraphSON` and `Gryo` + driver tests for `GraphSONMessageSerializer` and `GraphSONMessageGremlinSerializer`

What I've done for testing:
- `mvn clean install` **OK**
- `mvn verify -DskipIntegrationTests=false -pl gremlin-server` **OK**
- Ran tests with the php driver against `application/json`  **OK** 