### PR TITLE
TINKERPOP-1003 Setting up latest/current links for bins and docs.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -25,9 +25,9 @@ Documentation
 TinkerPop3 provides graph computing capabilities for both graph databases (OLTP) and graph analytic systems (OLAP).
 
 * link:http://tinkerpop.apache.org/[homepage (downloads)]
-* link:http://tinkerpop.apache.org/docs/3.1.3-SNAPSHOT/reference/[reference documentation]
-* link:http://tinkerpop.apache.org/javadocs/3.1.3-SNAPSHOT/core/[core javadoc]
-* link:http://tinkerpop.apache.org/javadocs/3.1.3-SNAPSHOT/full/[full javadoc]
+* link:http://tinkerpop.apache.org/docs/current/reference/[reference documentation]
+* link:http://tinkerpop.apache.org/javadocs/current/core/[core javadoc]
+* link:http://tinkerpop.apache.org/javadocs/current/full/[full javadoc]
 
 Building and Testing
 ~~~~~~~~~~~~~~~~~~~~
@@ -42,7 +42,7 @@ The zip distributions can be found in the following directories:
 . `gremlin-server/target`
 . `gremlin-console/target`
 
-Please see the link:http://tinkerpop.apache.org/docs/3.1.3-SNAPSHOT/dev/developer/#_contributing[CONTRIBUTING.asciidoc] file for more detailed information and options for building, test running and developing TinkerPop.
+Please see the link:http://tinkerpop.apache.org/docs/current/dev/developer/#_contributing[CONTRIBUTING.asciidoc] file for more detailed information and options for building, test running and developing TinkerPop.
 
 Get Started
 ~~~~~~~~~~~

--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -56,6 +56,21 @@ cp -R target/site/apidocs/full/. "target/svn/javadocs/${VERSION}/full"
 
 pushd target/svn
 rm "docs/${VERSION}/images/tinkerpop3.graffle"
+${SVN_CMD} update --depth empty "docs/${VERSION}"
+${SVN_CMD} update --depth empty "javadocs/${VERSION}"
+
+for dir in "docs" "javadocs"
+do
+  CURRENT=$(${SVN_CMD} list "${dir}" | tr -d '/' | grep -v SNAPSHOT | grep -Fv current | sort -rV | head -n1)
+
+  ${SVN_CMD} update --depth empty "${dir}/current"
+  ${SVN_CMD} rm "${dir}/current"
+
+  ${SVN_CMD} update --depth empty "${dir}/${CURRENT}"
+  ln -s "${CURRENT}" "${dir}/current"
+  ${SVN_CMD} update --depth empty "${dir}/current"
+done
+
 ${SVN_CMD} add * --force
 ${SVN_CMD} commit -m "Deploy docs for TinkerPop ${VERSION}"
 popd

--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -61,7 +61,7 @@ ${SVN_CMD} update --depth empty "javadocs/${VERSION}"
 
 for dir in "docs" "javadocs"
 do
-  CURRENT=$(${SVN_CMD} list "${dir}" | tr -d '/' | grep -v SNAPSHOT | grep -Fv current | sort -rV | head -n1)
+  CURRENT=$((${SVN_CMD} list "${dir}" ; ls "${dir}") | tr -d '/' | grep -v SNAPSHOT | grep -Fv current | sort -rV | head -n1)
 
   ${SVN_CMD} update --depth empty "${dir}/current"
   ${SVN_CMD} rm "${dir}/current"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-1003

Update "current" links as part of `bin/publish-docs.sh`.

VOTE: +1