### PR TITLE
TINKERPOP-1163: GraphComputer's can have TraversalStrategies.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/Computer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/Computer.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
  */
 public final class Computer implements Function<Graph, GraphComputer>, Serializable {
 
-    private Class<? extends GraphComputer> graphComputerClass = null;
+    private Class<? extends GraphComputer> graphComputerClass = GraphComputer.class;
     private Map<String, Object> configuration = new HashMap<>();
     private int workers = -1;
     private GraphComputer.Persist persist = null;
@@ -47,7 +47,7 @@ public final class Computer implements Function<Graph, GraphComputer>, Serializa
     }
 
     public static Computer compute() {
-        return new Computer(null);
+        return new Computer(GraphComputer.class);
     }
 
     public static Computer compute(final Class<? extends GraphComputer> graphComputerClass) {
@@ -85,9 +85,13 @@ public final class Computer implements Function<Graph, GraphComputer>, Serializa
         return this;
     }
 
+    public Class<? extends GraphComputer> getGraphComputerClass() {
+        return this.graphComputerClass;
+    }
+
     @Override
     public GraphComputer apply(final Graph graph) {
-        GraphComputer computer = null == this.graphComputerClass ? graph.compute() : graph.compute(this.graphComputerClass);
+        GraphComputer computer = this.graphComputerClass.equals(GraphComputer.class) ? graph.compute() : graph.compute(this.graphComputerClass);
         for (final Map.Entry<String, Object> entry : this.configuration.entrySet()) {
             computer = computer.configure(entry.getKey(), entry.getValue());
         }
@@ -106,6 +110,6 @@ public final class Computer implements Function<Graph, GraphComputer>, Serializa
 
     @Override
     public String toString() {
-        return null == this.graphComputerClass ? GraphComputer.class.getSimpleName().toLowerCase() : this.graphComputerClass.getSimpleName().toLowerCase();
+        return this.graphComputerClass.getSimpleName().toLowerCase();
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalSource.java
@@ -20,14 +20,14 @@ package org.apache.tinkerpop.gremlin.process.traversal;
 
 import org.apache.tinkerpop.gremlin.process.computer.Computer;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SackStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SideEffectStrategy;
-import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ComputerVerificationStrategy;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.function.ConstantSupplier;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -98,7 +98,13 @@ public interface TraversalSource extends Cloneable {
      * @return a new traversal source with updated strategies
      */
     public default TraversalSource withComputer(final Computer computer) {
-        return this.withStrategies(new VertexProgramStrategy(computer), ComputerVerificationStrategy.instance());
+        final List<TraversalStrategy<?>> graphComputerStrategies = TraversalStrategies.GlobalCache.getStrategies(computer.getGraphComputerClass()).toList();
+        final TraversalStrategy[] traversalStrategies = new TraversalStrategy[graphComputerStrategies.size() + 1];
+        traversalStrategies[0] = new VertexProgramStrategy(computer);
+        for (int i = 0; i < graphComputerStrategies.size(); i++) {
+            traversalStrategies[i+1] = graphComputerStrategies.get(i);
+        }
+        return this.withStrategies(traversalStrategies);
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1163

GraphComputers can now have their own `TraversalStrategy` registrations in the global cache. Currently, as it stands, all that is registered is `GraphComputer.class` which has `PathProcessStrategy`, `OrderLimitStrategy`, `ComputerVerificationStrategy`. Moving forward, we will be able to have strategies like `SparkCountStrategy` which will convert `g.V().count()` into `inputRDD.count()` and thus, allow us to talk more directly to the `GraphComputer` engine. `TinkerCountStrategy` would do `g.V().count()` as `this.vertices.count()`. Blazin'. .... however, what we have here is the the infrastructure to allow for the distinction between `Graph` and `GraphComputer` strategies. Note that this PR is backwards compatible.

CHANGELOG

```
* `TraversalStrategies.GlobalCache` supports both `Graph` and `GraphComputer` strategy registrations.
```

VOTE +1.