### PR TITLE
TINKERPOP-1267 Added option for "none" on remote timeouts.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Added configuration option for disabling `:remote` timeout with `:remote config timeout none`.
 * Added `init-tp-spark.sh` to Gremlin Console binary distribution.
 * Fixed bug where use of `:x` in a Gremlin Console initialization script would generate a stack trace.
 * Added configuration options to Gremlin Driver and Server to override the SSL configuration with an `SslContext`.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -467,8 +467,8 @@ The Gremlin Server `:remote config` command for the driver has the following con
 !`reset` !Clears any aliases that were supplied in previous configurations of the remote.
 !`show` !Shows the current set of aliases which is returned as a `Map`
 !=========================================================
-|timeout |Specifies the length of time in milliseconds a will wait for a response from the server. Specify "max" to
-essentially have no timeout.
+|timeout |Specifies the length of time in milliseconds a will wait for a response from the server. Specify "none" to
+have no timeout. By default, this setting uses "none".
 |=========================================================
 
 [[console-aliases]]

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -29,6 +29,31 @@ TinkerPop 3.1.3
 
 Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.1.2-incubating/CHANGELOG.asciidoc#tinkerpop-313-release-date-MONTH-DAY-YEAR[changelog] for a complete list of all the modifications that are part of this release.
 
+Upgrading for Users
+~~~~~~~~~~~~~~~~~~~
+
+Remote Timeout
+^^^^^^^^^^^^^^
+
+Disabling the timeout for a `:remote` to Gremlin Server was previously accomplished by setting the timeout to `max` as
+in:
+
+[source,text]
+:remote config timeout max
+
+where `max` would set the timeout to be `Integer.MAX_VALUE`. While this feature is still supported, it has been
+deprecated in favor of the new configuration option of `none`, as in:
+
+[source,text]
+:remote config timeout none
+
+The use of `none` completely disables the timeout rather than just setting an arbitrarily high one. Note that it is
+still possible to get a timeout on a request if the server timeout limits are reached. The console timeout value only
+refers to how long the console will wait for a response from the server before giving up. By default, the timeout is
+set to `none`.
+
+See: https://issues.apache.org/jira/browse/TINKERPOP-1267[TINKERPOP-1267]
+
 Upgrading for Providers
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptor.java
+++ b/gremlin-console/src/main/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptor.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.console.groovy.plugin;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.groovy.plugin.RemoteAcceptor;
@@ -52,15 +53,23 @@ import java.util.stream.Stream;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class DriverRemoteAcceptor implements RemoteAcceptor {
+    public static final int NO_TIMEOUT = -1;
+
     private Cluster currentCluster;
     private Client currentClient;
-    private int timeout = 180000;
+    private int timeout = NO_TIMEOUT;
     private Map<String,String> aliases = new HashMap<>();
     private Optional<String> session = Optional.empty();
 
     private static final String TOKEN_RESET = "reset";
     private static final String TOKEN_SHOW = "show";
+
+    /**
+     * @deprecated As of 3.1.3-incubating, replaced by "none" option
+     */
+    @Deprecated
     private static final String TOKEN_MAX = "max";
+    private static final String TOKEN_NONE = "none";
     private static final String TOKEN_TIMEOUT = "timeout";
     private static final String TOKEN_ALIAS = "alias";
     private static final String TOKEN_SESSION = "session";
@@ -104,13 +113,14 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
         final List<String> arguments = args.subList(1, args.size());
 
         if (option.equals(TOKEN_TIMEOUT)) {
-            final String errorMessage = "The timeout option expects a positive integer representing milliseconds or 'max' as an argument";
+            final String errorMessage = "The timeout option expects a positive integer representing milliseconds or 'none' as an argument";
             if (arguments.size() != 1) throw new RemoteException(errorMessage);
             try {
-                final int to = arguments.get(0).equals(TOKEN_MAX) ? Integer.MAX_VALUE : Integer.parseInt(arguments.get(0));
-                if (to <= 0) throw new RemoteException(errorMessage);
-                this.timeout = to;
-                return "Set remote timeout to " + to + "ms";
+                // first check for MAX timeout then NONE and finally parse the config to int. "max" is now "deprecated"
+                // in the sense that it will no longer be promoted. support for it will be removed at a later date
+                timeout = arguments.get(0).equals(TOKEN_MAX) ? Integer.MAX_VALUE :
+                        arguments.get(0).equals(TOKEN_NONE) ? NO_TIMEOUT : Integer.parseInt(arguments.get(0));
+                return timeout == NO_TIMEOUT ? "Remote timeout is disable" : "Set remote timeout to " + timeout + "ms";
             } catch (Exception ignored) {
                 throw new RemoteException(errorMessage);
             }
@@ -171,10 +181,14 @@ public class DriverRemoteAcceptor implements RemoteAcceptor {
         if (this.currentCluster != null) this.currentCluster.close();
     }
 
+    public int getTimeout() {
+        return timeout;
+    }
+
     private List<Result> send(final String gremlin) throws SaslException {
         try {
-            return this.currentClient.submitAsync(gremlin, aliases, Collections.emptyMap()).get()
-                    .all().get(this.timeout, TimeUnit.MILLISECONDS);
+            final ResultSet rs = this.currentClient.submitAsync(gremlin, aliases, Collections.emptyMap()).get();
+            return timeout > 0 ? rs.all().get(timeout, TimeUnit.MILLISECONDS) : rs.all().get();
         } catch(TimeoutException ignored) {
             throw new IllegalStateException("Request timed out while processing - increase the timeout with the :remote command");
         } catch (Exception e) {

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorTest.java
@@ -109,6 +109,24 @@ public class DriverRemoteAcceptorTest {
     }
 
     @Test
+    public void shouldConfigureTimeoutToMax() throws Exception {
+        acceptor.configure(Arrays.asList("timeout", "max"));
+        assertEquals(Integer.MAX_VALUE, acceptor.getTimeout());
+    }
+
+    @Test
+    public void shouldConfigureTimeoutToNone() throws Exception {
+        acceptor.configure(Arrays.asList("timeout", "none"));
+        assertEquals(DriverRemoteAcceptor.NO_TIMEOUT, acceptor.getTimeout());
+    }
+
+    @Test
+    public void shouldConfigureTimeout() throws Exception {
+        acceptor.configure(Arrays.asList("timeout", "123456"));
+        assertEquals(123456, acceptor.getTimeout());
+    }
+
+    @Test
     public void shouldConnect() throws Exception {
         // there is no gremlin server running for this test, but gremlin-driver lazily connects so this should
         // be ok to just validate that a connection is created

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/DriverRemoteAcceptorTest.java
@@ -126,6 +126,11 @@ public class DriverRemoteAcceptorTest {
         assertEquals(123456, acceptor.getTimeout());
     }
 
+    @Test(expected = RemoteException.class)
+    public void shouldConfigureTimeoutNotLessThanNoTimeout() throws Exception {
+        acceptor.configure(Arrays.asList("timeout", "-1"));
+    }
+
     @Test
     public void shouldConnect() throws Exception {
         // there is no gremlin server running for this test, but gremlin-driver lazily connects so this should


### PR DESCRIPTION
Added some tests to validate the new timeout setting and did some manual tests:

```text
gremlin> :remote connect tinkerpop.server conf/remote.yaml
==>Connected - localhost/127.0.0.1:8182
gremlin> :remote config timeout max
==>Set remote timeout to 2147483647ms
gremlin> :remote config timeout none
==>Remote timeout is disable
gremlin> :remote config timeout 10000
==>Set remote timeout to 10000ms
gremlin> :> Thread.sleep(9000)
==>null
gremlin> :> Thread.sleep(11000)
Request timed out while processing - increase the timeout with the :remote command
Display stack trace? [yN] n
```

Successful run of `mvn clean install && mvn verify -pl gremlin-console -DskipIntegrationTests=false`

VOTE +1
