### PR TITLE
Bump SLF4J to 1.7.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ limitations under the License.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skipIntegrationTests>true</skipIntegrationTests>
         <skipPerformanceTests>true</skipPerformanceTests>
-        <slf4j.version>1.7.19</slf4j.version>
+        <slf4j.version>1.7.21</slf4j.version>
         <hadoop.version>2.7.2</hadoop.version>
         <java.tuples.version>1.2</java.tuples.version>
         <javadoc-plugin.version>2.10.1</javadoc-plugin.version>


### PR DESCRIPTION
Releases 1.7.19 and 1.7.20 suffer from a memory leak. See http://www.slf4j.org/news.html.