### PR TITLE
TINKERPOP-1020 Provide --dryRun selectivity for "half publishing" docs.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Improved dryRun functionality for the docs processor. It's now possible to dry run (or full run) only specific files.
 
 
 [[release-3-1-2-incubating]]

--- a/bin/process-docs.sh
+++ b/bin/process-docs.sh
@@ -26,6 +26,18 @@ DRYRUN=
 DRYRUN_DOCS=
 FULLRUN_DOCS=
 
+makeAbsPaths () {
+  for doc in $(tr ',' $'\n' <<< "$1"); do
+    if [ -d $doc ]; then
+      for d in $(find "$doc" -name "*.asciidoc"); do
+        echo $(cd $(dirname "$d") && pwd -P)/$(basename "$d")
+      done
+    else
+      echo $(cd $(dirname "$doc") && pwd -P)/$(basename "$doc")
+    fi
+  done | paste -sd ',' -
+}
+
 while [[ $# -gt 0 ]]
 do
   key="$1"
@@ -38,7 +50,7 @@ do
       DRYRUN=1
       shift
       if [[ $# -gt 0 ]] && [[ $1 != -* ]]; then
-        DRYRUN_DOCS="$1"
+        DRYRUN_DOCS=$(makeAbsPaths "$1")
         shift
       else
         DRYRUN_DOCS="*"
@@ -48,7 +60,7 @@ do
       DRYRUN=1
       DRYRUN_DOCS=${DRYRUN_DOCS:-"*"}
       shift
-      FULLRUN_DOCS="$1"
+      FULLRUN_DOCS=$(makeAbsPaths "$1")
       shift
       ;;
     *)

--- a/docs/preprocessor/preprocess-file.sh
+++ b/docs/preprocessor/preprocess-file.sh
@@ -56,7 +56,7 @@ input=$4
 output=`sed 's@/docs/src/@/target/postprocess-asciidoc/@' <<< "${input}"`
 
 SKIP=
-if dryRun `basename ${input} .asciidoc`; then
+if dryRun ${input}; then
   SKIP=1
 fi
 

--- a/docs/preprocessor/preprocess.sh
+++ b/docs/preprocessor/preprocess.sh
@@ -19,36 +19,42 @@
 # under the License.
 #
 
+DRYRUN_DOCS="$1"
+FULLRUN_DOCS="$2"
+
 pushd "$(dirname $0)/../.." > /dev/null
 
-if [ ! -f bin/gremlin.sh ]; then
-  echo "Gremlin REPL is not available. Cannot preprocess AsciiDoc files."
-  popd > /dev/null
-  exit 1
-fi
+if [ "${DRYRUN_DOCS}" != "" ]; then
 
-for daemon in "NameNode" "DataNode" "ResourceManager" "NodeManager"
-do
-  running=`jps | cut -d ' ' -f2 | grep -c ${daemon}`
-  if [ ${running} -eq 0 ]; then
-    echo "Hadoop is not running, be sure to start it before processing the docs."
+  if [ ! -f bin/gremlin.sh ]; then
+    echo "Gremlin REPL is not available. Cannot preprocess AsciiDoc files."
+    popd > /dev/null
     exit 1
   fi
-done
 
-netstat -an | awk '{print $4}' | grep -o '[0-9]*$' | grep 8182 > /dev/null && {
-  echo "The port 8182 is required for Gremlin Server, but already in use. Be sure to close the application that currently uses the port before processing the docs."
-  exit 1
-}
+  for daemon in "NameNode" "DataNode" "ResourceManager" "NodeManager"
+  do
+    running=`jps | cut -d ' ' -f2 | grep -c ${daemon}`
+    if [ ${running} -eq 0 ]; then
+      echo "Hadoop is not running, be sure to start it before processing the docs."
+      exit 1
+    fi
+  done
 
-if [ -e /tmp/neo4j ]; then
-  echo "The directory '/tmp/neo4j' is required by the pre-processor, be sure to delete it before processing the docs."
-  exit 1
-fi
+  netstat -an | awk '{print $4}' | grep -o '[0-9]*$' | grep 8182 > /dev/null && {
+    echo "The port 8182 is required for Gremlin Server, but already in use. Be sure to close the application that currently uses the port before processing the docs."
+    exit 1
+  }
 
-if [ -e /tmp/tinkergraph.kryo ]; then
-  echo "The file '/tmp/tinkergraph.kryo' is required by the pre-processor, be sure to delete it before processing the docs."
-  exit 1
+  if [ -e /tmp/neo4j ]; then
+    echo "The directory '/tmp/neo4j' is required by the pre-processor, be sure to delete it before processing the docs."
+    exit 1
+  fi
+
+  if [ -e /tmp/tinkergraph.kryo ]; then
+    echo "The file '/tmp/tinkergraph.kryo' is required by the pre-processor, be sure to delete it before processing the docs."
+    exit 1
+  fi
 fi
 
 function directory {
@@ -91,19 +97,23 @@ function cleanup() {
 
 trap cleanup EXIT
 
-# install plugins
-echo
-echo "=========================="
-echo "+   Installing Plugins   +"
-echo "=========================="
-echo
-cp ${CONSOLE_HOME}/ext/plugins.txt ${TMP_DIR}/plugins.txt.orig
-docs/preprocessor/install-plugins.sh "${CONSOLE_HOME}" "${TP_VERSION}" "${TMP_DIR}"
+if [ "${DRYRUN_DOCS}" != "*" ]; then
 
-if [ $? -ne 0 ]; then
-  exit 1
-else
+  # install plugins
   echo
+  echo "=========================="
+  echo "+   Installing Plugins   +"
+  echo "=========================="
+  echo
+  cp ${CONSOLE_HOME}/ext/plugins.txt ${TMP_DIR}/plugins.txt.orig
+  docs/preprocessor/install-plugins.sh "${CONSOLE_HOME}" "${TP_VERSION}" "${TMP_DIR}"
+
+  if [ $? -ne 0 ]; then
+    exit 1
+  else
+    echo
+  fi
+
 fi
 
 # process *.asciidoc files
@@ -125,7 +135,7 @@ find "${TP_HOME}/docs/src/" -name index.asciidoc | xargs -n1 dirname | while rea
          xargs -n1 basename |
          xargs -n1 -I {} echo "echo -ne {}' '; (grep -n {} ${subdir}/index.asciidoc || echo 0) | head -n1 | cut -d ':' -f1" | /bin/bash | sort -nk2 | cut -d ' ' -f1 |
          xargs -n1 -I {} echo "${subdir}/{}" |
-         xargs -n1 ${TP_HOME}/docs/preprocessor/preprocess-file.sh "${CONSOLE_HOME}"
+         xargs -n1 ${TP_HOME}/docs/preprocessor/preprocess-file.sh "${CONSOLE_HOME}" "${DRYRUN_DOCS}" "${FULLRUN_DOCS}"
 
     ps=(${PIPESTATUS[@]})
     for i in {0..7}; do

--- a/docs/preprocessor/preprocess.sh
+++ b/docs/preprocessor/preprocess.sh
@@ -24,7 +24,7 @@ FULLRUN_DOCS="$2"
 
 pushd "$(dirname $0)/../.." > /dev/null
 
-if [ "${DRYRUN_DOCS}" != "" ]; then
+if [ "${DRYRUN_DOCS}" != "*" ]; then
 
   if [ ! -f bin/gremlin.sh ]; then
     echo "Gremlin REPL is not available. Cannot preprocess AsciiDoc files."

--- a/docs/src/dev/developer/contributing.asciidoc
+++ b/docs/src/dev/developer/contributing.asciidoc
@@ -80,6 +80,8 @@ mvn -Dmaven.javadoc.skip=true --projects tinkergraph-gremlin test
 * Check license headers are present: `mvn apache-rat:check`
 * Build AsciiDocs (Hadoop must be running and link:http://www.grymoire.com/Unix/Awk.html[awk] version `4.0.1` is required): `bin/process-docs.sh`
 ** Build AsciiDocs (but don't evaluate code blocks): `bin/process-docs.sh --dryRun`
+** Build AsciiDocs (but don't evaluate code blocks in specific files): `bin/process-docs.sh --dryRun the-graph,the-traversal,...`
+** Build AsciiDocs (but evaluate code blocks only in specific files): `bin/process-docs.sh --fullRun the-graph,the-traversal,...`
 ** Process a single AsciiDoc file: +pass:[docs/preprocessor/preprocess-file.sh `pwd`/gremlin-console/target/apache-gremlin-console-*-standalone `pwd`/docs/src/xyz.asciidoc]+
 * Build JavaDocs: `mvn process-resources -Djavadoc`
 * Check for Apache License headers: `mvn apache-rat:check`

--- a/docs/src/dev/developer/contributing.asciidoc
+++ b/docs/src/dev/developer/contributing.asciidoc
@@ -80,8 +80,8 @@ mvn -Dmaven.javadoc.skip=true --projects tinkergraph-gremlin test
 * Check license headers are present: `mvn apache-rat:check`
 * Build AsciiDocs (Hadoop must be running and link:http://www.grymoire.com/Unix/Awk.html[awk] version `4.0.1` is required): `bin/process-docs.sh`
 ** Build AsciiDocs (but don't evaluate code blocks): `bin/process-docs.sh --dryRun`
-** Build AsciiDocs (but don't evaluate code blocks in specific files): `bin/process-docs.sh --dryRun the-graph,the-traversal,...`
-** Build AsciiDocs (but evaluate code blocks only in specific files): `bin/process-docs.sh --fullRun the-graph,the-traversal,...`
+** Build AsciiDocs (but don't evaluate code blocks in specific files): `bin/process-docs.sh --dryRun docs/src/reference/the-graph.asciidoc,docs/src/tutorial/getting-started,...`
+** Build AsciiDocs (but evaluate code blocks only in specific files): `bin/process-docs.sh --fullRun docs/src/reference/the-graph.asciidoc,docs/src/tutorial/getting-started,...`
 ** Process a single AsciiDoc file: +pass:[docs/preprocessor/preprocess-file.sh `pwd`/gremlin-console/target/apache-gremlin-console-*-standalone `pwd`/docs/src/xyz.asciidoc]+
 * Build JavaDocs: `mvn process-resources -Djavadoc`
 * Check for Apache License headers: `mvn apache-rat:check`


### PR DESCRIPTION
**Process all docs**:

```sh
bin/process-docs.sh
```

**Dry-run all docs**:

```sh
bin/process-docs.sh -d
bin/process-docs.sh --dryRun
```

**Process only `the-graph.asciidoc` and `the-traversal.asciidoc`** (dry-run the others):

```sh
bin/process-docs.sh -f the-graph,the-traversal
bin/process-docs.sh --fullRun the-graph,the-traversal
```

**Dry-run `the-graph.asciidoc` and `the-traversal.asciidoc`** (process the others):

```sh
bin/process-docs.sh -d the-graph,the-traversal
bin/process-docs.sh --dryRun the-graph,the-traversal
```

VOTE: +1