### PR TITLE
TINKERPOP-1196 Fix for Result.one() which could have blocked indefinitely.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ TinkerPop 3.1.3 (NOT OFFICIALLY RELEASED YET)
 
 * Named the thread pool used by Gremlin Server sessions: "gremlin-server-session-$n".
 * Fixed a bug in `BulkSet.equals()` which made itself apparent when using `store()` and `aggregate()` with labeled `cap()`.
+* Fixed a bug where `Result.one()` could potentially block indefinitely under certain circumstances.
 * Ensured that all asserts of vertex and edge counts were being applied properly in the test suite.
 * Fixed bug in `gremlin-driver` where certain channel-level errors would not allow the driver to reconnect.
 * `SubgraphStep` now consults the parent graph features to determine cardinality of a property.

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/ResultSet.java
@@ -127,11 +127,7 @@ public final class ResultSet implements Iterable<Result> {
 
             @Override
             public boolean hasNext() {
-                final List<Result> list = some(1).join();
-                assert list.size() <= 1;
-
-                nextOne = list.size() == 0 ? null : list.get(0);
-
+                nextOne = one();
                 return nextOne != null;
             }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1196

Result.one() sometimes would hang under rare but possible conditions. This change should prevent that from happening now as it removes the chance of await() futures from being created while a flush of existing waiting futures is occurring. When that happened it seemed to create the possibility where an await() future could get created but never been completed.

I would have CTR'd this as it is a small change but I was hoping for reviewers to do:

```text
mvn clean install && mvn verify -pl gremlin-server -DskipIntegrationTests=false
```

so as to validate that the problem is resolved on their systems. This problem didn't typically occur on mine - @okram this seemed to happen a lot to you during test runs so it would be great if you could give it a try.

VOTE +1