### PR TITLE
Broaden catch for computePath.

### DIFF
--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/TestHelper.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/TestHelper.java
@@ -113,7 +113,7 @@ public final class TestHelper {
         String clsPath;
 		try {
 			clsPath = new File(url.toURI()).getAbsolutePath();
-		} catch (URISyntaxException e) {
+		} catch (Exception e) {
 			throw new RuntimeException("Unable to computePath for " + clazz, e);
 		}
         return clsPath.substring(0, clsPath.length() - clsUri.length());


### PR DESCRIPTION
I'm getting `java.lang.IllegalArgumentException: URI is not hierarchical`, on OS/X, but don't get any context, therefore broaden the catch.