### PR TITLE
TINKERPOP-1088 Preserve Cardinality in Subgraph

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 * Fixed a bug in `BulkSet.equals()` which made itself apparent when using `store()` and `aggregate()` with labeled `cap()`.
 * Ensured that all asserts of vertex and edge counts were being applied properly in the test suite.
 * Fixed bug in `gremlin-driver` where certain channel-level errors would not allow the driver to reconnect.
+* `SubgraphStep` now consults the parent graph features to determine cardinality of a property.
 * Use of `Ctrl-C` in Gremlin Console now triggers closing of open remotes.
 * Bumped SLF4J to 1.7.21 as previous versions suffered from a memory leak.
 * Fixed a bug in `Neo4jGraphStepStrategy` where it wasn't defined properly as a `ProviderOptimizationStrategy`.

--- a/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySubgraphTest.groovy
+++ b/gremlin-groovy-test/src/main/groovy/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/GroovySubgraphTest.groovy
@@ -41,5 +41,10 @@ public abstract class GroovySubgraphTest {
                 final Graph subgraph) {
             TraversalScriptHelper.compute("g.withSideEffect('sg') { subgraph }.V.repeat(__.bothE('created').subgraph('sg').outV).times(5).name.dedup", g, "subgraph", subgraph)
         }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph) {
+            TraversalScriptHelper.compute("g.withSideEffect('sg') { subgraph }.V.has('name','daniel').outE.subgraph('sg').inV", g, "subgraph", subgraph);
+        }
     }
 }

--- a/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
+++ b/gremlin-test/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/step/sideEffect/SubgraphTest.java
@@ -30,15 +30,18 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
+import static org.apache.tinkerpop.gremlin.LoadGraphWith.GraphData.CREW;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.bothE;
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.EdgeFeatures.FEATURE_ADD_EDGES;
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.ElementFeatures.FEATURE_USER_SUPPLIED_IDS;
 import static org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures.FEATURE_ADD_VERTICES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -48,6 +51,8 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
     public abstract Traversal<Vertex, Graph> get_g_V_withSideEffectXsgX_outEXknowsX_subgraphXsgX_name_capXsgX(final Object v1Id, final Graph subgraph);
 
     public abstract Traversal<Vertex, String> get_g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup(final Graph subgraph);
+
+    public abstract Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph);
 
     @Test
     @LoadGraphWith(MODERN)
@@ -90,13 +95,35 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
     public void g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup() throws Exception {
         final Configuration config = graphProvider.newGraphConfiguration("subgraph", this.getClass(), name.getMethodName(), MODERN);
         graphProvider.clear(config);
-        final Graph subgraph = graphProvider.openTestGraph(config);
+        Graph subgraph = graphProvider.openTestGraph(config);
         /////
         final Traversal<Vertex, String> traversal = get_g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup(subgraph);
         printTraversalForm(traversal);
         checkResults(Arrays.asList("marko", "josh", "peter"), traversal);
-        final Graph subGraph = traversal.asAdmin().getSideEffects().<Graph>get("sg").get();
+        subgraph = traversal.asAdmin().getSideEffects().<Graph>get("sg").get();
         assertVertexEdgeCounts(subgraph, 5, 4);
+
+        graphProvider.clear(subgraph, config);
+    }
+
+    @Test
+    @LoadGraphWith(CREW)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = FEATURE_ADD_VERTICES)
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = FEATURE_ADD_EDGES)
+    @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
+    @FeatureRequirement(featureClass = Graph.Features.EdgeFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
+    public void g_withSideEffectXsgX_V_hasXname_danielXout_capXsgX() throws Exception {
+        final Configuration config = graphProvider.newGraphConfiguration("subgraph", this.getClass(), name.getMethodName(), CREW);
+        graphProvider.clear(config);
+        final Graph subgraph = graphProvider.openTestGraph(config);
+        /////
+        final Traversal<Vertex, Vertex> traversal = get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(subgraph);
+        printTraversalForm(traversal);
+        traversal.iterate();
+        assertVertexEdgeCounts(subgraph, 3, 2);
+
+        final List<String> locations = subgraph.traversal().V().has("name", "daniel").<String>values("location").toList();
+        assertThat(locations, contains("spremberg", "kaiserslautern", "aachen"));
 
         graphProvider.clear(subgraph, config);
     }
@@ -111,6 +138,11 @@ public abstract class SubgraphTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, String> get_g_V_withSideEffectXsgX_repeatXbothEXcreatedX_subgraphXsgX_outVX_timesX5X_name_dedup(final Graph subgraph) {
             return g.withSideEffect("sg", () -> subgraph).V().repeat(bothE("created").subgraph("sg").outV()).times(5).<String>values("name").dedup();
+        }
+
+        @Override
+        public Traversal<Vertex, Vertex> get_g_withSideEffectXsgX_V_hasXname_danielX_outE_subgraphXsgX_inV(final Graph subgraph) {
+            return g.withSideEffect("sg", () -> subgraph).V().has("name","daniel").outE().subgraph("sg").inV();
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1088

Fixes a problem where cardinality is better respected with subgraph step. SubgraphStep now consults the parent graph features to determine cardinality of a property.

`mvn clean install` is all good.

VOTE +1