### PR TITLE
TINKERPOP-1269 Additional SSL options for Driver

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added driver configuration settings for SSL: `keyCertChainFile`, `keyFile` and `keyPassword`.
 * Fixed bug where transaction managed sessions were not properly rolling back transactions for exceptions encountered during script evaluation.
 * Fixed bug in `:uninstall` command if the default `/ext` directory was not used.
 

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -610,6 +610,9 @@ The following table describes the various configuration options for the Gremlin 
 |Key |Description |Default
 |connectionPool.channelizer |The fully qualified classname of the client `Channelizer` that defines how to connect to the server. |`Channelizer.WebSocketChannelizer`
 |connectionPool.enableSsl |Determines if SSL should be enabled or not. If enabled on the server then it must be enabled on the client. |false
+|connectionPool.keyCertChainFile |The X.509 certificate chain file in PEM format. |_none_
+|connectionPool.keyFile |The `PKCS#8` private key file in PEM format. |_none_
+|connectionPool.keyPassword |The password of the `keyFile` if it's not password-protected |_none_
 |connectionPool.maxContentLength |The maximum length in bytes that a message can be sent to the server. This number can be no greater than the setting of the same name in the server configuration. |65536
 |connectionPool.maxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |4
 |connectionPool.maxSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |16

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Cluster.java
@@ -144,6 +144,9 @@ public final class Cluster {
                 .port(settings.port)
                 .enableSsl(settings.connectionPool.enableSsl)
                 .trustCertificateChainFile(settings.connectionPool.trustCertChainFile)
+                .keyCertChainFile(settings.connectionPool.keyCertChainFile)
+                .keyFile(settings.connectionPool.keyFile)
+                .keyPassword(settings.connectionPool.keyPassword)
                 .nioPoolSize(settings.nioPoolSize)
                 .workerPoolSize(settings.workerPoolSize)
                 .reconnectInterval(settings.connectionPool.reconnectInterval)
@@ -286,6 +289,9 @@ public final class Cluster {
         private String channelizer = Channelizer.WebSocketChannelizer.class.getName();
         private boolean enableSsl = false;
         private String trustCertChainFile = null;
+        private String keyCertChainFile = null;
+        private String keyFile = null;
+        private String keyPassword = null;
         private LoadBalancingStrategy loadBalancingStrategy = new LoadBalancingStrategy.RoundRobin();
         private AuthProperties authProps = new AuthProperties();
 
@@ -359,6 +365,30 @@ public final class Cluster {
          */
         public Builder trustCertificateChainFile(final String certificateChainFile) {
             this.trustCertChainFile = certificateChainFile;
+            return this;
+        }
+
+        /**
+         * The X.509 certificate chain file in PEM format.
+         */
+        public Builder keyCertChainFile(final String keyCertChainFile) {
+            this.keyCertChainFile = keyCertChainFile;
+            return this;
+        }
+
+        /**
+         * The PKCS#8 private key file in PEM format.
+         */
+        public Builder keyFile(final String keyFile) {
+            this.keyFile = keyFile;
+            return this;
+        }
+
+        /**
+         * The password of the {@link #keyFile}, or {@code null} if it's not password-protected.
+         */
+        public Builder keyPassword(final String keyPassword) {
+            this.keyPassword = keyPassword;
             return this;
         }
 
@@ -587,6 +617,9 @@ public final class Cluster {
             connectionPoolSettings.resultIterationBatchSize = this.resultIterationBatchSize;
             connectionPoolSettings.enableSsl = this.enableSsl;
             connectionPoolSettings.trustCertChainFile = this.trustCertChainFile;
+            connectionPoolSettings.keyCertChainFile = this.keyCertChainFile;
+            connectionPoolSettings.keyFile = this.keyFile;
+            connectionPoolSettings.keyPassword = this.keyPassword;
             connectionPoolSettings.channelizer = this.channelizer;
             return new Cluster(getContactPoints(), serializer, this.nioPoolSize, this.workerPoolSize,
                     connectionPoolSettings, loadBalancingStrategy, authProps);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -119,6 +119,21 @@ final class Settings {
         public String trustCertChainFile = null;
 
         /**
+         * The X.509 certificate chain file in PEM format.
+         */
+        public String keyCertChainFile = null;
+
+        /**
+         * The PKCS#8 private key file in PEM format.
+         */
+        public String keyFile = null;
+
+        /**
+         * The password of the {@link #keyFile}, or {@code null} if it's not password-protected.
+         */
+        public String keyPassword = null;
+
+        /**
          * The minimum size of a connection pool for a {@link Host}. By default this is set to 2.
          */
         public int minSize = ConnectionPool.MIN_POOL_SIZE;


### PR DESCRIPTION
This is a really boring PR - just added some more flexibility to the driver to allow the user to do more SSL stuff. Existing SSL settings still works as before:

```text
gremlin> :remote connect tinkerpop.server conf/remote-secure.yaml
WARN  org.apache.tinkerpop.gremlin.driver.Channelizer$AbstractChannelizer  - SSL configured without a trustCertChainFile and thus trusts all certificates without verification (not suitable for production)
==>Connected - localhost/127.0.0.1:8182
gremlin> :remote console
==>All scripts will now be sent to Gremlin Server - [localhost/127.0.0.1:8182] - type ':remote console' to return to local mode
gremlin> 1 + 1
==>2
```

Tests for SSL still working after:

```text
$ mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false -DincludeNeo4j
``` 

VOTE +1