### PR TITLE
TINKERPOP-1301 Provide Javadoc for ScriptInput/OutputFormat's

### DIFF
--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptInputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptInputFormat.java
@@ -28,6 +28,11 @@ import org.apache.tinkerpop.gremlin.hadoop.structure.io.VertexWritable;
 import java.io.IOException;
 
 /**
+ * ScriptInputFormat and {@link org.apache.tinkerpop.gremlin.hadoop.structure.io.script.ScriptOutputFormat}
+ * take an arbitrary script and use that script to either read or write Vertex objects,
+ * respectively. This can be considered the most general InputFormat/OutputFormat
+ * possible in that Hadoop-Gremlin uses the user provided script for all reading/writing.
+ * @see <a href="http://tinkerpop.apache.org/docs/current/reference/#script-io-format">Script I/O Format Reference Documentation</a>
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  * @author Daniel Kuppitz (http://gremlin.guru)
  */

--- a/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptOutputFormat.java
+++ b/hadoop-gremlin/src/main/java/org/apache/tinkerpop/gremlin/hadoop/structure/io/script/ScriptOutputFormat.java
@@ -29,6 +29,12 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
+ * {@link org.apache.tinkerpop.gremlin.hadoop.structure.io.script.ScriptInputFormat}
+ * and ScriptOutputFormat take an arbitrary script and use that script to either
+ * read or write Vertex objects, respectively. This can be considered the most
+ * general InputFormat/OutputFormat possible in that Hadoop-Gremlin uses the user
+ * provided script for all reading/writing.
+ * @see <a href="http://tinkerpop.apache.org/docs/current/reference/#script-io-format">Script I/O Format Reference Documentation</a>
  * @author Daniel Kuppitz (http://gremlin.guru)
  */
 public final class ScriptOutputFormat extends CommonFileOutputFormat implements HadoopPoolsConfigurable {


### PR DESCRIPTION
This trivial patch consolidates the Javadoc and links to the official reference documentation for the very powerful ScriptI/OFormats. The relevant Jira issue can be found at 
https://issues.apache.org/jira/browse/TINKERPOP-1301