### PR TITLE
TINKERPOP-1120: If there is no view nor messages, don't create empty views/messages in SparkExecutor

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraverserExecutor.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/computer/traversal/TraverserExecutor.java
@@ -154,9 +154,10 @@ public final class TraverserExecutor {
                         traverser.addLabels(step.getLabels());  // this might need to be generalized for working with global barriers too
                         if (traverser.isHalted()) {
                             traverser.detach();
-                            haltedTraversers.add(traverser);
                             if (returnHaltedTraversers)
                                 memory.add(TraversalVertexProgram.HALTED_TRAVERSERS, new TraverserSet<>(traverser.split()));
+                            else
+                                haltedTraversers.add(traverser);
                         } else {
                             traverser.detach();
                             traverserSet.add(traverser);
@@ -175,9 +176,10 @@ public final class TraverserExecutor {
             step.forEachRemaining(traverser -> {
                 if (traverser.isHalted()) {
                     traverser.detach();
-                    haltedTraversers.add(traverser);
                     if (returnHaltedTraversers)
                         memory.add(TraversalVertexProgram.HALTED_TRAVERSERS, new TraverserSet<>(traverser.split()));
+                    else
+                        haltedTraversers.add(traverser);
                 } else {
                     activeTraversers.add(traverser);
                 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/computer/GraphComputerTest.java
@@ -1973,10 +1973,10 @@ public class GraphComputerTest extends AbstractGremlinProcessTest {
         assertEquals(2l, traversers.stream().filter(s -> s.get().equals("software")).map(Traverser::bulk).reduce((a, b) -> a + b).get().longValue());
         assertEquals(6, graph3.traversal().V().count().next().intValue());
         assertEquals(6, graph3.traversal().E().count().next().intValue());
-        assertEquals(6, graph3.traversal().V().values(TraversalVertexProgram.HALTED_TRAVERSERS).count().next().intValue());
+        assertEquals(0, graph3.traversal().V().values(TraversalVertexProgram.HALTED_TRAVERSERS).count().next().intValue());
         assertEquals(6, graph3.traversal().V().values(PeerPressureVertexProgram.CLUSTER).count().next().intValue());
         assertEquals(6, graph3.traversal().V().values(PageRankVertexProgram.PAGE_RANK).count().next().intValue());
-        assertEquals(30, graph3.traversal().V().values().count().next().intValue());
+        assertEquals(24, graph3.traversal().V().values().count().next().intValue()); // no halted traversers
 
         // TODO: add a test the shows DAG behavior -- splitting another TraversalVertexProgram off of the PeerPressureVertexProgram job.
     }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -96,28 +96,27 @@ public final class SparkExecutor {
                         final boolean hasViewAndMessages = vertexViewIncoming._2()._2().isPresent(); // if this is the first iteration, then there are no views or messages
                         final List<DetachedVertexProperty<Object>> previousView = hasViewAndMessages ? vertexViewIncoming._2()._2().get().getView() : memory.isInitialIteration() ? new ArrayList<>() : Collections.emptyList();
                         // revive compute properties if they already exist
-                        if (memory.isInitialIteration() && elementComputeKeysArray.length > 0) {
+                        if (memory.isInitialIteration() && elementComputeKeysArray.length > 0)
                             vertex.properties(elementComputeKeysArray).forEachRemaining(vertexProperty -> previousView.add(DetachedFactory.detach(vertexProperty, true)));
-                        }
                         // drop any computed properties that are cached in memory
-                        if (elementComputeKeysArray.length > 0)
-                            vertex.dropVertexProperties(elementComputeKeysArray);
+                        if (elementComputeKeysArray.length > 0) vertex.dropVertexProperties(elementComputeKeysArray);
                         final List<M> incomingMessages = hasViewAndMessages ? vertexViewIncoming._2()._2().get().getIncomingMessages() : Collections.emptyList();
                         previousView.forEach(property -> property.attach(Attachable.Method.create(vertex)));  // attach the view to the vertex
-                        // previousView.clear(); // no longer needed so kill it from memory
+                        previousView.clear(); // no longer needed so kill it from memory
                         ///
                         messenger.setVertexAndIncomingMessages(vertex, incomingMessages); // set the messenger with the incoming messages
                         workerVertexProgram.execute(ComputerGraph.vertexProgram(vertex, workerVertexProgram), messenger, memory); // execute the vertex program on this vertex for this iteration
-                        // incomingMessages.clear(); // no longer needed so kill it from memory
+                        incomingMessages.clear(); // no longer needed so kill it from memory
                         ///
                         final List<DetachedVertexProperty<Object>> nextView = elementComputeKeysArray.length == 0 ?  // not all vertex programs have compute keys
                                 Collections.emptyList() :
-                                IteratorUtils.list(
-                                        IteratorUtils.map(
-                                                IteratorUtils.filter(
-                                                        vertex.properties(elementComputeKeysArray),
-                                                        VertexProperty::isPresent),
-                                                property -> DetachedFactory.detach(property, true)));
+                                IteratorUtils.list(IteratorUtils.map(
+                                        IteratorUtils.filter(
+                                                vertex.properties(elementComputeKeysArray),
+                                                VertexProperty::isPresent),
+                                        property -> DetachedFactory.detach(property, true)));
+                        // drop any computed properties that are cached in memory
+                        if (elementComputeKeysArray.length > 0) vertex.dropVertexProperties(elementComputeKeysArray);
                         final List<Tuple2<Object, M>> outgoingMessages = messenger.getOutgoingMessages(); // get the outgoing messages
                         if (!partitionIterator.hasNext())
                             workerVertexProgram.workerIterationEnd(memory.asImmutable()); // if no more vertices in the partition, end the worker's iteration

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/SparkExecutor.java
@@ -101,12 +101,13 @@ public final class SparkExecutor {
                         // drop any computed properties that are cached in memory
                         if (elementComputeKeysArray.length > 0) vertex.dropVertexProperties(elementComputeKeysArray);
                         final List<M> incomingMessages = hasViewAndMessages ? vertexViewIncoming._2()._2().get().getIncomingMessages() : Collections.emptyList();
-                        previousView.forEach(property -> property.attach(Attachable.Method.create(vertex)));  // attach the view to the vertex
-                        previousView.clear(); // no longer needed so kill it from memory
+                        IteratorUtils.removeOnNext(previousView.iterator()).forEachRemaining(property -> property.attach(Attachable.Method.create(vertex)));  // attach the view to the vertex
+                        assert previousView.isEmpty();
                         ///
                         messenger.setVertexAndIncomingMessages(vertex, incomingMessages); // set the messenger with the incoming messages
                         workerVertexProgram.execute(ComputerGraph.vertexProgram(vertex, workerVertexProgram), messenger, memory); // execute the vertex program on this vertex for this iteration
-                        incomingMessages.clear(); // no longer needed so kill it from memory
+                        // assert incomingMessages.isEmpty();  // maybe the program didn't read all the messages
+                        incomingMessages.clear();
                         ///
                         final List<DetachedVertexProperty<Object>> nextView = elementComputeKeysArray.length == 0 ?  // not all vertex programs have compute keys
                                 Collections.emptyList() :

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewIncomingPayload.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewIncomingPayload.java
@@ -44,7 +44,9 @@ public final class ViewIncomingPayload<M> implements Payload {
 
     public ViewIncomingPayload(final ViewPayload viewPayload) {
         this.incomingMessages = null;
-        this.view = viewPayload.getView().isEmpty() ? null : viewPayload.getView();
+        this.view = viewPayload.getView();
+        if (this.view.isEmpty())
+            this.view = null;
     }
 
 

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewIncomingPayload.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewIncomingPayload.java
@@ -49,6 +49,11 @@ public final class ViewIncomingPayload<M> implements Payload {
             this.view = null;
     }
 
+    public ViewIncomingPayload(final MessagePayload<M> messagePayload) {
+        this.incomingMessages = new ArrayList<>();
+        this.incomingMessages.add(messagePayload.getMessage());
+    }
+
 
     public List<DetachedVertexProperty<Object>> getView() {
         return null == this.view ? Collections.emptyList() : this.view;

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewIncomingPayload.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewIncomingPayload.java
@@ -44,7 +44,7 @@ public final class ViewIncomingPayload<M> implements Payload {
 
     public ViewIncomingPayload(final ViewPayload viewPayload) {
         this.incomingMessages = null;
-        this.view = viewPayload.getView();
+        this.view = viewPayload.getView().isEmpty() ? null : viewPayload.getView();
     }
 
 
@@ -58,7 +58,7 @@ public final class ViewIncomingPayload<M> implements Payload {
     }
 
     public boolean hasView() {
-        return null != view;
+        return null != this.view;
     }
 
     ////////////////////

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewOutgoingPayload.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewOutgoingPayload.java
@@ -21,6 +21,7 @@ package org.apache.tinkerpop.gremlin.spark.process.computer.payload;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 import scala.Tuple2;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -36,15 +37,15 @@ public final class ViewOutgoingPayload<M> implements Payload {
     }
 
     public ViewOutgoingPayload(final List<DetachedVertexProperty<Object>> view, final List<Tuple2<Object, M>> outgoingMessages) {
-        this.view = view;
-        this.outgoingMessages = outgoingMessages;
+        this.view = view.isEmpty() ? null : view;
+        this.outgoingMessages = outgoingMessages.isEmpty() ? null : outgoingMessages;
     }
 
     public ViewPayload getView() {
-        return new ViewPayload(this.view);
+        return new ViewPayload(null == this.view ? Collections.emptyList() : this.view);
     }
 
     public List<Tuple2<Object, M>> getOutgoingMessages() {
-        return this.outgoingMessages;
+        return null == this.outgoingMessages ? Collections.emptyList() : this.outgoingMessages;
     }
 }

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewOutgoingPayload.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewOutgoingPayload.java
@@ -42,7 +42,7 @@ public final class ViewOutgoingPayload<M> implements Payload {
     }
 
     public ViewPayload getView() {
-        return new ViewPayload(null == this.view ? Collections.emptyList() : this.view);
+        return new ViewPayload(this.view);
     }
 
     public List<Tuple2<Object, M>> getOutgoingMessages() {

--- a/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewPayload.java
+++ b/spark-gremlin/src/main/java/org/apache/tinkerpop/gremlin/spark/process/computer/payload/ViewPayload.java
@@ -38,6 +38,6 @@ public final class ViewPayload implements Payload {
     }
 
     public List<DetachedVertexProperty<Object>> getView() {
-        return this.view;
+        return null == this.view ? Collections.emptyList() : this.view;
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1120

The following PR effects TraversalVertexProgram and SparkGraphComputer. Here is what changed in both:

	-------SparkGraphComputer
	1. If the vertex doesn't pass any messages, don't serialize an empty list, serialize null.
	2. If the vertex doesn't have a view, don't serialize an empty list of detached vertex properties, serialize null.
	3. If the vertex doesn't have a view nor messages, don't do anything!
	-------TraversalVertexProgram
	4. Found a memory bug where halted traversers were still distributed amongst the vertices even though they were sent to the master traversal.
	5. If a halted traverser TraverserSet is empty, remove the property (remove the vertex view!).

You can read about the performance gains by doing this here:
	https://groups.google.com/d/msg/gremlin-users/NKjEXdRNp-M/S48pDXjdAQAJ


CHANGELOG

```
* `SparkGraphComputer` no longer shuffles empty views or empty outgoing messages in order to save time and space.
* `TraversalVertexProgram` no longer maintains empty halted traverser properties in order to save space.
```

UPGRADE

```
TraversalVertexProgram
----------------------

`TraversalVertexProgram` always maintained a `HALTED_TRAVERSERS` `TraverserSet` for each vertex throughout the life of the OLAP computation. However, if there are no halted traversers in the set, then there is no point in keeping the compute property around as without it, time and space are saved. Users that have `VertexPrograms` that are chained off of `TraversalVertexProgram` that have previously assumed that `HALTED_TRAVERSERS` always exists, should now no longer assume that.

---java
// bad code
TraverserSet haltedTraversers = vertex.value(TraversalVertexProgram.HALTED_TRAVERSERS);
// good code
TraverserSet haltedTraversers = vertex.property(TraversalVertexProgram.HALTED_TRAVERSERS).orElse(new TraverserSet());
---
```
