### PR TITLE
TINKERPOP-1312 .count().is(0) is not properly optimized

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ image::https://raw.githubusercontent.com/apache/incubator-tinkerpop/master/docs/
 TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Optimized a few special cases in `RangeByIsCountStrategy`.
 * Named the thread pool used by Gremlin Server sessions: "gremlin-server-session-$n".
 * Fixed a bug in `BulkSet.equals()` which made itself apparent when using `store()` and `aggregate()` with labeled `cap()`.
 * Ensured that all asserts of vertex and edge counts were being applied properly in the test suite.

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
@@ -70,7 +70,7 @@ public final class RangeByIsCountStrategy extends AbstractTraversalStrategy<Trav
 
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
-        final int size = traversal.getSteps().size();
+        int size = traversal.getSteps().size();
         Step prev = null;
         for (int i = 0; i < size; i++) {
             final Step curr = traversal.getSteps().get(i);
@@ -109,7 +109,7 @@ public final class RangeByIsCountStrategy extends AbstractTraversalStrategy<Trav
                         if (useNotStep) {
                             traversal.asAdmin().removeStep(next); // IsStep
                             traversal.asAdmin().removeStep(curr); // CountStep
-                            i += 2;
+                            size -= 2;
                             final Traversal.Admin inner = __.start().asAdmin();
                             TraversalHelper.insertAfterStep(prev, inner.getStartStep(), inner);
                             TraversalHelper.replaceStep(prev, new NotStep<>(traversal, inner), traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
@@ -109,6 +109,7 @@ public final class RangeByIsCountStrategy extends AbstractTraversalStrategy<Trav
                         if (useNotStep) {
                             traversal.asAdmin().removeStep(next); // IsStep
                             traversal.asAdmin().removeStep(curr); // CountStep
+                            i += 2;
                             final Traversal.Admin inner = __.start().asAdmin();
                             TraversalHelper.insertAfterStep(prev, inner.getStartStep(), inner);
                             TraversalHelper.replaceStep(prev, new NotStep<>(traversal, inner), traversal);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
@@ -27,6 +27,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.FilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.IsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
@@ -95,17 +96,16 @@ public final class RangeByIsCountStrategy extends AbstractTraversalStrategy<Trav
                             final Long highRangeCandidate = ((Number) value).longValue() + highRangeOffset;
                             final boolean update = highRange == null || highRangeCandidate > highRange;
                             if (update) {
-                                final boolean isNested = !(parent instanceof EmptyStep);
-                                if (isNested) {
+                                if (parent instanceof EmptyStep) {
+                                    useNotStep = true;
+                                } else {
                                     if (parent instanceof RepeatStep) {
                                         final RepeatStep repeatStep = (RepeatStep) parent;
                                         useNotStep = Objects.equals(traversal, repeatStep.getUntilTraversal())
                                                 || Objects.equals(traversal, repeatStep.getEmitTraversal());
                                     } else {
-                                        useNotStep = parent instanceof SideEffectStep;
+                                        useNotStep = parent instanceof FilterStep || parent instanceof SideEffectStep;
                                     }
-                                } else {
-                                    useNotStep = true;
                                 }
                                 highRange = highRangeCandidate;
                                 useNotStep &= curr.getLabels().isEmpty() && next.getLabels().isEmpty()

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategy.java
@@ -90,8 +90,9 @@ public final class RangeByIsCountStrategy extends AbstractTraversalStrategy<Trav
                             final boolean update = highRange == null || highRangeCandidate > highRange;
                             if (update) {
                                 highRange = highRangeCandidate;
-                                useNotStep = (highRange <= 1L && predicate.equals(Compare.lt)) ||
-                                        (highRange == 1L && (predicate.equals(Compare.eq) || predicate.equals(Compare.lte)));
+                                useNotStep = curr.getLabels().isEmpty() && next.getLabels().isEmpty()
+                                        && ((highRange <= 1L && predicate.equals(Compare.lt))
+                                        || (highRange == 1L && (predicate.equals(Compare.eq) || predicate.equals(Compare.lte))));
                             }
                         } else {
                             final Long highRangeOffset = RANGE_PREDICATES.get(predicate);

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/util/DefaultTraversal.java
@@ -303,9 +303,10 @@ public class DefaultTraversal<S, E> implements Traversal.Admin<S, E> {
 
     @Override
     public int hashCode() {
+        int index = 0;
         int result = this.getClass().hashCode();
         for (final Step step : this.asAdmin().getSteps()) {
-            result ^= step.hashCode();
+            result ^= Integer.rotateLeft(step.hashCode(), index++);
         }
         return result;
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
@@ -145,6 +145,8 @@ public class RangeByIsCountStrategyTest {
                     {__.sideEffect(__.count().is(0)), __.sideEffect(__.not(__.identity()))},
                     {__.branch(__.count().is(0)), __.branch(__.count().limit(1).is(0))},
                     {__.count().is(0).store("x"), __.limit(1).count().is(0).store("x")},
+                    {__.repeat(__.out()).until(__.outE().count().is(0)), __.repeat(__.out()).until(__.not(__.outE()))},
+                    {__.repeat(__.out()).emit(__.outE().count().is(0)), __.repeat(__.out()).emit(__.not(__.outE()))},
             });
         }
     }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
@@ -124,10 +124,12 @@ public class RangeByIsCountStrategyTest {
         static Iterable<Object[]> generateTestParameters() {
 
             return Arrays.asList(new Traversal[][]{
+                    {__.count().is(0), __.not(__.identity())},
+                    {__.count().is(1), __.limit(2).count().is(1)},
                     {__.out().count().is(0), __.not(__.out())},
-                    {__.out().count().is(lt(1)), __.not(__.out())},
-                    {__.out().count().is(lte(0)), __.not(__.out())},
-                    {__.out().count().is(0).as("a"), __.out().limit(1).count().is(0).as("a")},
+                    {__.outE().count().is(lt(1)), __.not(__.outE())},
+                    {__.both().count().is(lte(0)), __.not(__.both())},
+                    {__.store("x").count().is(0).as("a"), __.store("x").limit(1).count().is(0).as("a")},
                     {__.out().count().as("a").is(0), __.out().limit(1).count().as("a").is(0)},
                     {__.out().count().is(neq(4)), __.out().limit(5).count().is(neq(4))},
                     {__.out().count().is(lte(3)), __.out().limit(4).count().is(lte(3))},
@@ -137,7 +139,13 @@ public class RangeByIsCountStrategyTest {
                     {__.out().count().is(inside(2, 4)), __.out().limit(4).count().is(inside(2, 4))},
                     {__.out().count().is(outside(2, 4)), __.out().limit(5).count().is(outside(2, 4))},
                     {__.out().count().is(within(2, 6, 4)), __.out().limit(7).count().is(within(2, 6, 4))},
-                    {__.out().count().is(without(2, 6, 4)), __.out().limit(6).count().is(without(2, 6, 4))}});
+                    {__.out().count().is(without(2, 6, 4)), __.out().limit(6).count().is(without(2, 6, 4))},
+                    {__.map(__.count().is(0)), __.map(__.count().limit(1).is(0))},
+                    {__.flatMap(__.count().is(0)), __.flatMap(__.count().limit(1).is(0))},
+                    {__.sideEffect(__.count().is(0)), __.sideEffect(__.not(__.identity()))},
+                    {__.branch(__.count().is(0)), __.branch(__.count().limit(1).is(0))},
+                    {__.count().is(0).store("x"), __.limit(1).count().is(0).store("x")},
+            });
         }
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
@@ -127,6 +127,8 @@ public class RangeByIsCountStrategyTest {
                     {__.out().count().is(0), __.not(__.out())},
                     {__.out().count().is(lt(1)), __.not(__.out())},
                     {__.out().count().is(lte(0)), __.not(__.out())},
+                    {__.out().count().is(0).as("a"), __.out().limit(1).count().is(0).as("a")},
+                    {__.out().count().as("a").is(0), __.out().limit(1).count().as("a").is(0)},
                     {__.out().count().is(neq(4)), __.out().limit(5).count().is(neq(4))},
                     {__.out().count().is(lte(3)), __.out().limit(4).count().is(lte(3))},
                     {__.out().count().is(lt(3)), __.out().limit(3).count().is(lt(3))},

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
@@ -142,6 +142,7 @@ public class RangeByIsCountStrategyTest {
                     {__.out().count().is(without(2, 6, 4)), __.out().limit(6).count().is(without(2, 6, 4))},
                     {__.map(__.count().is(0)), __.map(__.limit(1).count().is(0))},
                     {__.flatMap(__.count().is(0)), __.flatMap(__.limit(1).count().is(0))},
+                    {__.filter(__.count().is(0)), __.filter(__.not(__.identity()))},
                     {__.sideEffect(__.count().is(0)), __.sideEffect(__.not(__.identity()))},
                     {__.branch(__.count().is(0)), __.branch(__.limit(1).count().is(0))},
                     {__.count().is(0).store("x"), __.limit(1).count().is(0).store("x")},

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/optimization/RangeByIsCountStrategyTest.java
@@ -107,7 +107,7 @@ public class RangeByIsCountStrategyTest {
 
         protected TraversalEngine traversalEngine;
 
-        void applyAdjacentToIncidentStrategy(final Traversal traversal) {
+        void applyRangeByIsCountStrategy(final Traversal traversal) {
             final TraversalStrategies strategies = new DefaultTraversalStrategies();
             strategies.addStrategies(RangeByIsCountStrategy.instance());
 
@@ -117,7 +117,7 @@ public class RangeByIsCountStrategyTest {
         }
 
         public void doTest(final Traversal traversal, final Traversal optimized) {
-            applyAdjacentToIncidentStrategy(traversal);
+            applyRangeByIsCountStrategy(traversal);
             assertEquals(optimized, traversal);
         }
 
@@ -140,10 +140,10 @@ public class RangeByIsCountStrategyTest {
                     {__.out().count().is(outside(2, 4)), __.out().limit(5).count().is(outside(2, 4))},
                     {__.out().count().is(within(2, 6, 4)), __.out().limit(7).count().is(within(2, 6, 4))},
                     {__.out().count().is(without(2, 6, 4)), __.out().limit(6).count().is(without(2, 6, 4))},
-                    {__.map(__.count().is(0)), __.map(__.count().limit(1).is(0))},
-                    {__.flatMap(__.count().is(0)), __.flatMap(__.count().limit(1).is(0))},
+                    {__.map(__.count().is(0)), __.map(__.limit(1).count().is(0))},
+                    {__.flatMap(__.count().is(0)), __.flatMap(__.limit(1).count().is(0))},
                     {__.sideEffect(__.count().is(0)), __.sideEffect(__.not(__.identity()))},
-                    {__.branch(__.count().is(0)), __.branch(__.count().limit(1).is(0))},
+                    {__.branch(__.count().is(0)), __.branch(__.limit(1).count().is(0))},
                     {__.count().is(0).store("x"), __.limit(1).count().is(0).store("x")},
                     {__.repeat(__.out()).until(__.outE().count().is(0)), __.repeat(__.out()).until(__.not(__.outE()))},
                     {__.repeat(__.out()).emit(__.outE().count().is(0)), __.repeat(__.out()).emit(__.not(__.outE()))},

--- a/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
+++ b/tinkergraph-gremlin/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraphPlayTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
-import org.apache.tinkerpop.gremlin.process.computer.bulkloading.BulkLoaderVertexProgram;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -32,20 +31,30 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.graphml.GraphMLIo;
-import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.apache.tinkerpop.gremlin.util.TimeUtil;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.P.lt;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.as;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.both;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.choose;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.count;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.fold;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.union;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.valueMap;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.values;
 
 /**
  * @author Stephen Mallette (http://stephen.genoprime.com)
@@ -71,7 +80,7 @@ public class TinkerGraphPlayTest {
         graph.io(GraphMLIo.build()).readGraph("data/grateful-dead.xml");
         /////////
 
-        g.V().group().by(T.label).by(values("name")).forEachRemaining(x->logger.info(x.toString()));
+        g.V().group().by(T.label).by(values("name")).forEachRemaining(x -> logger.info(x.toString()));
 
         logger.info("group: " + g.V().both("followedBy").both("followedBy").group().by("songType").by(count()).next());
         logger.info("groupV3d0: " + g.V().both("followedBy").both("followedBy").groupV3d0().by("songType").by().by(__.count(Scope.local)).next());
@@ -126,7 +135,7 @@ public class TinkerGraphPlayTest {
         v7.addEdge("link", v9, "weight", 1f);
         v8.addEdge("link", v9, "weight", 7f);
 
-        g.traversal().withSack(Float.MIN_VALUE).V(v1).repeat(outE().sack(Operator.max, "weight").inV()).times(5).sack().forEachRemaining(x->logger.info(x.toString()));
+        g.traversal().withSack(Float.MIN_VALUE).V(v1).repeat(outE().sack(Operator.max, "weight").inV()).times(5).sack().forEachRemaining(x -> logger.info(x.toString()));
     }
 
    /* @Test
@@ -200,18 +209,12 @@ public class TinkerGraphPlayTest {
     @Ignore
     public void testPlayDK() throws Exception {
 
-        new File("/tmp/tinkergraph2.kryo").deleteOnExit();
-        new File("/tmp/tinkergraph3.kryo").deleteOnExit();
-
-        final Graph graph1 = TinkerFactory.createModern();
-        final Graph graph2 = GraphFactory.open("/tmp/graph2.properties");
-        TinkerFactory.generateModern((TinkerGraph) graph2);
-        graph2.close();
-
-        logger.info("graph1 -> graph2");
-        graph1.compute().workers(1).program(BulkLoaderVertexProgram.build().userSuppliedIds(true).writeGraph("/tmp/graph2.properties").create(graph1)).submit().get();
-        logger.info("graph1 -> graph3");
-        graph1.compute().workers(1).program(BulkLoaderVertexProgram.build().userSuppliedIds(true).writeGraph("/tmp/graph3.properties").create(graph1)).submit().get();
+        Graph graph = TinkerGraph.open();
+        GraphTraversalSource g = graph.traversal();
+        graph.io(GraphMLIo.build()).readGraph("/projects/apache/incubator-tinkerpop/data/grateful-dead.xml");
+        System.out.println(g.V().filter(outE("sungBy").count().is(0)).explain());
+        System.out.println(g.V().filter(outE("sungBy").count().is(lt(1))).explain());
+        System.out.println(g.V().filter(outE("sungBy").count().is(1)).explain());
     }
 
     @Test
@@ -256,7 +259,7 @@ public class TinkerGraphPlayTest {
 
         logger.info(traversal.get().toString());
         logger.info(traversal.get().iterate().toString());
-        traversal.get().forEachRemaining(x->logger.info(x.toString()));
+        traversal.get().forEachRemaining(x -> logger.info(x.toString()));
 
     }
 


### PR DESCRIPTION
Tweaked `RangeByIsCountStrategy`. The patterns ...

* `....count().is(0)`
* `....count().is(lt(1))`
* `....count().is(lte(0))`

... are now replaced by `not(...)`.

`docker/build.sh -t -i -n` succeeded.

VOTE: +1