### PR TITLE
TINKERPOP-1300 Fixed many broken count asserts not being applied in test suite.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fixed a bug in `BulkSet.equals()` which made itself apparent when using `store()` and `aggregate()` with labeled `cap()`.
+* Ensured that all asserts of vertex and edge counts were being applied properly in the test suite.
 * Fixed bug in `gremlin-driver` where certain channel-level errors would not allow the driver to reconnect.
 * Bumped SLF4J to 1.7.21 as previous versions suffered from a memory leak.
 * Fixed a bug in `Neo4jGraphStepStrategy` where it wasn't defined properly as a `ProviderOptimizationStrategy`.

--- a/docs/src/upgrade/release-3.1.x-incubating.asciidoc
+++ b/docs/src/upgrade/release-3.1.x-incubating.asciidoc
@@ -60,6 +60,19 @@ Upgrading for Providers
 IMPORTANT: It is recommended that providers also review all the upgrade instructions specified for users. Many of the
 changes there may prove important for the provider's implementation.
 
+Graph Database Providers
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Vertex and Edge Counts
+++++++++++++++++++++++
+
+A large number of asserts for vertex and edge counts in the test suite were not being applied. This problem has been
+rectified, but could manifest as test errors for different implementations. The chances of the new assertions
+identifying previously unrecognized bugs seems slim however, as there are many other tests that validate these counts
+in other ways. If those were passing previously, then these new asserts should likely not pose a problem.
+
+See: link:https://issues.apache.org/jira/browse/TINKERPOP-1300[TINKERPOP-1300]
+
 Graph Language Providers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/AbstractGremlinTest.java
@@ -258,7 +258,11 @@ public abstract class AbstractGremlinTest {
         return this.graphComputerClass.isPresent();
     }
 
-    public static Consumer<Graph> assertVertexEdgeCounts(final int expectedVertexCount, final int expectedEdgeCount) {
+    public static void assertVertexEdgeCounts(final Graph graph, final int expectedVertexCount, final int expectedEdgeCount) {
+        getAssertVertexEdgeCounts(expectedVertexCount, expectedEdgeCount).accept(graph);
+    }
+
+    public static Consumer<Graph> getAssertVertexEdgeCounts(final int expectedVertexCount, final int expectedEdgeCount) {
         return (g) -> {
             assertEquals(expectedVertexCount, IteratorUtils.count(g.vertices()));
             assertEquals(expectedEdgeCount, IteratorUtils.count(g.edges()));

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
@@ -24,7 +24,6 @@ import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.AbstractGremlinProcessTest;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
@@ -64,7 +63,7 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         final Traversal<Vertex, Graph> traversal = get_g_V_withSideEffectXsgX_outEXknowsX_subgraphXsgX_name_capXsgX(convertToVertexId("marko"), subgraph);
         printTraversalForm(traversal);
         subgraph = traversal.next();
-        assertVertexEdgeCounts(3, 2).accept(subgraph);
+        assertVertexEdgeCounts(subgraph, 3, 2);
         subgraph.edges().forEachRemaining(e -> {
             assertEquals("knows", e.label());
             assertEquals("marko", e.outVertex().values("name").next());
@@ -97,7 +96,7 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         printTraversalForm(traversal);
         checkResults(Arrays.asList("marko", "josh", "peter"), traversal);
         final Graph subGraph = traversal.asAdmin().getSideEffects().<Graph>get("sg").get();
-        assertVertexEdgeCounts(5, 4).accept(subGraph);
+        assertVertexEdgeCounts(subgraph, 5, 4);
 
         graphProvider.clear(subgraph, config);
     }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/EdgeTest.java
@@ -21,21 +21,15 @@ package org.apache.tinkerpop.gremlin.structure;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.ExceptionCoverage;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
-import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.PropertyFeatures.*;
 import static org.junit.Assert.*;
@@ -260,14 +254,14 @@ public class EdgeTest {
                 v.addEdge("friend", v);
             }
 
-            tryCommit(graph, assertVertexEdgeCounts(25, 25));
+            tryCommit(graph, getAssertVertexEdgeCounts(25, 25));
 
             for (Edge e : g.E().toList()) {
                 e.remove();
                 tryCommit(graph);
             }
 
-            tryCommit(graph, assertVertexEdgeCounts(25, 0));
+            tryCommit(graph, getAssertVertexEdgeCounts(25, 0));
         }
 
         @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphConstructionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphConstructionTest.java
@@ -56,7 +56,7 @@ public class GraphConstructionTest extends AbstractGremlinTest {
      */
     @Test
     public void shouldConstructAnEmptyGraph() {
-        assertVertexEdgeCounts(0, 0).accept(graph);
+        assertVertexEdgeCounts(graph, 0, 0);
     }
 
     /**

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphTest.java
@@ -22,8 +22,6 @@ import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.ExceptionCoverage;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
-import org.apache.tinkerpop.gremlin.GraphManager;
-import org.apache.tinkerpop.gremlin.GraphProvider;
 import org.apache.tinkerpop.gremlin.structure.io.util.CustomId;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedFactory;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
@@ -866,7 +864,7 @@ public class GraphTest extends AbstractGremlinTest {
         final Random random = new Random();
 
         IntStream.range(0, vertexCount).forEach(i -> vertices.add(graph.addVertex()));
-        tryCommit(graph, assertVertexEdgeCounts(vertexCount, 0));
+        tryCommit(graph, getAssertVertexEdgeCounts(vertexCount, 0));
 
         IntStream.range(0, edgeCount).forEach(i -> {
             boolean created = false;
@@ -880,7 +878,7 @@ public class GraphTest extends AbstractGremlinTest {
             }
         });
 
-        tryCommit(graph, assertVertexEdgeCounts(vertexCount, edgeCount));
+        tryCommit(graph, getAssertVertexEdgeCounts(vertexCount, edgeCount));
 
         int counter = 0;
         for (Edge e : edges) {
@@ -888,7 +886,7 @@ public class GraphTest extends AbstractGremlinTest {
             e.remove();
 
             final int currentCounter = counter;
-            tryCommit(graph, assertVertexEdgeCounts(vertexCount, edgeCount - currentCounter));
+            tryCommit(graph, getAssertVertexEdgeCounts(vertexCount, edgeCount - currentCounter));
         }
     }
 
@@ -905,7 +903,7 @@ public class GraphTest extends AbstractGremlinTest {
         final List<Edge> edges = new ArrayList<>();
 
         IntStream.range(0, vertexCount).forEach(i -> vertices.add(graph.addVertex()));
-        tryCommit(graph, assertVertexEdgeCounts(vertexCount, 0));
+        tryCommit(graph, getAssertVertexEdgeCounts(vertexCount, 0));
 
         for (int i = 0; i < vertexCount; i = i + 2) {
             final Vertex a = vertices.get(i);
@@ -913,7 +911,7 @@ public class GraphTest extends AbstractGremlinTest {
             edges.add(a.addEdge(graphProvider.convertLabel("a" + UUID.randomUUID()), b));
         }
 
-        tryCommit(graph, assertVertexEdgeCounts(vertexCount, vertexCount / 2));
+        tryCommit(graph, getAssertVertexEdgeCounts(vertexCount, vertexCount / 2));
 
         int counter = 0;
         for (Vertex v : vertices) {
@@ -922,7 +920,7 @@ public class GraphTest extends AbstractGremlinTest {
 
             if ((counter + 1) % 2 == 0) {
                 final int currentCounter = counter;
-                tryCommit(graph, assertVertexEdgeCounts(
+                tryCommit(graph, getAssertVertexEdgeCounts(
                         vertexCount - currentCounter, edges.size() - ((currentCounter + 1) / 2)));
             }
         }
@@ -991,14 +989,14 @@ public class GraphTest extends AbstractGremlinTest {
             d = graph.addVertex();
         }
 
-        tryCommit(graph, assertVertexEdgeCounts(4, 0));
+        tryCommit(graph, getAssertVertexEdgeCounts(4, 0));
 
         final Edge e = a.addEdge(graphProvider.convertLabel("knows"), b);
         final Edge f = b.addEdge(graphProvider.convertLabel("knows"), c);
         final Edge g = c.addEdge(graphProvider.convertLabel("knows"), d);
         final Edge h = d.addEdge(graphProvider.convertLabel("knows"), a);
 
-        tryCommit(graph, assertVertexEdgeCounts(4, 4));
+        tryCommit(graph, getAssertVertexEdgeCounts(4, 4));
 
         graph.vertices().forEachRemaining(v -> {
             assertEquals(1l, IteratorUtils.count(v.edges(Direction.OUT)));
@@ -1186,7 +1184,7 @@ public class GraphTest extends AbstractGremlinTest {
             totalVertices = totalVertices + (int) Math.pow(branchSize, i);
         }
 
-        tryCommit(graph, assertVertexEdgeCounts(totalVertices, totalVertices - 1));
+        tryCommit(graph, getAssertVertexEdgeCounts(totalVertices, totalVertices - 1));
     }
 
     @Test
@@ -1204,11 +1202,11 @@ public class GraphTest extends AbstractGremlinTest {
         if (graph.features().edge().properties().supportsStringValues())
             e.property("location", "internet");
 
-        tryCommit(graph, assertVertexEdgeCounts(2, 1));
+        tryCommit(graph, getAssertVertexEdgeCounts(2, 1));
         graph.close();
 
         final Graph reopenedGraph = graphProvider.standardTestGraph(this.getClass(), name.getMethodName(), null);
-        assertVertexEdgeCounts(2, 1).accept(reopenedGraph);
+        assertVertexEdgeCounts(reopenedGraph, 2, 1);
 
         if (graph.features().vertex().properties().supportsStringValues()) {
             reopenedGraph.vertices().forEachRemaining(vertex -> {

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphWritePerformanceTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/GraphWritePerformanceTest.java
@@ -28,11 +28,8 @@ import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.structure.io.GraphWriter;
 import org.apache.tinkerpop.gremlin.structure.io.graphml.GraphMLIo;
-import org.apache.tinkerpop.gremlin.structure.io.graphml.GraphMLWriter;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
-import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
-import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoWriter;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -66,7 +63,7 @@ public class GraphWritePerformanceTest {
                 tryBatchCommit(graph, ix);
             }
 
-            assertVertexEdgeCounts(verticesToGenerate, 0).accept(graph);
+            assertVertexEdgeCounts(graph, verticesToGenerate, 0);
         }
 
         @Test
@@ -83,7 +80,7 @@ public class GraphWritePerformanceTest {
                 tryBatchCommit(graph, ix);
             }
 
-            assertVertexEdgeCounts(verticesToGenerate, verticesToGenerate - 1).accept(graph);
+            assertVertexEdgeCounts(graph, verticesToGenerate, verticesToGenerate - 1);
         }
     }
 

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/TransactionTest.java
@@ -240,23 +240,23 @@ public class TransactionTest extends AbstractGremlinTest {
     public void shouldCommitElementAutoTransactionByDefault() {
         final Vertex v1 = graph.addVertex();
         final Edge e1 = v1.addEdge("l", v1);
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
         assertEquals(v1.id(), graph.vertices(v1.id()).next().id());
         assertEquals(e1.id(), graph.edges(e1.id()).next().id());
         g.tx().commit();
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
         assertEquals(v1.id(), graph.vertices(v1.id()).next().id());
         assertEquals(e1.id(), graph.edges(e1.id()).next().id());
 
         graph.vertices(v1.id()).forEachRemaining(Element::remove);
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
         g.tx().rollback();
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
 
         graph.vertices(v1.id()).forEachRemaining(Element::remove);
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
         g.tx().commit();
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
     }
 
     @Test
@@ -266,11 +266,11 @@ public class TransactionTest extends AbstractGremlinTest {
     public void shouldRollbackElementAutoTransactionByDefault() {
         final Vertex v1 = graph.addVertex();
         final Edge e1 = v1.addEdge("l", v1);
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
         assertEquals(v1.id(), graph.vertices(v1.id()).next().id());
         assertEquals(e1.id(), graph.edges(e1.id()).next().id());
         g.tx().rollback();
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
     }
 
     @Test
@@ -280,7 +280,7 @@ public class TransactionTest extends AbstractGremlinTest {
         final Vertex v1 = graph.addVertex();
         final Edge e1 = v1.addEdge("l", v1);
         g.tx().commit();
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
         assertEquals(v1.id(), graph.vertices(v1.id()).next().id());
         assertEquals(e1.id(), graph.edges(e1.id()).next().id());
 
@@ -312,7 +312,7 @@ public class TransactionTest extends AbstractGremlinTest {
         assertEquals("xxx", e1.<String>value("name"));
         assertEquals("xxx", graph.edges(e1.id()).next().<String>value("name"));
 
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
         assertEquals(v1.id(), graph.vertices(v1.id()).next().id());
         assertEquals(e1.id(), graph.edges(e1.id()).next().id());
     }
@@ -323,7 +323,7 @@ public class TransactionTest extends AbstractGremlinTest {
     public void shouldRollbackPropertyAutoTransactionByDefault() {
         final Vertex v1 = graph.addVertex("name", "marko");
         final Edge e1 = v1.addEdge("l", v1, "name", "xxx");
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
         assertEquals(v1.id(), graph.vertices(v1.id()).next().id());
         assertEquals(e1.id(), graph.edges(e1.id()).next().id());
         assertEquals("marko", v1.<String>value("name"));
@@ -353,7 +353,7 @@ public class TransactionTest extends AbstractGremlinTest {
         assertEquals("xxx", e1.<String>value("name"));
         assertEquals("xxx", graph.edges(e1.id()).next().<String>value("name"));
 
-        assertVertexEdgeCounts(1, 1);
+        assertVertexEdgeCounts(graph, 1, 1);
     }
 
     @Test
@@ -461,7 +461,7 @@ public class TransactionTest extends AbstractGremlinTest {
         }
 
         assertEquals(completedThreads.get(), 250);
-        assertVertexEdgeCounts(vertices.get(), edges.get());
+        assertVertexEdgeCounts(graph, vertices.get(), edges.get());
     }
 
     @Test
@@ -560,7 +560,7 @@ public class TransactionTest extends AbstractGremlinTest {
         threadTryCommitTx.join();
 
         assertTrue(noVerticesInFirstThread.get());
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
     }
 
     @Test
@@ -583,11 +583,11 @@ public class TransactionTest extends AbstractGremlinTest {
         latch.await(10000, TimeUnit.MILLISECONDS);
 
         // threaded transaction is not yet committed so g should not reflect any change
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
         threadedG.tx().commit();
 
         // there should be one vertex for each thread
-        assertVertexEdgeCounts(numberOfThreads, 0);
+        assertVertexEdgeCounts(graph, numberOfThreads, 0);
     }
 
 
@@ -600,15 +600,15 @@ public class TransactionTest extends AbstractGremlinTest {
             grx.addVertex();
             throw new Exception("fail");
         })).fireAndForget();
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will work
         g.tx().submit(grx -> graph.addVertex()).fireAndForget();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
 
         // make sure a commit happened and a new tx started
         g.tx().rollback();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
     }
 
     @Test
@@ -625,15 +625,15 @@ public class TransactionTest extends AbstractGremlinTest {
             assertEquals("fail", ex.getCause().getCause().getMessage());
         }
 
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will work
         g.tx().submit(grx -> graph.addVertex()).oneAndDone();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
 
         // make sure a commit happened and a new tx started
         g.tx().rollback();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
     }
 
     @Test
@@ -654,7 +654,7 @@ public class TransactionTest extends AbstractGremlinTest {
         }
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES, attempts.get());
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will work after several tries
         final AtomicInteger tries = new AtomicInteger(0);
@@ -667,11 +667,11 @@ public class TransactionTest extends AbstractGremlinTest {
         })).exponentialBackoff();
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES - 2, tries.get());
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
 
         // make sure a commit happened and a new tx started
         g.tx().rollback();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
     }
 
     @Test
@@ -695,7 +695,7 @@ public class TransactionTest extends AbstractGremlinTest {
         }
 
         assertEquals(1, attempts.get());
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will retry for specific tx and then fail after several tries
         final AtomicInteger setOfTries = new AtomicInteger(0);
@@ -712,7 +712,7 @@ public class TransactionTest extends AbstractGremlinTest {
         }
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES - 2, setOfTries.get());
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will work after several tries
         final AtomicInteger tries = new AtomicInteger(0);
@@ -725,11 +725,11 @@ public class TransactionTest extends AbstractGremlinTest {
         })).exponentialBackoff(Transaction.Workload.DEFAULT_TRIES, 20, exceptions);
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES - 2, tries.get());
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
 
         // make sure a commit happened and a new tx started
         g.tx().rollback();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
     }
 
     @Test
@@ -749,7 +749,7 @@ public class TransactionTest extends AbstractGremlinTest {
         }
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES, attempts.get());
-        assertVertexEdgeCounts(0, 0);
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will work after several tries
         final AtomicInteger tries = new AtomicInteger(0);
@@ -762,11 +762,11 @@ public class TransactionTest extends AbstractGremlinTest {
         })).retry();
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES - 2, tries.get());
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
 
         // make sure a commit happened and a new tx started
         g.tx().rollback();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
     }
 
     @Test
@@ -788,7 +788,9 @@ public class TransactionTest extends AbstractGremlinTest {
         }
 
         assertEquals(Transaction.Workload.DEFAULT_TRIES, attempts.get());
-        assertVertexEdgeCounts(0, 0);
+        assertFalse(g.tx().isOpen());
+        g.tx().open();
+        assertVertexEdgeCounts(graph, 0, 0);
 
         // this tx will work after several tries
         final AtomicInteger tries = new AtomicInteger(0);
@@ -803,7 +805,7 @@ public class TransactionTest extends AbstractGremlinTest {
         assertEquals(Transaction.Workload.DEFAULT_TRIES - 2, tries.get());
         assertFalse(g.tx().isOpen());
         g.tx().open();
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
         g.tx().rollback();
     }
 
@@ -816,17 +818,17 @@ public class TransactionTest extends AbstractGremlinTest {
         Vertex v1 = graph.addVertex();
         graph.tx().commit();
 
-        assertVertexEdgeCounts(1, 0);
+        assertVertexEdgeCounts(graph, 1, 0);
 
         final Vertex v2 = graph.addVertex();
         v1 = graph.vertices(v1.id()).next();
         v1.addEdge("friend", v2);
 
-        assertVertexEdgeCounts(2, 1);
+        assertVertexEdgeCounts(graph, 2, 1);
 
         graph.tx().commit();
 
-        assertVertexEdgeCounts(2, 1);
+        assertVertexEdgeCounts(graph, 2, 1);
     }
 
     @Test

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexPropertyTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexPropertyTest.java
@@ -117,7 +117,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
                 assertEquals(34, v.<Integer>value("age").intValue());
                 assertEquals(1, IteratorUtils.count(v.properties("name")));
                 assertEquals(2, IteratorUtils.count(v.properties()));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
 
             final VertexProperty<String> property = v.property(VertexProperty.Cardinality.list, "name", "marko a. rodriguez");
@@ -134,13 +134,13 @@ public class VertexPropertyTest extends AbstractGremlinTest {
             assertTrue(IteratorUtils.list(v.values("name")).contains("marko a. rodriguez"));
             assertEquals(3, IteratorUtils.count(v.properties()));
             assertEquals(2, IteratorUtils.count(v.properties("name")));
-            assertVertexEdgeCounts(1, 0);
+            assertVertexEdgeCounts(graph, 1, 0);
 
             assertEquals(v, v.property(VertexProperty.Cardinality.list, "name", "mrodriguez").element());
             tryCommit(graph, g -> {
                 assertEquals(3, IteratorUtils.count(v.properties("name")));
                 assertEquals(4, IteratorUtils.count(v.properties()));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
 
             v.<String>properties("name").forEachRemaining(meta -> {
@@ -164,7 +164,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
                     }
                 });
 
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
         }
 
@@ -211,9 +211,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
             });
 
             v.remove();
-            tryCommit(graph, g -> {
-                assertVertexEdgeCounts(0, 0);
-            });
+            tryCommit(graph, getAssertVertexEdgeCounts(0, 0));
 
             final Vertex u = graph.addVertex("name", "marko", "name", "marko a. rodriguez", "name", "marko rodriguez");
             tryCommit(graph);
@@ -394,28 +392,28 @@ public class VertexPropertyTest extends AbstractGremlinTest {
                 assertThat(values, hasItem("marko a. rodriguez"));
                 assertThat(values, hasItem("marko rodriguez"));
                 assertThat(values, hasItem("marko"));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
 
             IteratorUtils.filter(v.properties(), p -> p.value().equals("marko")).forEachRemaining(VertexProperty::remove);
             tryCommit(graph, graph -> {
                 assertEquals(3, IteratorUtils.count(v.properties()));
                 assertEquals(2, IteratorUtils.count(v.properties("name")));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
 
             v.property("age").remove();
             tryCommit(graph, graph -> {
                 assertEquals(2, IteratorUtils.count(v.properties()));
                 assertEquals(2, IteratorUtils.count(v.properties("name")));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
 
             IteratorUtils.filter(v.properties("name"), p -> p.key().equals("name")).forEachRemaining(VertexProperty::remove);
             tryCommit(graph, graph -> {
                 assertEquals(0, IteratorUtils.count(v.properties()));
                 assertEquals(0, IteratorUtils.count(v.properties("name")));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
         }
 
@@ -428,7 +426,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
             final Vertex marko = graph.addVertex("name", "marko", "name", "okram");
             final Vertex stephen = graph.addVertex("name", "stephen", "name", "spmallette");
             tryCommit(graph, graph -> {
-                assertVertexEdgeCounts(2, 0);
+                assertVertexEdgeCounts(graph, 2, 0);
                 assertEquals(2, IteratorUtils.count(marko.properties("name")));
                 assertEquals(2, IteratorUtils.count(stephen.properties("name")));
                 assertEquals(2, IteratorUtils.count(marko.properties()));
@@ -439,7 +437,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
 
             stephen.remove();
             tryCommit(graph, graph -> {
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
                 assertEquals(2, IteratorUtils.count(marko.properties("name")));
                 assertEquals(2, IteratorUtils.count(marko.properties()));
                 assertEquals(0, IteratorUtils.count(marko.properties("blah")));
@@ -449,7 +447,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
                 marko.property(VertexProperty.Cardinality.list, "name", "Remove-" + String.valueOf(i));
             }
             tryCommit(graph, graph -> {
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
                 assertEquals(102, IteratorUtils.count(marko.properties("name")));
                 assertEquals(102, IteratorUtils.count(marko.properties()));
                 assertEquals(0, IteratorUtils.count(marko.properties("blah")));
@@ -457,15 +455,13 @@ public class VertexPropertyTest extends AbstractGremlinTest {
 
             g.V().properties("name").has(T.value, P.test((a, b) -> ((String) a).startsWith((String) b), "Remove-")).forEachRemaining(Property::remove);
             tryCommit(graph, graph -> {
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
                 assertEquals(2, IteratorUtils.count(marko.properties("name")));
                 assertEquals(2, IteratorUtils.count(marko.properties()));
                 assertEquals(0, IteratorUtils.count(marko.properties("blah")));
             });
             marko.remove();
-            tryCommit(graph, graph -> {
-                assertVertexEdgeCounts(0, 0);
-            });
+            tryCommit(graph, getAssertVertexEdgeCounts(0, 0));
         }
     }
 
@@ -489,7 +485,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
             final Vertex v = graph.addVertex("name", "marko", "age", 34);
             tryCommit(graph, g -> {
                 assertEquals(2, IteratorUtils.count(v.properties()));
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
                 assertEquals(v.property("name"), v.property("name").property("acl", "public").element());
                 assertEquals(v.property("age"), v.property("age").property("acl", "private").element());
             });
@@ -506,7 +502,7 @@ public class VertexPropertyTest extends AbstractGremlinTest {
                 assertEquals(1, IteratorUtils.count(v.property("name").properties("acl")));
                 assertEquals("private", v.property("age").values("acl").next());
                 assertEquals("public", v.property("name").values("acl").next());
-                assertVertexEdgeCounts(1, 0);
+                assertVertexEdgeCounts(graph, 1, 0);
             });
 
             v.property("age").property("acl", "public");

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/structure/VertexTest.java
@@ -22,26 +22,20 @@ import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.ExceptionCoverage;
 import org.apache.tinkerpop.gremlin.FeatureRequirement;
 import org.apache.tinkerpop.gremlin.FeatureRequirementSet;
-import org.apache.tinkerpop.gremlin.GraphManager;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures;
-import org.apache.tinkerpop.gremlin.structure.io.IoTest;
 import org.apache.tinkerpop.gremlin.structure.io.util.CustomId;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.PropertyFeatures.*;
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures.FEATURE_USER_SUPPLIED_IDS;
@@ -323,7 +317,7 @@ public class VertexTest {
             assertTrue(v.keys().contains("name"));
             assertTrue(v.keys().contains("age"));
             assertFalse(v.keys().contains("location"));
-            assertVertexEdgeCounts(1, 0).accept(graph);
+            assertVertexEdgeCounts(graph, 1, 0);
 
             v.properties("name").forEachRemaining(Property::remove);
             v.property(VertexProperty.Cardinality.single, "name", "marko rodriguez");
@@ -336,7 +330,7 @@ public class VertexTest {
             assertTrue(v.keys().contains("name"));
             assertTrue(v.keys().contains("age"));
             assertFalse(v.keys().contains("location"));
-            assertVertexEdgeCounts(1, 0).accept(graph);
+            assertVertexEdgeCounts(graph, 1, 0);
 
             v.property(VertexProperty.Cardinality.single, "location", "santa fe");
             assertEquals(3, IteratorUtils.count(v.properties()));
@@ -348,11 +342,11 @@ public class VertexTest {
             assertTrue(v.keys().contains("age"));
             assertTrue(v.keys().contains("location"));
             v.property("location").remove();
-            assertVertexEdgeCounts(1, 0).accept(graph);
+            assertVertexEdgeCounts(graph, 1, 0);
             assertEquals(2, IteratorUtils.count(v.properties()));
             v.properties().forEachRemaining(Property::remove);
             assertEquals(0, IteratorUtils.count(v.properties()));
-            assertVertexEdgeCounts(1, 0).accept(graph);
+            assertVertexEdgeCounts(graph, 1, 0);
         }
 
         @Test
@@ -515,7 +509,7 @@ public class VertexTest {
             }
             graph.vertices().forEachRemaining(v -> graph.vertices().forEachRemaining(u -> v.addEdge("knows", u, "myEdgeId", 12)));
 
-            tryCommit(graph, assertVertexEdgeCounts(25, 625));
+            tryCommit(graph, getAssertVertexEdgeCounts(25, 625));
 
             final List<Vertex> vertices = new ArrayList<>();
             IteratorUtils.fill(graph.vertices(), vertices);
@@ -524,7 +518,7 @@ public class VertexTest {
                 tryCommit(graph);
             }
 
-            tryCommit(graph, assertVertexEdgeCounts(0, 0));
+            tryCommit(graph, getAssertVertexEdgeCounts(0, 0));
         }
 
         @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1300

tested with `mvn clean install -DincludeNeo4j`

VOTE +1