### PR TITLE
TINKERPOP-1234: program() step that takes arbitrary vertex programs

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PageRankVertexProgramStep.java
@@ -45,8 +45,6 @@ import java.util.function.Function;
  */
 public final class PageRankVertexProgramStep extends VertexProgramStep implements TraversalParent, ByModulating, TimesModulating {
 
-    private transient Function<Graph, GraphComputer> graphComputerFunction = Graph::compute;
-
     private PureTraversal<Vertex, Edge> edgeTraversal;
     private String pageRankProperty = PageRankVertexProgram.PAGE_RANK;
     private int times = 30;
@@ -85,11 +83,6 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
     }
 
     @Override
-    public void setGraphComputerFunction(final Function<Graph, GraphComputer> graphComputerFunction) {
-        this.graphComputerFunction = graphComputerFunction;
-    }
-
-    @Override
     public PageRankVertexProgram generateProgram(final Graph graph) {
         final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
         detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
@@ -104,13 +97,13 @@ public final class PageRankVertexProgramStep extends VertexProgramStep implement
     }
 
     @Override
-    public Set<TraverserRequirement> getRequirements() {
-        return TraversalParent.super.getSelfAndChildRequirements();
+    public GraphComputer generateComputer(final Graph graph) {
+        return this.computer.apply(graph).persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW);
     }
 
     @Override
-    public GraphComputer generateComputer(final Graph graph) {
-        return this.graphComputerFunction.apply(graph).persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW);
+    public Set<TraverserRequirement> getRequirements() {
+        return TraversalParent.super.getSelfAndChildRequirements();
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/PeerPressureVertexProgramStep.java
@@ -37,14 +37,11 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class PeerPressureVertexProgramStep extends VertexProgramStep implements TraversalParent, ByModulating, TimesModulating {
-
-    private transient Function<Graph, GraphComputer> graphComputerFunction = Graph::compute;
 
     private PureTraversal<Vertex, Edge> edgeTraversal;
     private String clusterProperty = PeerPressureVertexProgram.CLUSTER;
@@ -87,11 +84,6 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
     }
 
     @Override
-    public void setGraphComputerFunction(final Function<Graph, GraphComputer> graphComputerFunction) {
-        this.graphComputerFunction = graphComputerFunction;
-    }
-
-    @Override
     public PeerPressureVertexProgram generateProgram(final Graph graph) {
         final Traversal.Admin<Vertex, Edge> detachedTraversal = this.edgeTraversal.getPure();
         detachedTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()));
@@ -109,7 +101,7 @@ public final class PeerPressureVertexProgramStep extends VertexProgramStep imple
 
     @Override
     public GraphComputer generateComputer(final Graph graph) {
-        return this.graphComputerFunction.apply(graph).persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW);
+        return this.computer.apply(graph).persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW);
     }
 
     @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
@@ -23,6 +23,7 @@ import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +34,7 @@ import java.util.Map;
 public final class ProgramVertexProgramStep extends VertexProgramStep {
 
     private final Map<String, Object> configuration;
+    private final String toStringOfVertexProgram;
 
     public ProgramVertexProgramStep(final Traversal.Admin traversal, final VertexProgram vertexProgram) {
         super(traversal);
@@ -40,10 +42,21 @@ public final class ProgramVertexProgramStep extends VertexProgramStep {
         final MapConfiguration base = new MapConfiguration(this.configuration);
         base.setDelimiterParsingDisabled(true);
         vertexProgram.storeState(base);
+        this.toStringOfVertexProgram = vertexProgram.toString();
     }
 
     @Override
     public VertexProgram generateProgram(final Graph graph) {
         return VertexProgram.createVertexProgram(graph, new MapConfiguration(this.configuration));
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.configuration.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.stepString(this, this.toStringOfVertexProgram);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
@@ -20,12 +20,11 @@
 package org.apache.tinkerpop.gremlin.process.computer.traversal.step.map;
 
 import org.apache.commons.configuration.MapConfiguration;
-import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -37,19 +36,14 @@ public final class ProgramVertexProgramStep extends VertexProgramStep {
 
     public ProgramVertexProgramStep(final Traversal.Admin traversal, final VertexProgram vertexProgram) {
         super(traversal);
-        final MapConfiguration base = new MapConfiguration(Collections.emptyMap());
+        this.configuration = new HashMap<>();
+        final MapConfiguration base = new MapConfiguration(this.configuration);
         base.setDelimiterParsingDisabled(true);
         vertexProgram.storeState(base);
-        this.configuration = base.getMap();
     }
 
     @Override
     public VertexProgram generateProgram(final Graph graph) {
         return VertexProgram.createVertexProgram(graph, new MapConfiguration(this.configuration));
-    }
-
-    @Override
-    public GraphComputer generateComputer(final Graph graph) {
-        return this.computer.apply(graph);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
@@ -17,25 +17,39 @@
  * under the License.
  */
 
-package org.apache.tinkerpop.gremlin.process.computer.traversal.step;
+package org.apache.tinkerpop.gremlin.process.computer.traversal.step.map;
 
-import org.apache.tinkerpop.gremlin.process.computer.Computer;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public interface VertexComputing {
+public final class ProgramVertexProgramStep extends VertexProgramStep {
 
-    public void setComputer(final Computer computer);
+    final Map<String, Object> configuration;
 
-    public Computer getComputer();
+    public ProgramVertexProgramStep(final Traversal.Admin traversal, final VertexProgram vertexProgram) {
+        super(traversal);
+        final MapConfiguration base = new MapConfiguration(Collections.emptyMap());
+        base.setDelimiterParsingDisabled(true);
+        vertexProgram.storeState(base);
+        this.configuration = base.getMap();
+    }
 
-    public VertexProgram generateProgram(final Graph graph);
+    @Override
+    public VertexProgram generateProgram(final Graph graph) {
+        return VertexProgram.createVertexProgram(graph, new MapConfiguration(this.configuration));
+    }
 
-    public default GraphComputer generateComputer(final Graph graph) {
-        return this.getComputer().apply(graph);
+    @Override
+    public GraphComputer generateComputer(final Graph graph) {
+        return this.computer.apply(graph);
     }
 }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/ProgramVertexProgramStep.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public final class ProgramVertexProgramStep extends VertexProgramStep {
 
-    final Map<String, Object> configuration;
+    private final Map<String, Object> configuration;
 
     public ProgramVertexProgramStep(final Traversal.Admin traversal, final VertexProgram vertexProgram) {
         super(traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/step/map/TraversalVertexProgramStep.java
@@ -33,14 +33,12 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public final class TraversalVertexProgramStep extends VertexProgramStep implements TraversalParent {
 
-    private transient Function<Graph, GraphComputer> graphComputerFunction = Graph::compute;
     public PureTraversal<?, ?> computerTraversal;
 
     public TraversalVertexProgramStep(final Traversal.Admin traversal, final Traversal.Admin<?, ?> computerTraversal) {
@@ -74,11 +72,6 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
     }
 
     @Override
-    public void setGraphComputerFunction(final Function<Graph, GraphComputer> graphComputerFunction) {
-        this.graphComputerFunction = graphComputerFunction;
-    }
-
-    @Override
     public TraversalVertexProgram generateProgram(final Graph graph) {
         final Traversal.Admin<?, ?> computerSpecificTraversal = this.computerTraversal.getPure();
         computerSpecificTraversal.setStrategies(TraversalStrategies.GlobalCache.getStrategies(graph.getClass()).clone());
@@ -92,8 +85,8 @@ public final class TraversalVertexProgramStep extends VertexProgramStep implemen
 
     @Override
     public GraphComputer generateComputer(final Graph graph) {
-        final GraphComputer graphComputer = this.graphComputerFunction.apply(graph);
-        if (!(this.getNextStep() instanceof ComputerResultStep))
+        final GraphComputer graphComputer = this.computer.apply(graph);
+        if (!this.isEndStep())
             graphComputer.persist(GraphComputer.Persist.EDGES).result(GraphComputer.ResultGraph.NEW);
         return graphComputer;
     }

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/remote/RemoteGraph.java
@@ -74,6 +74,10 @@ import java.util.Iterator;
         method = "g_V_pageRank",
         reason = "RemoteGraph retrieves detached vertices that can't be attached to a remote OLAP graph")
 @Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest",
+        method = "g_V_programXpageRankX",
+        reason = "RemoteGraph retrieves detached vertices that can't be attached to a remote OLAP graph")
+@Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgramTest",
         method = "*",
         reason = "RemoteGraph does not support direct Graph.compute() access")

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversal.java
@@ -18,8 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.process.traversal.dsl.graph;
 
+import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PageRankVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.PeerPressureVertexProgramStep;
+import org.apache.tinkerpop.gremlin.process.computer.traversal.step.map.ProgramVertexProgramStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
@@ -1164,6 +1166,9 @@ public interface GraphTraversal<S, E> extends Traversal<S, E> {
         return this.asAdmin().addStep((Step<E, E>) new PeerPressureVertexProgramStep(this.asAdmin()));
     }
 
+    public default GraphTraversal<S, E> program(final VertexProgram<?> vertexProgram) {
+        return this.asAdmin().addStep((Step<E, E>) new ProgramVertexProgramStep(this.asAdmin(), vertexProgram));
+    }
 
     ///////////////////// UTILITY STEPS /////////////////////
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/VertexProgramStrategy.java
@@ -120,7 +120,7 @@ public final class VertexProgramStrategy extends AbstractTraversalStrategy<Trave
             traversal.addStep(new ComputerResultStep<>(traversal));
         }
         // all vertex computing steps needs the graph computer function
-        traversal.getSteps().stream().filter(step -> step instanceof VertexComputing).forEach(step -> ((VertexComputing) step).setGraphComputerFunction(this.computer));
+        traversal.getSteps().stream().filter(step -> step instanceof VertexComputing).forEach(step -> ((VertexComputing) step).setComputer(this.computer));
     }
 
     private static Step<?, ?> getFirstLegalOLAPStep(Step<?, ?> currentStep) {

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ScriptTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/ScriptTraversal.java
@@ -57,6 +57,7 @@ public final class ScriptTraversal<S, E> extends DefaultTraversal<S, E> {
             final ScriptEngine engine = ScriptEngineCache.get(this.scriptEngine);
             final Bindings engineBindings = engine.createBindings();
             engineBindings.put("g", this.factory.createTraversalSource(this.graph));
+            engineBindings.put("graph", this.graph);
             for (int i = 0; i < this.bindings.length; i = i + 2) {
                 engineBindings.put((String) this.bindings[i], this.bindings[i + 1]);
             }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/graph/GraphTraversalTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class GraphTraversalTest {
 
-    private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "option", "iterate", "to", "from", "profile", "pageRank", "peerPressure"));
+    private static Set<String> NO_GRAPH = new HashSet<>(Arrays.asList("asAdmin", "by", "option", "iterate", "to", "from", "profile", "pageRank", "peerPressure", "program"));
     private static Set<String> NO_ANONYMOUS = new HashSet<>(Arrays.asList("start", "__"));
 
     @Test

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyProgramTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyProgramTest.groovy
@@ -32,12 +32,12 @@ public abstract class GroovyProgramTest {
 
         @Override
         public Traversal<Vertex, Vertex> get_g_V_programXpageRankX() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.program(PageRankVertexProgram.build().create(graph))", "graph", graph)
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.program(PageRankVertexProgram.build().create(graph))")
         }
 
         @Override
         public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_programXpageRank_rankX_order_byXrank_incrX_valueMapXname_rankX() {
-            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').program(PageRankVertexProgram.build().property('rank').create(graph)).order.by('rank',incr).valueMap('name','rank')", "graph", graph);
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').program(PageRankVertexProgram.build().property('rank').create(graph)).order.by('rank',incr).valueMap('name','rank')");
         }
     }
 }

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyProgramTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/map/GroovyProgramTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal
+import org.apache.tinkerpop.gremlin.process.traversal.util.ScriptTraversal
+import org.apache.tinkerpop.gremlin.structure.Vertex
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class GroovyProgramTest {
+
+    public static class Traversals extends ProgramTest {
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_programXpageRankX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.program(PageRankVertexProgram.build().create(graph))", "graph", graph)
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_programXpageRank_rankX_order_byXrank_incrX_valueMapXname_rankX() {
+            new ScriptTraversal<>(g, "gremlin-groovy", "g.V.hasLabel('person').program(PageRankVertexProgram.build().property('rank').create(graph)).order.by('rank',incr).valueMap('name','rank')", "graph", graph);
+        }
+    }
+}
+
+

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/process/GroovyProcessComputerSuite.java
@@ -61,6 +61,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPageRankTes
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPeerPressureTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyProfileTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovyPropertiesTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GroovySumTest;
@@ -146,6 +147,7 @@ public class GroovyProcessComputerSuite extends ProcessComputerSuite {
             GroovyPathTest.Traversals.class,
             GroovyPeerPressureTest.Traversals.class,
             GroovyProfileTest.Traversals.class,
+            GroovyProgramTest.Traversals.class,
             GroovyPropertiesTest.Traversals.class,
             GroovySelectTest.Traversals.class,
             GroovySumTest.Traversals.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/ProcessComputerSuite.java
@@ -64,6 +64,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.PageRankTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PathTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PeerPressureTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProfileTest;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.ProgramTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.PropertiesTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.SumTest;
@@ -154,6 +155,7 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             PathTest.Traversals.class,
             PeerPressureTest.Traversals.class,
             ProfileTest.Traversals.class,
+            ProgramTest.Traversals.class,
             PropertiesTest.Traversals.class,
             SelectTest.Traversals.class,
             UnfoldTest.Traversals.class,
@@ -227,8 +229,10 @@ public class ProcessComputerSuite extends AbstractGremlinSuite {
             MatchTest.class,
             OrderTest.class,
             PageRankTest.class,
+            PeerPressureTest.class,
             PathTest.class,
             ProfileTest.class,
+            ProgramTest.class,
             PropertiesTest.class,
             SelectTest.class,
             UnfoldTest.class,

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProgramTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ProgramTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tinkerpop.gremlin.process.traversal.step.map;
+
+import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
+import org.apache.tinkerpop.gremlin.process.computer.ranking.pagerank.PageRankVertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Marko A. Rodriguez (http://markorodriguez.com)
+ */
+public abstract class ProgramTest extends AbstractGremlinProcessTest {
+
+    public abstract Traversal<Vertex, Vertex> get_g_V_programXpageRankX();
+
+    public abstract Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_programXpageRank_rankX_order_byXrank_incrX_valueMapXname_rankX();
+
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_programXpageRankX() {
+        final Traversal<Vertex, Vertex> traversal = get_g_V_programXpageRankX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        while (traversal.hasNext()) {
+            final Vertex vertex = traversal.next();
+            counter++;
+            assertTrue(vertex.property(PageRankVertexProgram.PAGE_RANK).isPresent());
+        }
+        assertEquals(6, counter);
+    }
+
+    @Test
+    @LoadGraphWith(MODERN)
+    public void g_V_hasLabelXpersonX_programXpageRank_rankX_order_byXrank_decrX_valueMapXname_rankX() {
+        final Traversal<Vertex, Map<String, List<Object>>> traversal = get_g_V_hasLabelXpersonX_programXpageRank_rankX_order_byXrank_incrX_valueMapXname_rankX();
+        printTraversalForm(traversal);
+        int counter = 0;
+        double lastRank = Double.MIN_VALUE;
+        while (traversal.hasNext()) {
+            final Map<String, List<Object>> map = traversal.next();
+            assertEquals(2, map.size());
+            assertEquals(1, map.get("name").size());
+            assertEquals(1, map.get("rank").size());
+            String name = (String) map.get("name").get(0);
+            double rank = (Double) map.get("rank").get(0);
+            assertTrue(rank >= lastRank);
+            lastRank = rank;
+            assertFalse(name.equals("lop") || name.equals("ripple"));
+            counter++;
+        }
+        assertEquals(4, counter);
+    }
+
+
+    public static class Traversals extends ProgramTest {
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_V_programXpageRankX() {
+            return g.V().program(PageRankVertexProgram.build().create(graph));
+        }
+
+        @Override
+        public Traversal<Vertex, Map<String, List<Object>>> get_g_V_hasLabelXpersonX_programXpageRank_rankX_order_byXrank_incrX_valueMapXname_rankX() {
+            return g.V().hasLabel("person").program(PageRankVertexProgram.build().property("rank").create(graph)).order().by("rank", Order.incr).valueMap("name", "rank");
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1234

We now have `GraphTraversal.program(VertexProgram)`. This allows users to do things such as:

```
g.V().out("bought").in("bought").program(CollaborativeFilteringVertexProgram.build()....)
```

Behaves just like any other `VertexProgramStep` where:

```
g.V().pageRank() == g.V().program(PageRankVertexProgram...)
```

CHANGELOG

```
* Added `GraphTraversal.program(VertexProgram)` to allow arbitrary user vertex programs in OLAP.
```

VOTE +1. @dkuppitz tested it with his use case as well.