### PR TITLE
TINKERPOP-1297 Updated the gephi plugin to work on Gephi 0.9.x

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ TinkerPop 3.2.1 (NOT OFFICIALLY RELEASED YET)
 * Added tests to ensure that threaded transactions cannot be re-used.
 * `GraphFilter` helper methods are now more intelligent when determining edge direction/label legality.
 * Added `GraphFilterStrategy` to automatically construct `GraphFilters` via traversal introspection in OLAP.
+* Updated the Gephi Plugin to support Gephi 0.9.x.
 * Increased the testing and scope of `TraversalHelper.isLocalStarGraph()`.
 * Changed signature of `get_g_VXlistXv1_v2_v3XX_name` and `get_g_VXlistX1_2_3XX_name` of `VertexTest` to take arguments for the `Traversal` to be constructed by extending classes.
 * Added `VertexProgramInterceptor` interface as a general pattern for `GraphComputer` providers to use for bypassing `GraphComputer` semantics where appropriate.

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -1630,18 +1630,18 @@ This plugin imports the appropriate classes for managing the credentials graph.
 Gephi Plugin
 ~~~~~~~~~~~~
 
-image:gephi-logo.png[width=200, float=left] link:http://gephi.github.io/[Gephi] is an interactive visualization,
-exploration, and analysis platform for graphs. The link:https://marketplace.gephi.org/plugin/graph-streaming/[Graph Streaming]
-plugin for Gephi provides an link:https://wiki.gephi.org/index.php/Graph_Streaming[API] that can be leveraged to
-stream graphs and visualize traversals interactively through the Gremlin Gephi Plugin.
+image:gephi-logo.png[width=200, float=left] link:http://gephi.org/[Gephi] is an interactive visualization,
+exploration, and analysis platform for graphs. The link:https://gephi.org/plugins/#/plugin/graphstreaming[Graph Streaming]
+plugin for Gephi provides an API that can be leveraged to stream graph data to a running Gephi application. The Gephi
+plugin for Gremlin Console utilizes this API to allow for graph and traversal visualization.
 
-The following instructions assume that Gephi has been download and installed.  It further assumes that the Graph
-Streaming plugin has been installed (`Tools > Plugins`). The following instructions explain how to visualize a `Graph`
-and `Traversal`.
+The Gephi plugin for Gremlin Console is compatible with Gephi 0.9.x. The following instructions assume that Gephi
+has been download and installed.  It further assumes that the Graph Streaming plugin has been installed
+(`Tools > Plugins`). The following instructions explain how to visualize a `Graph` and `Traversal`.
 
 In Gephi, create a new project with `File > New Project`.  In the lower left view, click the "Streaming" tab, open the
 Master drop down, and right click `Master Server > Start` which starts the Graph Streaming server in Gephi and by
-default accepts requests at `http://localhost:8080/workspace0`:
+default accepts requests at `http://localhost:8080/workspace1`:
 
 image::gephi-start-server.png[width=800]
 
@@ -1686,12 +1686,15 @@ that it requires use of the `visualTraversal` option on the `config` function of
 :remote config visualTraversal graph                   <1>
 traversal = vg.V(2).in().out('knows').
                     has('age',gt(30)).outE('created').
-                    has('weight',gt(0.5d)).inV();null
-:> traversal                                           <2>
+                    has('weight',gt(0.5d)).inV();[]    <2>
+:> traversal                                           <3>
 ----
 
-<1> Configure a "visual traversal" from your "graph" - this must be a `Graph` instance.
-<2> Submit the `Traversal` to visualize to Gephi.
+<1> Configure a "visual traversal" from your "graph" - this must be a `Graph` instance. This command will create a
+new `TraversalSource` called "vg" that must be used to visualize any spawned traversals in Gephi.
+<2> Define the traversal to be visualized. Note that ending the line with `;[]` simply prevents iteration of
+the traversal before it is submitted.
+<3> Submit the `Traversal` to visualize to Gephi.
 
 When the `:>` line is called, each step of the `Traversal` that produces or filters vertices generates events to
 Gephi. The events update the color and size of the vertices at that step with `startRGBColor` and `startSize`
@@ -1723,7 +1726,7 @@ Gephi plugin configuration parameters as accepted via the `:remote config` comma
 [width="100%",cols="3,10,^2",options="header"]
 |=========================================================
 |Parameter |Description |Default
-|workspace |The name of the workspace that your Graph Streaming server is started for. |workspace0
+|workspace |The name of the workspace that your Graph Streaming server is started for. |workspace1
 |host |The host URL where the Graph Streaming server is configured for. |localhost
 |port |The port number of the URL that the Graph Streaming server is listening on. |8080
 |sizeDecrementRate |The rate at which the size of an element decreases on each step of the visualization. |0.33
@@ -1732,7 +1735,7 @@ Gephi plugin configuration parameters as accepted via the `:remote config` comma
 |startSize |The size an element should be when it is most recently visited. |20
 |colorToFade |A single char from the set `{r,g,b,R,G,B}` determining which color to fade for vertices visited in prior steps |g
 |colorFadeRate |A float value in the range `(0.0,1.0]` which is multiplied against the current `colorToFade` value for prior vertices; a `1.0` value effectively turns off the color fading of prior step visited vertices |0.7
-|visualTraversal |Creates a `TraversalSource` variable in the Console named `vg` which can be used for visualizing traversals. This configuration option takes two parameters.  The first is required and is the name of the `Graph` instance variable that will generate the `TraversalSource`.  The second parameter is the variable name that the `TraversalSource` should have when referenced in the Console.  If left unspecified, this value defaults to `vg`.
+|visualTraversal |Creates a `TraversalSource` variable in the Console named `vg` which can be used for visualizing traversals. This configuration option takes two parameters.  The first is required and is the name of the `Graph` instance variable that will generate the `TraversalSource`.  The second parameter is the variable name that the `TraversalSource` should have when referenced in the Console.  If left unspecified, this value defaults to `vg`. |vg
 |=========================================================
 
 [[server-plugin]]

--- a/docs/src/upgrade/release-3.2.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.2.x-incubating.asciidoc
@@ -32,6 +32,14 @@ Please see the link:https://github.com/apache/incubator-tinkerpop/blob/3.2.1-inc
 Upgrading for Users
 ~~~~~~~~~~~~~~~~~~~
 
+Gephi Plugin
+^^^^^^^^^^^^
+
+The Gephi Plugin has been updated to support Gephi 0.9.x. Please upgrade to this latest version to use the Gephi Plugin
+for Gremlin Console.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1297[TINKERPOP-1297]
+
 TraversalVertexProgram
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/GephiRemoteAcceptorIntegrateTest.java
+++ b/gremlin-console/src/test/java/org/apache/tinkerpop/gremlin/console/groovy/plugin/GephiRemoteAcceptorIntegrateTest.java
@@ -82,31 +82,31 @@ public class GephiRemoteAcceptorIntegrateTest {
 
     @Test
     public void shouldConnectWithDefaults() throws RemoteException {
-        assertThat(acceptor.connect(Collections.emptyList()).toString(), startsWith("Connection to Gephi - http://localhost:" + port + "/workspace0"));
+        assertThat(acceptor.connect(Collections.emptyList()).toString(), startsWith("Connection to Gephi - http://localhost:" + port + "/workspace1"));
     }
 
     @Test
     public void shouldSubmitGraph() throws RemoteException {
-        stubFor(post(urlPathEqualTo("/workspace0"))
+        stubFor(post(urlPathEqualTo("/workspace1"))
                 .withQueryParam("format", equalTo("JSON"))
                 .withQueryParam("operation", equalTo("updateGraph"))
                 .willReturn(aResponse()
                         .withStatus(200)));
 
-        stubFor(get(urlPathEqualTo("/workspace0"))
+        stubFor(get(urlPathEqualTo("/workspace1"))
                 .withQueryParam("operation", equalTo("getNode"))
                 .willReturn(aResponse()
                         .withStatus(200)));
 
         acceptor.submit(Arrays.asList("g = org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph.open();g.addVertex();g"));
 
-        wireMockRule.verify(4, postRequestedFor(urlPathEqualTo("/workspace0")));
-        wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/workspace0")));
+        wireMockRule.verify(4, postRequestedFor(urlPathEqualTo("/workspace1")));
+        wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/workspace1")));
     }
 
     @Test
     public void shouldSubmitTraversalAfterConfigWithDefaultG() throws RemoteException {
-        stubFor(post(urlPathEqualTo("/workspace0"))
+        stubFor(post(urlPathEqualTo("/workspace1"))
                 .withQueryParam("format", equalTo("JSON"))
                 .withQueryParam("operation", equalTo("updateGraph"))
                 .willReturn(aResponse()
@@ -118,12 +118,12 @@ public class GephiRemoteAcceptorIntegrateTest {
         acceptor.submit(Arrays.asList(
                 "vg.V(2).in('knows').out('knows').has('age',org.apache.tinkerpop.gremlin.process.traversal.P.gt(30)).outE('created').has('weight',org.apache.tinkerpop.gremlin.process.traversal.P.gt(0.5d)).inV().iterate()"));
 
-        wireMockRule.verify(18, postRequestedFor(urlPathEqualTo("/workspace0")));
+        wireMockRule.verify(18, postRequestedFor(urlPathEqualTo("/workspace1")));
     }
 
     @Test
     public void shouldSubmitTraversalAfterConfigWithDefinedG() throws RemoteException {
-        stubFor(post(urlPathEqualTo("/workspace0"))
+        stubFor(post(urlPathEqualTo("/workspace1"))
                 .withQueryParam("format", equalTo("JSON"))
                 .withQueryParam("operation", equalTo("updateGraph"))
                 .willReturn(aResponse()
@@ -135,12 +135,12 @@ public class GephiRemoteAcceptorIntegrateTest {
         acceptor.submit(Arrays.asList(
                 "x.V(2).in('knows').out('knows').has('age',org.apache.tinkerpop.gremlin.process.traversal.P.gt(30)).outE('created').has('weight',org.apache.tinkerpop.gremlin.process.traversal.P.gt(0.5d)).inV().iterate()"));
 
-        wireMockRule.verify(18, postRequestedFor(urlPathEqualTo("/workspace0")));
+        wireMockRule.verify(18, postRequestedFor(urlPathEqualTo("/workspace1")));
     }
 
     @Test
     public void shouldSubmitTraversalOverRepeat() throws RemoteException {
-        stubFor(post(urlPathEqualTo("/workspace0"))
+        stubFor(post(urlPathEqualTo("/workspace1"))
                 .withQueryParam("format", equalTo("JSON"))
                 .withQueryParam("operation", equalTo("updateGraph"))
                 .willReturn(aResponse()
@@ -152,12 +152,12 @@ public class GephiRemoteAcceptorIntegrateTest {
         acceptor.submit(Arrays.asList(
                 "vg.V(1).repeat(org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__().out()).times(2).iterate()"));
 
-        wireMockRule.verify(13, postRequestedFor(urlPathEqualTo("/workspace0")));
+        wireMockRule.verify(13, postRequestedFor(urlPathEqualTo("/workspace1")));
     }
 
     @Test
     public void shouldClearGraph() throws RemoteException {
-        stubFor(post(urlPathEqualTo("/workspace0"))
+        stubFor(post(urlPathEqualTo("/workspace1"))
                 .withQueryParam("format", equalTo("JSON"))
                 .withQueryParam("operation", equalTo("updateGraph"))
                 .withRequestBody(equalToJson("{\"dn\":{\"filter\":\"ALL\"}}"))
@@ -166,7 +166,7 @@ public class GephiRemoteAcceptorIntegrateTest {
 
         acceptor.submit(Arrays.asList("clear"));
 
-        wireMockRule.verify(1, postRequestedFor(urlPathEqualTo("/workspace0")));
+        wireMockRule.verify(1, postRequestedFor(urlPathEqualTo("/workspace1")));
     }
 
     private static int pickOpenPort() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1297

Also Improved output of HTTP request errors to gephi. It is likely that this change will not allow Gephi to work with 0.8.x anymore.

Tested manually and ran tests with: 

```text
mvn clean install && mvn verify -pl gremlin-console -DskipIntegrationTests=false
```

VOTE +1