### PR TITLE
TINKERPOP-1109 Make Gremlin Console better suited for system level installs

### DIFF
--- a/gremlin-console/src/main/bin/gremlin.sh
+++ b/gremlin-console/src/main/bin/gremlin.sh
@@ -24,6 +24,7 @@ set -u
 
 DIR="$( cd -P "$( dirname "$0" )" && pwd )"
 SYSTEM_EXT_DIR="${DIR}/../ext"
+JAVA_OPTIONS=${JAVA_OPTIONS:-}
 
 if [ ! -z "${JAVA_OPTIONS}" ]; then
   USER_EXT_DIR=$(grep -o '\-Dtinkerpop.ext=\(\([^"][^ ]*\)\|\("[^"]*"\)\)' <<< "${JAVA_OPTIONS}" | cut -f2 -d '=' | xargs -0 echo)

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Console.groovy
@@ -34,7 +34,6 @@ import org.codehaus.groovy.tools.shell.util.Preferences
 import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.AnsiConsole
 
-import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
 import java.util.prefs.PreferenceChangeEvent
 import java.util.prefs.PreferenceChangeListener
@@ -59,7 +58,6 @@ class Console {
     private static final int DEFAULT_ITERATION_MAX = 100
     private static int maxIteration = DEFAULT_ITERATION_MAX
 
-    private static final String HISTORY_FILE = ".gremlin_groovy_history"
     private static final String STANDARD_INPUT_PROMPT = "gremlin> "
     private static final String STANDARD_RESULT_PROMPT = "==>"
     private static final String IMPORT_SPACE = "import "
@@ -71,6 +69,7 @@ class Console {
 
     private final IO io = new IO(System.in, System.out, System.err)
     private final Groovysh groovy
+
 
     public Console(final String initScriptFile) {
         io.out.println()
@@ -111,11 +110,11 @@ class Console {
         final InteractiveShellRunner runner = new InteractiveShellRunner(groovy, handlePrompt)
         runner.setErrorHandler(handleError)
         try {
-            final FileHistory history = new FileHistory(new File(System.getProperty("user.home") + System.getProperty("file.separator") + HISTORY_FILE))
+            final FileHistory history = new FileHistory(new File(ConsoleFs.HISTORY_FILE))
             groovy.setHistory(history)
             runner.setHistory(history)
         } catch (IOException ignored) {
-            io.err.println("Unable to create history file: " + HISTORY_FILE)
+            io.err.println("Unable to create history file: " + ConsoleFs.HISTORY_FILE)
         }
 
         GremlinLoader.load()

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/ConsoleFs.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/ConsoleFs.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.console
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+class ConsoleFs {
+    public static final String FILE_SEP = System.getProperty("file.separator")
+    private static final String CONSOLE_USER_HOME = System.getProperty("user.home", ".") + FILE_SEP + "gremlin-console" + FILE_SEP + "ext";
+    public static final CONSOLE_HOME_DIR = System.getProperty("tinkerpop.ext", CONSOLE_USER_HOME) + FILE_SEP
+
+    public static final String PLUGIN_CONFIG_FILE = CONSOLE_HOME_DIR + "plugins.txt"
+    public static final String HISTORY_FILE = System.getProperty("user.home", ".") + FILE_SEP + ".gremlin_groovy_history"
+}

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/ConsoleFs.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/ConsoleFs.groovy
@@ -23,8 +23,7 @@ package org.apache.tinkerpop.gremlin.console
  */
 class ConsoleFs {
     public static final String FILE_SEP = System.getProperty("file.separator")
-    private static final String CONSOLE_USER_HOME = System.getProperty("user.home", ".") + FILE_SEP + "gremlin-console" + FILE_SEP + "ext";
-    public static final CONSOLE_HOME_DIR = System.getProperty("tinkerpop.ext", CONSOLE_USER_HOME) + FILE_SEP
+    public static final CONSOLE_HOME_DIR = System.getProperty("tinkerpop.ext", "ext") + FILE_SEP
 
     public static final String PLUGIN_CONFIG_FILE = CONSOLE_HOME_DIR + "plugins.txt"
     public static final String HISTORY_FILE = System.getProperty("user.home", ".") + FILE_SEP + ".gremlin_groovy_history"

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/Mediator.groovy
@@ -34,12 +34,7 @@ class Mediator {
 
     private final Console console
 
-
-    private static String FILE_SEP = System.getProperty("file.separator")
     private static String LINE_SEP = System.getProperty("line.separator")
-
-    private static final String PLUGIN_CONFIG_FILE =
-        System.getProperty("tinkerpop.ext", System.getProperty("user.dir", ".") + FILE_SEP + "ext") + FILE_SEP + "plugins.txt"
 
     public Mediator(final Console console) {
         this.console = console
@@ -76,7 +71,7 @@ class Mediator {
     }
 
     def writePluginState() {
-        def file = new File(PLUGIN_CONFIG_FILE)
+        def file = new File(ConsoleFs.PLUGIN_CONFIG_FILE)
 
         // ensure that the directories exist to hold the file.
         file.mkdirs()
@@ -84,7 +79,7 @@ class Mediator {
         if (file.exists())
             file.delete()
 
-        new File(PLUGIN_CONFIG_FILE).withWriter { out ->
+        new File(ConsoleFs.PLUGIN_CONFIG_FILE).withWriter { out ->
             activePlugins().each { k, v -> out << (k + LINE_SEP) }
         }
     }
@@ -94,7 +89,7 @@ class Mediator {
     }
 
     static def readPluginState() {
-        def file = new File(PLUGIN_CONFIG_FILE)
+        def file = new File(ConsoleFs.PLUGIN_CONFIG_FILE)
         return file.exists() ? file.readLines() : []
     }
 

--- a/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/InstallCommand.groovy
+++ b/gremlin-console/src/main/groovy/org/apache/tinkerpop/gremlin/console/commands/InstallCommand.groovy
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.console.commands
 
+import org.apache.tinkerpop.gremlin.console.ConsoleFs
 import org.apache.tinkerpop.gremlin.console.Mediator
 import org.apache.tinkerpop.gremlin.console.plugin.PluggedIn
 import org.apache.tinkerpop.gremlin.groovy.plugin.Artifact
@@ -34,7 +35,6 @@ import org.codehaus.groovy.tools.shell.Groovysh
  */
 class InstallCommand extends CommandSupport {
 
-    private final static String fileSep = System.getProperty("file.separator")
     private final Mediator mediator
 
     public InstallCommand(final Groovysh shell, final Mediator mediator) {
@@ -46,7 +46,7 @@ class InstallCommand extends CommandSupport {
     def Object execute(final List<String> arguments) {
         final def artifact = createArtifact(arguments)
         try {
-            def grabber = new DependencyGrabber(shell.getInterp().getClassLoader(), System.getProperty("user.dir") + fileSep + "ext")
+            def grabber = new DependencyGrabber(shell.getInterp().getClassLoader(), ConsoleFs.CONSOLE_HOME_DIR)
             grabber.copyDependenciesToPath(artifact)
 
             final def dep = grabber.makeDepsMap(artifact)


### PR DESCRIPTION
`gremlin.sh` now handles user-defined `ext/` directories (`tinkerpop.ext`). If the user specified directory doesn't exist, it will

a) create it and
b) copy the contents of `gremlin-console/ext` to it