### PR TITLE
TINKERPOP-1223: Allow jars in gremlin.distributedJars to be read from HDFS

### DIFF
--- a/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphGraphComputer.java
+++ b/giraph-gremlin/src/main/java/org/apache/tinkerpop/gremlin/giraph/process/computer/GiraphGraphComputer.java
@@ -247,7 +247,7 @@ public final class GiraphGraphComputer extends AbstractHadoopGraphComputer imple
             else {
                 final String[] paths = hadoopGremlinLibsLocal.split(":");
                 for (final String path : paths) {
-                    final File file = new File(path);
+                    final File file = AbstractHadoopGraphComputer.copyDirectoryIfNonExistent(fs, path);
                     if (file.exists()) {
                         Stream.of(file.listFiles()).filter(f -> f.getName().endsWith(Constants.DOT_JAR)).forEach(f -> {
                             try {

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -211,7 +211,7 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
             File file = new File(localDirectory);
             if ((Boolean.valueOf(System.getProperty("is.testing", "false")) || !file.exists()) && fileSystem.exists(new Path(localDirectory)) && fileSystem.isDirectory(new Path(localDirectory))) {
                 final File tempDirectory = new File(System.getProperty("java.io.tmpdir") + "/" + hadoopGremlinLibsRemote);
-                if (!tempDirectory.exists()) assert tempDirectory.mkdir();
+                if (!tempDirectory.exists()) assert tempDirectory.mkdirs();
                 final String tempPath = tempDirectory.getAbsolutePath() + "/" + new File(localDirectory).getName();
                 final RemoteIterator<LocatedFileStatus> files = fileSystem.listFiles(new Path(localDirectory), false);
                 while (files.hasNext()) {

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputer.java
@@ -210,13 +210,13 @@ public abstract class AbstractHadoopGraphComputer implements GraphComputer {
             final String hadoopGremlinLibsRemote = "hadoop-gremlin-" + Gremlin.version() + "-libs";
             File file = new File(localDirectory);
             if ((Boolean.valueOf(System.getProperty("is.testing", "false")) || !file.exists()) && fileSystem.exists(new Path(localDirectory)) && fileSystem.isDirectory(new Path(localDirectory))) {
-                final File tempDirectory = new File(System.getProperty("java.io.tmpdir") + "/" + hadoopGremlinLibsRemote);
+                final File tempDirectory = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + hadoopGremlinLibsRemote);
                 if (!tempDirectory.exists()) assert tempDirectory.mkdirs();
-                final String tempPath = tempDirectory.getAbsolutePath() + "/" + new File(localDirectory).getName();
+                final String tempPath = tempDirectory.getAbsolutePath() + System.getProperty("file.separator") + new File(localDirectory).getName();
                 final RemoteIterator<LocatedFileStatus> files = fileSystem.listFiles(new Path(localDirectory), false);
                 while (files.hasNext()) {
                     final LocatedFileStatus f = files.next();
-                    fileSystem.copyToLocalFile(f.getPath(), new Path(tempPath + "/" + f.getPath().getName()));
+                    fileSystem.copyToLocalFile(f.getPath(), new Path(tempPath + System.getProperty("file.separator") + f.getPath().getName()));
                 }
                 return new File(tempPath);
             } else

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputerTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.hadoop.process.computer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.tinkerpop.gremlin.util.Gremlin;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public class AbstractHadoopGraphComputerTest {
+
+    @Test
+    public void shouldCopyDirectoriesCorrectly() throws Exception {
+        final FileSystem fs = FileSystem.get(new Configuration());
+        if (!new File(System.getProperty("java.io.tmpdir") + "/tmp").exists())
+            assertTrue(new File(System.getProperty("java.io.tmpdir") + "/tmp").mkdir());
+        File tempFile1 = new File(System.getProperty("java.io.tmpdir") + "/tmp/test1.txt");
+        File tempFile2 = new File(System.getProperty("java.io.tmpdir") + "/tmp/test2.txt");
+        assertTrue(tempFile1.createNewFile());
+        assertTrue(tempFile2.createNewFile());
+        assertTrue(tempFile1.exists());
+        assertTrue(tempFile2.exists());
+        if (fs.exists(new Path("target/testing")))
+            assertTrue(fs.delete(new Path("target/testing"), true));
+        fs.copyFromLocalFile(true, new Path(tempFile1.getAbsolutePath()), new Path("target/testing/test1.dat"));
+        fs.copyFromLocalFile(true, new Path(tempFile2.getAbsolutePath()), new Path("target/testing/test2.dat"));
+        assertTrue(fs.exists(new Path("target/testing/test1.dat")));
+        assertTrue(fs.exists(new Path("target/testing/test2.dat")));
+        assertTrue(fs.exists(new Path("target/testing")));
+        assertTrue(fs.isDirectory(new Path("target/testing")));
+        assertFalse(tempFile1.exists());
+        assertFalse(tempFile2.exists());
+        assertTrue(new File(System.getProperty("java.io.tmpdir") + "/tmp").exists());
+        assertTrue(new File(System.getProperty("java.io.tmpdir") + "/tmp").delete());
+        assertTrue(fs.exists(new Path("target/testing/test1.dat")));
+        assertTrue(fs.exists(new Path("target/testing/test2.dat")));
+        assertTrue(fs.exists(new Path("target/testing")));
+        assertTrue(fs.isDirectory(new Path("target/testing")));
+        /////
+        final String hadoopGremlinLibsRemote = "hadoop-gremlin-" + Gremlin.version() + "-libs";
+        final File localDirectory = new File(System.getProperty("java.io.tmpdir") + "/" + hadoopGremlinLibsRemote);
+        final File localLibDirectory = new File(localDirectory.getAbsolutePath() + "/testing");
+        assertTrue(localDirectory.exists());
+        if (localLibDirectory.exists()) {
+            Stream.of(localLibDirectory.listFiles()).forEach(File::delete);
+            assertTrue(localLibDirectory.delete());
+        }
+        assertFalse(localLibDirectory.exists());
+        assertEquals(localLibDirectory, AbstractHadoopGraphComputer.copyDirectoryIfNonExistent(fs, "target/testing"));
+        assertTrue(localLibDirectory.exists());
+        assertTrue(localLibDirectory.isDirectory());
+        assertEquals(2, Stream.of(localLibDirectory.listFiles()).filter(file -> file.getName().endsWith(".dat")).count());
+    }
+}

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputerTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputerTest.java
@@ -68,7 +68,6 @@ public class AbstractHadoopGraphComputerTest {
         final String hadoopGremlinLibsRemote = "hadoop-gremlin-" + Gremlin.version() + "-libs";
         final File localDirectory = new File(System.getProperty("java.io.tmpdir") + "/" + hadoopGremlinLibsRemote);
         final File localLibDirectory = new File(localDirectory.getAbsolutePath() + "/testing");
-        assertTrue(localDirectory.exists());
         if (localLibDirectory.exists()) {
             Stream.of(localLibDirectory.listFiles()).forEach(File::delete);
             assertTrue(localLibDirectory.delete());

--- a/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputerTest.java
+++ b/hadoop-gremlin/src/test/java/org/apache/tinkerpop/gremlin/hadoop/process/computer/AbstractHadoopGraphComputerTest.java
@@ -39,41 +39,43 @@ public class AbstractHadoopGraphComputerTest {
 
     @Test
     public void shouldCopyDirectoriesCorrectly() throws Exception {
+        final String hdfsName = this.getClass().getSimpleName() + "-hdfs";
+        final String localName = this.getClass().getSimpleName() + "-local";
         final FileSystem fs = FileSystem.get(new Configuration());
-        if (!new File(System.getProperty("java.io.tmpdir") + "/tmp").exists())
-            assertTrue(new File(System.getProperty("java.io.tmpdir") + "/tmp").mkdir());
-        File tempFile1 = new File(System.getProperty("java.io.tmpdir") + "/tmp/test1.txt");
-        File tempFile2 = new File(System.getProperty("java.io.tmpdir") + "/tmp/test2.txt");
+        if (!new File(System.getProperty("java.io.tmpdir") + "/" + localName).exists())
+            assertTrue(new File(System.getProperty("java.io.tmpdir") + "/" + localName).mkdir());
+        File tempFile1 = new File(System.getProperty("java.io.tmpdir") + "/" + localName + "/test1.txt");
+        File tempFile2 = new File(System.getProperty("java.io.tmpdir") + "/" + localName + "/test2.txt");
         assertTrue(tempFile1.createNewFile());
         assertTrue(tempFile2.createNewFile());
         assertTrue(tempFile1.exists());
         assertTrue(tempFile2.exists());
-        if (fs.exists(new Path("target/testing")))
-            assertTrue(fs.delete(new Path("target/testing"), true));
-        fs.copyFromLocalFile(true, new Path(tempFile1.getAbsolutePath()), new Path("target/testing/test1.dat"));
-        fs.copyFromLocalFile(true, new Path(tempFile2.getAbsolutePath()), new Path("target/testing/test2.dat"));
-        assertTrue(fs.exists(new Path("target/testing/test1.dat")));
-        assertTrue(fs.exists(new Path("target/testing/test2.dat")));
-        assertTrue(fs.exists(new Path("target/testing")));
-        assertTrue(fs.isDirectory(new Path("target/testing")));
+        if (fs.exists(new Path("target/" + hdfsName)))
+            assertTrue(fs.delete(new Path("target/" + hdfsName), true));
+        fs.copyFromLocalFile(true, new Path(tempFile1.getAbsolutePath()), new Path("target/" + hdfsName + "/test1.dat"));
+        fs.copyFromLocalFile(true, new Path(tempFile2.getAbsolutePath()), new Path("target/" + hdfsName + "/test2.dat"));
+        assertTrue(fs.exists(new Path("target/" + hdfsName + "/test1.dat")));
+        assertTrue(fs.exists(new Path("target/" + hdfsName + "/test2.dat")));
+        assertTrue(fs.exists(new Path("target/" + hdfsName)));
+        assertTrue(fs.isDirectory(new Path("target/" + hdfsName)));
         assertFalse(tempFile1.exists());
         assertFalse(tempFile2.exists());
-        assertTrue(new File(System.getProperty("java.io.tmpdir") + "/tmp").exists());
-        assertTrue(new File(System.getProperty("java.io.tmpdir") + "/tmp").delete());
-        assertTrue(fs.exists(new Path("target/testing/test1.dat")));
-        assertTrue(fs.exists(new Path("target/testing/test2.dat")));
-        assertTrue(fs.exists(new Path("target/testing")));
-        assertTrue(fs.isDirectory(new Path("target/testing")));
+        assertTrue(new File(System.getProperty("java.io.tmpdir") + "/" + localName).exists());
+        assertTrue(new File(System.getProperty("java.io.tmpdir") + "/" + localName).delete());
+        assertTrue(fs.exists(new Path("target/" + hdfsName + "/test1.dat")));
+        assertTrue(fs.exists(new Path("target/" + hdfsName + "/test2.dat")));
+        assertTrue(fs.exists(new Path("target/" + hdfsName)));
+        assertTrue(fs.isDirectory(new Path("target/" + hdfsName)));
         /////
         final String hadoopGremlinLibsRemote = "hadoop-gremlin-" + Gremlin.version() + "-libs";
         final File localDirectory = new File(System.getProperty("java.io.tmpdir") + "/" + hadoopGremlinLibsRemote);
-        final File localLibDirectory = new File(localDirectory.getAbsolutePath() + "/testing");
+        final File localLibDirectory = new File(localDirectory.getAbsolutePath() + "/" + hdfsName);
         if (localLibDirectory.exists()) {
             Stream.of(localLibDirectory.listFiles()).forEach(File::delete);
             assertTrue(localLibDirectory.delete());
         }
         assertFalse(localLibDirectory.exists());
-        assertEquals(localLibDirectory, AbstractHadoopGraphComputer.copyDirectoryIfNonExistent(fs, "target/testing"));
+        assertEquals(localLibDirectory, AbstractHadoopGraphComputer.copyDirectoryIfNonExistent(fs, "target/" + hdfsName));
         assertTrue(localLibDirectory.exists());
         assertTrue(localLibDirectory.isDirectory());
         assertEquals(2, Stream.of(localLibDirectory.listFiles()).filter(file -> file.getName().endsWith(".dat")).count());

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkGraphComputer.java
@@ -323,13 +323,18 @@ public final class SparkGraphComputer extends AbstractHadoopGraphComputer {
             if (null == hadoopGremlinLocalLibs)
                 this.logger.warn(Constants.HADOOP_GREMLIN_LIBS + " is not set -- proceeding regardless");
             else {
-                final String[] paths = hadoopGremlinLocalLibs.split(":");
-                for (final String path : paths) {
-                    final File file = new File(path);
-                    if (file.exists())
-                        Stream.of(file.listFiles()).filter(f -> f.getName().endsWith(Constants.DOT_JAR)).forEach(f -> sparkContext.addJar(f.getAbsolutePath()));
-                    else
-                        this.logger.warn(path + " does not reference a valid directory -- proceeding regardless");
+                try {
+                    final String[] paths = hadoopGremlinLocalLibs.split(":");
+                    final FileSystem fs = FileSystem.get(hadoopConfiguration);
+                    for (final String path : paths) {
+                        final File file = AbstractHadoopGraphComputer.copyDirectoryIfNonExistent(fs, path);
+                        if (file.exists())
+                            Stream.of(file.listFiles()).filter(f -> f.getName().endsWith(Constants.DOT_JAR)).forEach(f -> sparkContext.addJar(f.getAbsolutePath()));
+                        else
+                            this.logger.warn(path + " does not reference a valid directory -- proceeding regardless");
+                    }
+                } catch (IOException e) {
+                    throw new IllegalStateException(e.getMessage(), e);
                 }
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1223

If a `HADOOP_GREMLIN_LIBS` directory does not reference a local directory, then check for that directory in HDFS. If its there, copy it to a `java.io.tmp` directory and then process the `jars` from there.

CHANGELOG

```
* `HADOOP_GREMLIN_LIBS` can now reference a directory in HDFS and will be used if the directory does not exist locally.
```  

`mvn clean install` and tested manually via the Gremlin Console.

VOTE +1.