### PR TITLE
TINKERPOP-1284: StarGraph does not handle self-loops correctly.

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -206,10 +206,8 @@ public final class StarGraph implements Graph, Serializable {
         });
 
         vertex.edges(Direction.OUT).forEachRemaining(edge -> {
-            if (!ElementHelper.areEqual(starVertex, edge.inVertex())) { // only do a self loop once
-                final Edge starEdge = starVertex.addOutEdge(edge.label(), starGraph.addVertex(T.id, edge.inVertex().id()), T.id, edge.id());
-                edge.properties().forEachRemaining(p -> starEdge.property(p.key(), p.value()));
-            }
+            final Edge starEdge = starVertex.addOutEdge(edge.label(), starGraph.addVertex(T.id, edge.inVertex().id()), T.id, edge.id());
+            edge.properties().forEachRemaining(p -> starEdge.property(p.key(), p.value()));
         });
         return starGraph;
     }
@@ -290,7 +288,16 @@ public final class StarGraph implements Graph, Serializable {
 
         @Override
         public Edge addEdge(final String label, final Vertex inVertex, final Object... keyValues) {
-            return this.addOutEdge(label, inVertex, keyValues);
+            final Edge edge = this.addOutEdge(label, inVertex, keyValues);
+            if (inVertex.equals(this)) {
+                List<Edge> inE = inEdges.get(label);
+                if (null == inE) {
+                    inE = new ArrayList<>();
+                    this.inEdges.put(label, inE);
+                }
+                inE.add(edge);
+            }
+            return edge;
         }
 
         @Override

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraph.java
@@ -290,7 +290,9 @@ public final class StarGraph implements Graph, Serializable {
         public Edge addEdge(final String label, final Vertex inVertex, final Object... keyValues) {
             final Edge edge = this.addOutEdge(label, inVertex, keyValues);
             if (inVertex.equals(this)) {
-                List<Edge> inE = inEdges.get(label);
+                if(null == this.inEdges)
+                    this.inEdges = new HashMap<>();
+                List<Edge> inE = this.inEdges.get(label);
                 if (null == inE) {
                     inE = new ArrayList<>();
                     this.inEdges.put(label, inE);

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/util/star/StarGraphTest.java
@@ -229,7 +229,23 @@ public class StarGraphTest extends AbstractGremlinTest {
         TestHelper.validateVertexEquality(vertex, starGraph.getStarVertex(), true);
         TestHelper.validateVertexEquality(vertex, starGraphCopy.getStarVertex(), true);
         TestHelper.validateVertexEquality(starGraph.getStarVertex(), starGraphCopy.getStarVertex(), true);
+        // test native non-clone-based methods
+        final StarGraph starGraphNative = StarGraph.open();
+        Vertex v1 = starGraphNative.addVertex(T.label, "thing", T.id, "v1");
+        assertEquals("v1", v1.id());
+        assertEquals("thing", v1.label());
+        Edge e1 = v1.addEdge("self", v1, "name", "pipes");
+        assertEquals(2l, IteratorUtils.count(v1.vertices(Direction.BOTH, "self", "nothing")));
+        assertEquals(1l, IteratorUtils.count(v1.vertices(Direction.OUT)));
+        assertEquals(1l, IteratorUtils.count(v1.vertices(Direction.IN, "self")));
+        edgeIterator = v1.edges(Direction.BOTH);
+        TestHelper.validateEdgeEquality(e1, edgeIterator.next());
+        TestHelper.validateEdgeEquality(e1, edgeIterator.next());
+        assertFalse(edgeIterator.hasNext());
+        TestHelper.validateEdgeEquality(e1, v1.edges(Direction.OUT, "self", "nothing").next());
+        TestHelper.validateEdgeEquality(e1, v1.edges(Direction.IN).next());
     }
+
 
     private Pair<StarGraph, Integer> serializeDeserialize(final StarGraph starGraph) {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1284

```
gremlin> graph = TinkerGraph.open()
==>tinkergraph[vertices:0 edges:0]
gremlin>
gremlin> v = graph.addVertex()
==>v[0]
gremlin> v.addEdge("self",v)
==>e[1][0-self->0]
gremlin> g = graph.traversal()
==>graphtraversalsource[tinkergraph[vertices:1 edges:1], standard]
gremlin> g.V(0l)
==>v[0]
gremlin>  g.V(0l).bothE()
==>e[1][0-self->0]
==>e[1][0-self->0]
gremlin> g.V(0l).outE()
==>e[1][0-self->0]
gremlin> g.V(0l).inE()
==>e[1][0-self->0]
gremlin>
gremlin>
gremlin> starGraph = org.apache.tinkerpop.gremlin.structure.util.star.StarGraph.of(v)
==>stargraph[starOf:v[0]]
gremlin> sg = starGraph.traversal()
==>graphtraversalsource[stargraph[starOf:v[0]], standard]
gremlin> sg.V(0l)
==>v[0]
gremlin> sg.V(0l).bothE()
==>e[1][0-self->0]
==>e[1][0-self->0]
gremlin> sg.V(0l).outE()
==>e[1][0-self->0]
gremlin> sg.V(0l).inE()
==>e[1][0-self->0]
gremlin>
gremlin> // TADA!
==>true
gremlin>
```

`mvn clean install` and Spark integration tests.

VOTE +1